### PR TITLE
fix: Update test-coverage.yaml to use codecov-action v5

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -4,9 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
 
-name: test-coverage
+name: test-coverage.yaml
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -23,17 +24,28 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Test coverage
         run: |
-          covr::codecov(
+          cov <- covr::package_coverage(
             quiet = FALSE,
             clean = FALSE,
             install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()


### PR DESCRIPTION
## Summary
Update the test coverage GitHub Action to match the modern r-lib/actions pattern.

## Changes
- Switch from deprecated `covr::codecov()` to `covr::package_coverage()` + `covr::to_cobertura()`
- Use `codecov/codecov-action@v5` with cobertura.xml output
- Add `any::xml2` to extra-packages (required for cobertura export)
- Add `permissions: read-all` for security
- Remove branch filter from `pull_request` trigger (run on all PRs)

## Test plan
- [ ] CI runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)