### PR TITLE
fix: Update pkgdown theme to match hex sticker colors

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -3,7 +3,7 @@ template:
   bootstrap: 5
   light-switch: true
   bslib:
-    primary: "#6366f1"
+    primary: "#C9544D"
     border-radius: "0.5rem"
     btn-border-radius: "0.375rem"
     base_font: {google: "Inter"}


### PR DESCRIPTION
## Summary
- Change primary color from indigo (#6366f1) to coral red (#C9544D) to match the dsprrr hex sticker

## Test plan
- [x] Rebuild pkgdown site and verify colors match the hex sticker

🤖 Generated with [Claude Code](https://claude.com/claude-code)