### PR TITLE
fix: Add missing blank lines before lists in vignettes

### DIFF
--- a/vignettes/advanced-ellmer.Rmd
+++ b/vignettes/advanced-ellmer.Rmd
@@ -233,6 +233,7 @@ tryCatch(
 ## Summary
 
 Key integration points with ellmer:
+
 1. **Parallel processing**: Choose between mirai (multi-process) or ellmer native (async HTTP)
 2. **Tool integration**: Convert modules to ellmer tools with `as_ellmer_tool()`
 3. **Cost tracking**: Use `get_cost()`, `get_tokens()`, and `session_cost()` for usage tracking

--- a/vignettes/advanced-modules.Rmd
+++ b/vignettes/advanced-modules.Rmd
@@ -37,6 +37,7 @@ library(ellmer)
 ## Overview
 
 dsprrr provides advanced module types inspired by [DSPy](https://dspy.ai/) that implement sophisticated reasoning patterns. These modules go beyond simple prompt-response to enable:
+
 - **Step-by-step reasoning** with ChainOfThought
 - **Multiple attempts** with BestOfN
 - **Iterative refinement** with Refine
@@ -78,6 +79,7 @@ result$reasoning
 result$solution
 #> "60 miles per hour"
 ```
+
 ### Signature Transforms
 
 Under the hood, `chain_of_thought()` uses `with_reasoning()` to transform the signature. You can use this directly for more control:
@@ -670,6 +672,7 @@ compiled <- compile(tp, wrapper, trainset)
 ### Token Usage
 
 Advanced modules use more tokens than simple prediction:
+
 - **ChainOfThought**: ~1.5-2x tokens (reasoning + answer)
 - **BestOfN(N=3)**: Up to 3x tokens (worst case, no early stopping)
 - **Refine(N=3)**: Up to 3x tokens plus feedback overhead

--- a/vignettes/advanced-optimization.Rmd
+++ b/vignettes/advanced-optimization.Rmd
@@ -219,6 +219,7 @@ ens <- ensemble(
 ## KNNFewShot
 
 Selects demonstrations dynamically based on similarity to the input query. Uses embeddings to find the most relevant examples.
+
 **Best for:** Tasks where example relevance varies significantly by query.
 
 ```{r knn-fewshot}

--- a/vignettes/cheatsheet.Rmd
+++ b/vignettes/cheatsheet.Rmd
@@ -213,6 +213,7 @@ classifier <- chat_openai(model = "gpt-5-mini") |>
 classifier$predict(text = "Love it!")
 classifier$predict(text = "Hate it!")
 ```
+
 ### Full Control: `signature()` + `module()`
 
 ```{r full-module}
@@ -487,6 +488,7 @@ validate_workflow("workflow.yml")
 ```
 
 ---
+
 ## Common Patterns
 
 ### RAG (Retrieval-Augmented Generation)

--- a/vignettes/compilation-optimization.Rmd
+++ b/vignettes/compilation-optimization.Rmd
@@ -37,6 +37,7 @@ if (should_eval) {
 One of dsprrr's most powerful features is **automatic prompt optimization**. Instead of manually tweaking prompts and examples, you can let dsprrr systematically optimize your LLM programs using your training data and evaluation metrics.
 
 This vignette covers:
+
 - **Metrics**: How to evaluate LLM outputs
 - **Teleprompters**: Optimization strategies for improving programs
 - **Compilation**: The process of optimizing your modules
@@ -1239,6 +1240,7 @@ Key takeaways:
 - Consider ensemble methods for critical applications
 
 The compilation framework makes your LLM programs:
+
 - **More accurate** through systematic optimization
 - **More maintainable** by separating logic from prompt tuning
 - **More portable** across different LLMs and use cases

--- a/vignettes/concepts-dspy-philosophy.Rmd
+++ b/vignettes/concepts-dspy-philosophy.Rmd
@@ -85,6 +85,7 @@ mod <- module(signature("text -> sentiment"), type = "predict")
 ```
 
 Modules are:
+
 - **Stateful**: They remember their configuration, demos, and traces
 - **Composable**: You can chain modules together
 - **Optimizable**: Their parameters can be tuned automatically
@@ -119,6 +120,7 @@ The optimizer:
 - Keeps the best one
 
 This works because:
+
 1. LLMs are sensitive to prompt wording (small changes → big effects)
 2. The search space is navigable (parameters are mostly continuous)
 3. Evaluation is cheap compared to training
@@ -218,6 +220,7 @@ dsprrr is this shift for LLM applications in R.
 If you accept this philosophy, your workflow changes:
 
 **Before (prompt engineering)**:
+
 1. Write prompt
 2. Try examples manually
 3. Tweak wording
@@ -225,6 +228,7 @@ If you accept this philosophy, your workflow changes:
 5. Hope it keeps working
 
 **After (prompt programming)**:
+
 1. Define signature
 2. Create labeled dataset
 3. Define metric

--- a/vignettes/concepts-optimization-theory.Rmd
+++ b/vignettes/concepts-optimization-theory.Rmd
@@ -139,6 +139,7 @@ compiled <- compile(tp, mod, trainset)
 ```
 
 **How it works**:
+
 1. Sample k examples from training data
 2. Format as demonstrations
 3. Add to module
@@ -167,6 +168,7 @@ compiled <- compile(tp, mod, trainset)
 ```
 
 **How it works**:
+
 1. Start with labeled examples as initial demos
 2. Run teacher model on remaining training examples
 3. Score each prediction with your metric
@@ -203,6 +205,7 @@ compiled <- compile(tp, mod, trainset)
 ```
 
 **How it works**:
+
 1. Define a grid of parameter configurations
 2. Evaluate each on a validation set
 3. Select the best-performing configuration
@@ -230,6 +233,7 @@ compiled <- compile(tp, mod, trainset)
 ```
 
 **How it works**:
+
 1. Generate multiple demo configurations via bootstrapping
 2. Create candidate programs with different demo subsets
 3. Evaluate all candidates
@@ -254,6 +258,7 @@ compiled <- compile(tp, mod, trainset)
 ```
 
 **How it works**:
+
 1. Embed all training examples
 2. Cluster by semantic similarity
 3. Select diverse representatives from clusters
@@ -281,6 +286,7 @@ compiled <- compile(tp, mod, trainset)
 ```
 
 **How it works**:
+
 1. At compile time: embed all training examples
 2. At runtime: find k nearest neighbors to the input
 3. Use those neighbors as demonstrations
@@ -307,6 +313,7 @@ compiled <- compile(tp, mod, trainset)
 ```
 
 **How it works**:
+
 1. Generate breadth instruction candidates
 2. Evaluate each on training data
 3. Take top performers, ask LLM to improve them
@@ -436,6 +443,7 @@ Use cheaper models during optimization, then evaluate final config on your targe
 ### Validation Strategy
 
 Split your data:
+
 - **Training set**: Used to generate demos
 - **Validation set**: Used to evaluate candidates during optimization
 - **Test set**: Used to evaluate final model (never touched during optimization)

--- a/vignettes/concepts-signatures-modules.Rmd
+++ b/vignettes/concepts-signatures-modules.Rmd
@@ -117,6 +117,7 @@ signature(
 ```
 
 The string notation is:
+
 - **Concise**: One line instead of many
 - **Readable**: `context, question -> answer` is self-documenting
 - **DSPy-compatible**: Familiar to Python DSPy users
@@ -390,6 +391,7 @@ Create a new module when:
 - Different **execution contexts** (dev vs prod)
 
 Use the same module when:
+
 - **Sequential calls** in a workflow
 - **Accumulating traces** for analysis
 - The same logical "agent" in your application
@@ -433,6 +435,7 @@ mod$optimize_grid(
 ```
 
 The optimizer:
+
 1. Creates `copy(deep = TRUE)` for each candidate
 2. Varies config parameters per the grid
 3. Runs each copy's `forward()` on the devset

--- a/vignettes/concepts-why-metrics-matter.Rmd
+++ b/vignettes/concepts-why-metrics-matter.Rmd
@@ -155,6 +155,7 @@ result$n_errors      # 0
 ```
 
 This single function call:
+
 1. Runs your module on every example
 2. Applies your metric to each prediction
 3. Aggregates results into actionable statistics
@@ -357,6 +358,7 @@ Metric-driven development takes more upfront effort:
 - Maintaining train/val/test splits
 
 But it pays off:
+
 - **Confidence**: You know when things work
 - **Progress**: You can measure improvement
 - **Debugging**: You can identify failure modes

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -36,6 +36,7 @@ That one-liner handles prompt construction, structured output parsing, and type 
 ### New to dsprrr?
 
 Start with the **tutorial sequence**—hands-on lessons that build on each other:
+
 1. [Your First LLM Call](tutorial-hello-world.html) — Make structured calls with `dsp()` (10 min)
 2. [Building a Classifier](tutorial-build-classifier.html) — Create reusable modules (20 min)
 3. [Extracting Structured Data](tutorial-structured-outputs.html) — Multi-field outputs (25 min)
@@ -46,12 +47,14 @@ Start with the **tutorial sequence**—hands-on lessons that build on each other
 ### Already know the basics?
 
 Jump to what you need:
+
 - **[Quick Reference](cheatsheet.html)** — Signature syntax, module types, metrics
 - **[Troubleshooting](troubleshooting.html)** — Fix common issues
 
 ### Want to understand the "why"?
 
 Read the conceptual guides:
+
 - **[The DSPy Philosophy](concepts-dspy-philosophy.html)** — Programs, not prompts
 - **[Understanding Signatures & Modules](concepts-signatures-modules.html)** — Why S7 and R6
 - **[How Optimization Works](concepts-optimization-theory.html)** — Teleprompter theory
@@ -59,6 +62,7 @@ Read the conceptual guides:
 ### Building something specific?
 
 Check the how-to guides:
+
 - **[Compile & Optimize](compilation-optimization.html)** — Full optimization workflow
 - **[Build RAG Pipelines](rag-workflows.html)** — Retrieval-augmented generation
 - **[Deploy to Production](orchestration.html)** — pins, targets, and Quarto

--- a/vignettes/llms-txt.Rmd
+++ b/vignettes/llms-txt.Rmd
@@ -417,6 +417,7 @@ AnalysisResult <- new_class("AnalysisResult",
 ```
 
 Now you get:
+
 - **Type checking**: Can't create a `PurposeAnalysis` without a `purpose`
 - **Documentation**: Class definitions show what fields exist
 - **IDE support**: Autocomplete works with `@` slots

--- a/vignettes/orchestration.Rmd
+++ b/vignettes/orchestration.Rmd
@@ -20,6 +20,7 @@ knitr::opts_chunk$set(
 
 ## Introduction
 Building LLM applications in development is one thing; running them reliably in production is another. This vignette covers dsprrr's orchestration features that help you:
+
 - **Persist** module configurations and traces across sessions
 - **Orchestrate** complex pipelines with targets
 - **Report** on experiments with Quarto

--- a/vignettes/text-adventure.Rmd
+++ b/vignettes/text-adventure.Rmd
@@ -446,6 +446,7 @@ GameState <- new_class("GameState",
 ```
 
 Now you get:
+
 - **Validation**: `Player(name = "X", health = -10L)` throws an error
 - **Documentation**: Properties are self-describing
 - **Type safety**: Can't accidentally assign wrong types

--- a/vignettes/troubleshooting.Rmd
+++ b/vignettes/troubleshooting.Rmd
@@ -465,6 +465,7 @@ mod <- as_module("question -> answer")
 ```
 
 ### "Unknown module type"
+
 **Error:**
 ```
 Error: Unknown module type: 'chain'

--- a/vignettes/tutorial-deploy-to-production.Rmd
+++ b/vignettes/tutorial-deploy-to-production.Rmd
@@ -343,12 +343,14 @@ Congratulations! You've completed the core tutorial sequence. You now know how t
 ### Advanced Tutorials
 
 Build complete applications:
+
 - **[Text Adventure Game](text-adventure.html)** — Interactive AI with state management
 - **[Generate llms.txt](llms-txt.html)** — Multi-stage documentation pipeline
 
 ### How-To Guides
 
 Solve specific problems:
+
 - **[Build RAG Pipelines](rag-workflows.html)** — Retrieval-augmented generation
 - **[Evaluate with Vitals](vitals-integration.html)** — Rigorous evaluation
 - **[Production Orchestration](orchestration.html)** — targets and Quarto integration
@@ -356,5 +358,6 @@ Solve specific problems:
 ### Concepts
 
 Understand the "why":
+
 - **[The DSPy Philosophy](concepts-dspy-philosophy.html)** — Programs, not prompts
 - **[How Optimization Works](concepts-optimization-theory.html)** — Teleprompter theory

--- a/vignettes/tutorial-hello-world.Rmd
+++ b/vignettes/tutorial-hello-world.Rmd
@@ -37,6 +37,7 @@ if (should_eval) {
 ```
 
 In this tutorial, you'll make your first structured LLM call with dsprrr. By the end, you'll be able to ask questions, get typed responses, and understand why signatures are powerful.
+
 **Time**: 10-15 minutes
 
 ## What You'll Build


### PR DESCRIPTION
Fixed markdown formatting issues across 16 vignettes where lists (bullet or numbered) were missing required blank lines after introductory text. This ensures proper markdown rendering.

Files fixed:
- getting-started.Rmd
- tutorial-hello-world.Rmd
- cheatsheet.Rmd
- advanced-modules.Rmd
- advanced-optimization.Rmd
- advanced-ellmer.Rmd
- troubleshooting.Rmd
- compilation-optimization.Rmd
- concepts-dspy-philosophy.Rmd
- concepts-optimization-theory.Rmd
- concepts-signatures-modules.Rmd
- concepts-why-metrics-matter.Rmd
- orchestration.Rmd
- text-adventure.Rmd
- llms-txt.Rmd
- tutorial-deploy-to-production.Rmd