### PR TITLE
fix: Improve ensemble error context and weight handling (dsprrr-64e)

### DIFF
--- a/R/module-ensemble.R
+++ b/R/module-ensemble.R
@@ -135,8 +135,9 @@ EnsembleModule <- R6::R6Class(
           },
           error = function(e) {
             n_errors <<- n_errors + 1
+            mod_class <- class(self$modules[[i]])[1]
             cli::cli_warn(c(
-              "Module {i} failed in Ensemble",
+              "Module {i} ({.cls {mod_class}}) failed in Ensemble",
               "x" = e$message
             ))
             NULL

--- a/R/teleprompter-ensemble.R
+++ b/R/teleprompter-ensemble.R
@@ -162,11 +162,10 @@ compile_ensemble <- function(
       ))
       weights <- weights[seq_along(programs)]
     } else {
-      cli::cli_warn(c(
+      cli::cli_abort(c(
         "Fewer weights ({length(weights)}) than programs ({length(programs)})",
-        "i" = "Using equal weights"
+        "i" = "Provide exactly one weight per program, or omit weights entirely"
       ))
-      weights <- NULL
     }
   }
 

--- a/tests/testthat/test-ensemble.R
+++ b/tests/testthat/test-ensemble.R
@@ -22,31 +22,6 @@ create_mock_module <- function(response = "answer1") {
   mock_mod
 }
 
-# Create mock module with controlled responses
-create_varied_mock <- function(responses) {
-  idx <- 0
-  mock_mod <- list(
-    signature = signature("question -> answer"),
-    chat = NULL,
-    forward = function(batch, .llm = NULL, trace = TRUE, ...) {
-      idx <<- idx + 1
-      response <- responses[[min(idx, length(responses))]]
-      tibble::tibble(
-        output = list(list(answer = response)),
-        chat = list(NULL),
-        metadata = list(list(
-          total_tokens = 100,
-          cost = 0.001,
-          model = "mock-model"
-        ))
-      )
-    },
-    reset_copy = function() create_varied_mock(responses)
-  )
-  class(mock_mod) <- c("MockModule", "Module", "R6")
-  mock_mod
-}
-
 # ============================================================================
 # EnsembleModule Tests
 # ============================================================================
@@ -247,7 +222,7 @@ test_that("EnsembleModule handles module errors gracefully", {
 
   expect_warning(
     result <- ens$forward(list(question = "test")),
-    "Module 2 failed"
+    "Module 2.*failed"
   )
 
   # Should still succeed with 2 of 3 modules
@@ -316,7 +291,7 @@ test_that("EnsembleModule uses correct weights when middle module fails", {
   # With bug: weights are [1, 100] -> "b" wins with weight 100
   expect_warning(
     result <- ens$forward(list(question = "test")),
-    "Module 2 failed"
+    "Module 2.*failed"
   )
 
   # Should be a tie (both weight 1), so first answer "a" wins
@@ -849,16 +824,15 @@ test_that("compile_ensemble warns when more weights than programs", {
   expect_equal(result$weights, c(0.9, 0.8))
 })
 
-test_that("compile_ensemble warns when fewer weights than programs", {
+test_that("compile_ensemble errors when fewer weights than programs", {
   mods <- lapply(1:4, function(i) create_mock_module(paste0("a", i)))
   tp <- Ensemble(weights = c(0.9, 0.8)) # 2 weights for 4 programs
 
-  expect_warning(
-    result <- compile(tp, program = NULL, trainset = NULL, programs = mods),
+  # Should error since user explicitly provided weights but count is wrong
+  expect_error(
+    compile(tp, program = NULL, trainset = NULL, programs = mods),
     "Fewer weights"
   )
-  # Should use equal weights (default)
-  expect_equal(result$weights, rep(1, 4))
 })
 
 test_that("compile_ensemble errors without programs", {


### PR DESCRIPTION
## Summary

Minor improvements to ensemble error handling and cleanup:

1. **Weight mismatch is now an error** - When user provides fewer weights than programs, compile now errors instead of silently falling back to equal weights. This makes misconfiguration explicit.

2. **Better module failure warnings** - Warning now includes module class for easier debugging:
   - Before: `Module 2 failed in Ensemble`
   - After: `Module 2 (PredictModule) failed in Ensemble`

3. **Removed unused test helper** - `create_varied_mock` was defined but never used

## Changes

- `R/teleprompter-ensemble.R`: Change `cli::cli_warn` to `cli::cli_abort` for weight count mismatch
- `R/module-ensemble.R`: Add module class to failure warning message
- `tests/testthat/test-ensemble.R`: Remove unused helper, update test expectations

## Test plan

- [x] All 121 ensemble tests pass
- [x] Test for weight mismatch updated to expect error instead of warning
- [x] Test patterns updated to match new warning format

Resolves dsprrr-64e

🤖 Generated with [Claude Code](https://claude.com/claude-code)