### PR TITLE
fix: Use quote() for EvalResult examples default value

### DIFF
--- a/R/optimizer-core.R
+++ b/R/optimizer-core.R
@@ -145,7 +145,7 @@ EvalResult <- S7::new_class(
     # Per-example data
     examples = S7::new_property(
       S7::class_data.frame,
-      default = tibble::tibble()
+      default = quote(data.frame())
     ),
     # Aggregated summary
     mean_score = S7::new_property(S7::class_numeric, default = NA_real_),


### PR DESCRIPTION
## Summary

Fix coverage test failures by using `quote(data.frame())` instead of `tibble::tibble()` for the default value of the `examples` property in `EvalResult`.

## Problem

The CI test-coverage job was failing with:
```
@examples must be S3<data.frame>, not <list>
```

This happened because `tibble::tibble()` as a default value was evaluated once at class definition time, not fresh for each object creation. In the coverage testing environment, this caused issues.

## Solution

Use `quote(data.frame())` which defers evaluation until object creation time, ensuring each new EvalResult gets a fresh empty data.frame.

## Test plan

- [x] All 1783 tests pass locally
- [x] Coverage tests now pass
- [x] R CMD check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)