### PR TITLE
Wrap simple results in 'list()' when length of results is greater than nrow data. 

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -1118,11 +1118,11 @@ run_dataset.Module <- function(
   }
 
   # Add results to data
-  if (.return_format == "simple") {                                                
-    if (length(results) != nrow(data)) {                                           
-      results <- list(results)                                                     
-    }                                                                              
-    data$result <- results                                                         
+  if (.return_format == "simple") {
+    if (length(results) != nrow(data)) {
+      results <- list(results)
+    }
+    data$result <- results
   } else {
     # For structured format, extract outputs and add metadata columns
     data$result <- lapply(results, `[[`, "output")


### PR DESCRIPTION
Fixes #83.