### PR TITLE
fix: Convert reduce_best_by_metric fallbacks to errors

### DIFF
--- a/R/module-ensemble.R
+++ b/R/module-ensemble.R
@@ -616,12 +616,12 @@ reduce_best_by_metric <- function(
     }
 
     if (is.null(state$expected_value)) {
-      cli::cli_warn(c(
+      cli::cli_abort(c(
         "No expected value set for reduce_best_by_metric",
-        "i" = "Set expected value via set_expected() before calling",
-        "i" = "Falling back to first output"
+        "i" = "This reducer requires an expected value to score outputs",
+        "i" = "Set expected value via {.code attr(reducer, 'set_expected')(value)} before calling",
+        "i" = "If you don't have expected values, use {.fn reduce_majority} or {.fn reduce_first} instead"
       ))
-      return(outputs[[1]])
     }
 
     # Score each output
@@ -651,13 +651,13 @@ reduce_best_by_metric <- function(
     best_idx <- best_fn(scores)
 
     if (is.na(best_idx) || length(best_idx) == 0) {
-      # All scores NA, return first
-      cli::cli_warn(c(
+      cli::cli_abort(c(
         "All metric scores are NA in reduce_best_by_metric",
-        "i" = "{n_scoring_errors} scoring error{?s} occurred",
-        "i" = "Falling back to first output"
+        "x" = "The metric function failed to score any of the {length(outputs)} output{?s}",
+        "i" = "{n_scoring_errors} scoring error{?s} occurred during evaluation",
+        "i" = "Verify that the metric function is compatible with the output format",
+        "i" = "Check that the expected value format matches what the metric expects"
       ))
-      return(outputs[[1]])
     }
 
     outputs[[best_idx]]

--- a/tests/testthat/test-ensemble.R
+++ b/tests/testthat/test-ensemble.R
@@ -459,7 +459,7 @@ test_that("reduce_best_by_metric with maximize = FALSE returns lowest score", {
   expect_equal(result$answer, "short") # Shortest = lowest score
 })
 
-test_that("reduce_best_by_metric warns when no expected value set", {
+test_that("reduce_best_by_metric errors when no expected value set", {
   metric <- metric_exact_match(field = "answer")
   reducer <- reduce_best_by_metric(metric)
 
@@ -469,15 +469,13 @@ test_that("reduce_best_by_metric warns when no expected value set", {
     list(answer = "b")
   )
 
-  expect_warning(
-    result <- reducer(outputs),
+  expect_error(
+    reducer(outputs),
     "No expected value set"
   )
-  # Should fall back to first output
-  expect_equal(result$answer, "a")
 })
 
-test_that("reduce_best_by_metric warns when metric scoring fails", {
+test_that("reduce_best_by_metric warns for individual failures then errors when all fail", {
   # Create a metric that throws an error
   failing_metric <- function(output, expected) {
     stop("Metric computation failed")
@@ -491,14 +489,18 @@ test_that("reduce_best_by_metric warns when metric scoring fails", {
     list(answer = "b")
   )
 
-  # Should warn for each scoring failure and for all NA scores
-  expect_warning(
-    result <- reducer(outputs),
-    "Metric scoring failed"
+  # Should warn for each scoring failure, then error when all scores are NA
+
+  expect_error(
+    expect_warning(
+      reducer(outputs),
+      "Metric scoring failed"
+    ),
+    "All metric scores are NA"
   )
 })
 
-test_that("reduce_best_by_metric warns when all scores are NA", {
+test_that("reduce_best_by_metric errors when all scores are NA", {
   # Create a metric that returns NA
   na_metric <- function(output, expected) {
     NA_real_
@@ -512,11 +514,10 @@ test_that("reduce_best_by_metric warns when all scores are NA", {
     list(answer = "b")
   )
 
-  expect_warning(
-    result <- reducer(outputs),
+  expect_error(
+    reducer(outputs),
     "All metric scores are NA"
   )
-  expect_equal(result$answer, "a") # Falls back to first
 })
 
 test_that("reduce_weighted_vote errors on empty list", {


### PR DESCRIPTION
## Summary

- Convert silent fallback behaviors in `reduce_best_by_metric()` to explicit errors
- Missing expected value now aborts with guidance on alternatives
- All NA scores now aborts with debugging suggestions

Resolves dsprrr-2dm

## Test plan

- [x] Updated tests to expect errors instead of warnings
- [x] All 1876 tests pass
- [x] R CMD check passes (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)