### PR TITLE
docs: Add Diataxis cross-links to existing vignettes

### DIFF
--- a/vignettes/advanced-modules.Rmd
+++ b/vignettes/advanced-modules.Rmd
@@ -713,3 +713,20 @@ dsprrr's advanced modules bring battle-tested patterns from DSPy to R:
 - Add **BestOfN** when you need reliability
 - Use **ProgramOfThought** for exact computation (math, statistics)
 - Use **CodeAct** when you need tools AND code execution together
+
+## Further Reading
+
+**Tutorials:**
+- [Improving with Examples](tutorial-improve-with-demos.html) — Learn few-shot prompting
+- [Finding Best Configuration](tutorial-optimize-your-module.html) — Grid search optimization
+
+**How-to Guides:**
+- [Compile & Optimize](compilation-optimization.html) — Full optimization workflow with advanced modules
+- [Build RAG Pipelines](rag-workflows.html) — Use modules in retrieval workflows
+
+**Concepts:**
+- [Understanding Signatures & Modules](concepts-signatures-modules.html) — S7 vs R6 design choices
+- [How Optimization Works](concepts-optimization-theory.html) — Teleprompter theory
+
+**Reference:**
+- [Quick Reference](cheatsheet.html) — Syntax and patterns at a glance

--- a/vignettes/advanced-optimization.Rmd
+++ b/vignettes/advanced-optimization.Rmd
@@ -670,10 +670,19 @@ session_cost()  # Total cost so far
 | `GEPA` | Multi-objective | High (100+) | High |
 | `Ensemble` | Combines modules | N/A | Varies |
 
-## Next Steps
+## Further Reading
 
-- Start with `LabeledFewShot` or `BootstrapFewShot` for quick wins
-- Graduate to `COPRO` or `MIPROv2` for production optimization
-- Use `Ensemble` to combine your best models
-- See `vignette("compilation-optimization")` for basic optimization concepts
-- See `vignette("vitals-integration")` for evaluation with vitals package
+**Tutorials:**
+- [Finding Best Configuration](tutorial-optimize-your-module.html) — Hands-on grid search
+- [Taking to Production](tutorial-deploy-to-production.html) — Deploy optimized modules
+
+**How-to Guides:**
+- [Compile & Optimize](compilation-optimization.html) — Basic optimization concepts
+- [Evaluate with Vitals](vitals-recipes.html) — Integration with vitals package
+
+**Concepts:**
+- [How Optimization Works](concepts-optimization-theory.html) — Theory behind teleprompters
+- [Why Metrics Matter](concepts-why-metrics-matter.html) — Choosing the right metric
+
+**Reference:**
+- [Quick Reference](cheatsheet.html) — Metrics and teleprompter syntax

--- a/vignettes/compilation-optimization.Rmd
+++ b/vignettes/compilation-optimization.Rmd
@@ -1244,11 +1244,21 @@ The compilation framework makes your LLM programs:
 - **More portable** across different LLMs and use cases
 - **More efficient** by finding the best prompts automatically
 
-## Next Steps
+## Further Reading
 
-- Experiment with different metrics for your use case
-- Try both teleprompters to see which works better
-- Build a library of optimized modules for common tasks
-- Share your optimization patterns with the dsprrr community
+**Tutorials:**
+- [Improving with Examples](tutorial-improve-with-demos.html) — Learn few-shot prompting step by step
+- [Finding Best Configuration](tutorial-optimize-your-module.html) — Hands-on grid search tutorial
+- [Taking to Production](tutorial-deploy-to-production.html) — Deploy optimized modules
 
-Remember: Let dsprrr handle the prompt engineering while you focus on building great applications!
+**How-to Guides:**
+- [Advanced Optimizer Guide](advanced-optimization.html) — BootstrapFewShot, COPRO, MIPROv2, and more
+- [Evaluate with Vitals](vitals-recipes.html) — Integration with vitals package
+
+**Concepts:**
+- [How Optimization Works](concepts-optimization-theory.html) — Theory behind teleprompters
+- [Why Metrics Matter](concepts-why-metrics-matter.html) — Choosing the right metric
+- [Understanding Signatures & Modules](concepts-signatures-modules.html) — S7 vs R6 design choices
+
+**Reference:**
+- [Quick Reference](cheatsheet.html) — Metrics, signature syntax, and module types


### PR DESCRIPTION
## Summary

- Add "Further Reading" sections with Diataxis cross-links to:
  - advanced-modules.Rmd
  - advanced-optimization.Rmd
  - compilation-optimization.Rmd
- Links connect tutorials ↔ how-to guides ↔ concepts ↔ reference

Resolves dsprrr-3pa.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)