### PR TITLE
docs: replace ASCII vignette diagrams with Mermaid

### DIFF
--- a/vignettes/advanced-optimization.Rmd
+++ b/vignettes/advanced-optimization.Rmd
@@ -1,6 +1,9 @@
 ---
 title: "Advanced Optimizer Guide"
-output: rmarkdown::html_vignette
+output:
+  rmarkdown::html_vignette:
+    includes:
+      in_header: mermaid.html
 vignette: >
   %\VignetteIndexEntry{Advanced Optimizer Guide}
   %\VignetteEngine{knitr::rmarkdown}
@@ -38,32 +41,21 @@ For basic optimization concepts, see `vignette("compilation-optimization")`.
 
 ### Decision Tree
 
-```
-Start here: Do you have labeled training data?
-│
-├─ NO → Use zero-shot or manually write demos
-│
-└─ YES → How much data?
-    │
-    ├─ < 30 examples → LabeledFewShot (simple few-shot)
-    │
-    └─ 30+ examples → What do you want to optimize?
-        │
-        ├─ Just add demos → BootstrapFewShot
-        │
-        ├─ Demos + search configs → BootstrapFewShotWithRandomSearch
-        │
-        ├─ Different demos per query → KNNFewShot
-        │
-        ├─ Improve instructions → COPRO
-        │
-        ├─ Both instructions + demos → MIPROv2
-        │
-        ├─ Handle hard cases better → SIMBA
-        │
-        ├─ Balance quality vs cost → GEPA
-        │
-        └─ Combine multiple optimized modules → Ensemble
+```mermaid
+flowchart TB
+  Start["Do you have labeled training data?"]
+  Start -->|No| Zero["Use zero-shot or manually write demos"]
+  Start -->|Yes| Data["How much data?"]
+  Data -->|Fewer than 30 examples| Labeled["LabeledFewShot (simple few-shot)"]
+  Data -->|30+ examples| Optimize["What do you want to optimize?"]
+  Optimize -->|Just add demos| Bootstrap["BootstrapFewShot"]
+  Optimize -->|Demos + search configs| Random["BootstrapFewShotWithRandomSearch"]
+  Optimize -->|Different demos per query| KNN["KNNFewShot"]
+  Optimize -->|Improve instructions| COPRO["COPRO"]
+  Optimize -->|Both instructions + demos| MIPRO["MIPROv2"]
+  Optimize -->|Handle hard cases better| SIMBA["SIMBA"]
+  Optimize -->|Balance quality vs cost| GEPA["GEPA"]
+  Optimize -->|Combine multiple optimized modules| Ensemble["Ensemble"]
 ```
 
 ## Dataset Sizing Guidance

--- a/vignettes/cheatsheet.Rmd
+++ b/vignettes/cheatsheet.Rmd
@@ -1,6 +1,9 @@
 ---
 title: "Quick Reference"
-output: rmarkdown::html_vignette
+output:
+  rmarkdown::html_vignette:
+    includes:
+      in_header: mermaid.html
 vignette: >
   %\VignetteIndexEntry{Quick Reference}
   %\VignetteEngine{knitr::rmarkdown}
@@ -282,14 +285,13 @@ mod <- module(
 
 ## Module Types Decision Tree
 
-```
-What do you need?
-│
-├─ Simple text in/out → type = "predict" (PredictModule)
-│   └─ Q&A, classification, summarization, extraction
-│
-└─ Tool use / multi-step reasoning → type = "react" (ReactModule)
-    └─ Agents, search, calculations, API calls
+```mermaid
+flowchart TB
+  Start["What do you need?"]
+  Start -->|Simple text in/out| Predict["type = predict (PredictModule)"]
+  Predict --> PredictUse["Q&A, classification, summarization, extraction"]
+  Start -->|Tool use / multi-step reasoning| React["type = react (ReactModule)"]
+  React --> ReactUse["Agents, search, calculations, API calls"]
 ```
 
 | Type | Class | Use Case |
@@ -352,23 +354,19 @@ result <- run(mod, question = "Test", .llm = llm, .show_prompt = TRUE)
 
 ### Metric Selection Guide
 
-```
-What are you measuring?
-│
-├─ Exact correctness → metric_exact_match()
-│   └─ Facts, names, simple answers
-│
-├─ Approximate match → metric_f1() or metric_threshold(metric_f1(), 0.8)
-│   └─ Paraphrased answers, spelling tolerance
-│
-├─ Contains key info → metric_contains()
-│   └─ Important terms must appear
-│
-├─ Specific fields → metric_field_match(c("answer", "score"))
-│   └─ Multi-field outputs
-│
-└─ Custom logic → metric_custom(my_scorer_fn)
-    └─ Domain-specific evaluation
+```mermaid
+flowchart TB
+  Start["What are you measuring?"]
+  Start -->|Exact correctness| Exact["metric_exact_match()"]
+  Exact --> ExactUse["Facts, names, simple answers"]
+  Start -->|Approximate match| F1["metric_f1() or metric_threshold(metric_f1(), 0.8)"]
+  F1 --> F1Use["Paraphrased answers, spelling tolerance"]
+  Start -->|Contains key info| Contains["metric_contains()"]
+  Contains --> ContainsUse["Important terms must appear"]
+  Start -->|Specific fields| Field["metric_field_match(c('answer', 'score'))"]
+  Field --> FieldUse["Multi-field outputs"]
+  Start -->|Custom logic| Custom["metric_custom(my_scorer_fn)"]
+  Custom --> CustomUse["Domain-specific evaluation"]
 ```
 
 ### Metric by Task Type

--- a/vignettes/concepts-optimization-theory.Rmd
+++ b/vignettes/concepts-optimization-theory.Rmd
@@ -1,6 +1,9 @@
 ---
 title: "How Prompt Optimization Works"
-output: rmarkdown::html_vignette
+output:
+  rmarkdown::html_vignette:
+    includes:
+      in_header: mermaid.html
 vignette: >
   %\VignetteIndexEntry{How Prompt Optimization Works}
   %\VignetteEngine{knitr::rmarkdown}
@@ -361,26 +364,15 @@ Uses evolutionary algorithms (selection, mutation, crossover) to explore the pro
 
 Use this decision tree:
 
-```
-Start
-  │
-  ├─ "I just want a quick baseline"
-  │   └─> LabeledFewShot
-  │
-  ├─ "I have a reliable metric and want better demos"
-  │   └─> BootstrapFewShot
-  │
-  ├─ "I have specific instruction variants to test"
-  │   └─> GridSearchTeleprompter
-  │
-  ├─ "I want best results, have compute budget"
-  │   └─> MIPROv2 or BootstrapFewShotWithRandomSearch
-  │
-  ├─ "My inputs are diverse, need adaptive demos"
-  │   └─> KNNFewShot
-  │
-  └─ "I want to explore creatively"
-      └─> GEPA
+```mermaid
+flowchart TB
+  Start["Choose an optimizer"]
+  Start -->|Quick baseline| Labeled["LabeledFewShot"]
+  Start -->|Reliable metric, want better demos| Bootstrap["BootstrapFewShot"]
+  Start -->|Specific instruction variants to test| Grid["GridSearchTeleprompter"]
+  Start -->|Best results with compute budget| MIPRO["MIPROv2 or BootstrapFewShotWithRandomSearch"]
+  Start -->|Diverse inputs, need adaptive demos| KNN["KNNFewShot"]
+  Start -->|Explore creatively| GEPA["GEPA"]
 ```
 
 ## The Evaluation Loop

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -1,6 +1,9 @@
 ---
 title: "Getting Started with dsprrr"
-output: rmarkdown::html_vignette
+output:
+  rmarkdown::html_vignette:
+    includes:
+      in_header: mermaid.html
 vignette: >
   %\VignetteIndexEntry{Getting Started with dsprrr}
   %\VignetteEngine{knitr::rmarkdown}
@@ -120,35 +123,26 @@ OPENAI_API_KEY=sk-your-key-here
 
 ## Learning Path
 
-```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         TUTORIALS                                    │
-│  ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌──────────┐          │
-│  │ 1. Hello │ → │ 2. Build │ → │ 3. Struct│ → │ 4. Demos │          │
-│  │   World  │   │Classifier│   │ Outputs  │   │          │          │
-│  └──────────┘   └──────────┘   └──────────┘   └──────────┘          │
-│                                                      ↓               │
-│                                ┌──────────┐   ┌──────────┐          │
-│                                │ 5.Optim- │ → │ 6. Prod- │          │
-│                                │   ize    │   │  uction  │          │
-│                                └──────────┘   └──────────┘          │
-│                                                      ↓               │
-│                         ADVANCED TUTORIALS                           │
-│                    ┌────────────────┐   ┌────────────────┐          │
-│                    │ Text Adventure │   │  llms.txt Gen  │          │
-│                    └────────────────┘   └────────────────┘          │
-└─────────────────────────────────────────────────────────────────────┘
-                                   ↓
-                 ┌─────────────────┴─────────────────┐
-                 ↓                                   ↓
-        ┌────────────────┐                 ┌────────────────┐
-        │   HOW-TO       │                 │   CONCEPTS     │
-        │   GUIDES       │                 │                │
-        └────────────────┘                 └────────────────┘
-                 ↓                                   ↓
-        ┌────────────────┐                 ┌────────────────┐
-        │   REFERENCE    │ ←───────────────│   (cheatsheet) │
-        └────────────────┘                 └────────────────┘
+```mermaid
+flowchart TB
+  subgraph Tutorials
+    T1["1. Hello World"] --> T2["2. Build Classifier"] --> T3["3. Structured Outputs"]
+    T3 --> T4["4. Demos"] --> T5["5. Optimize"] --> T6["6. Production"]
+  end
+
+  T6 --> Adv["Advanced Tutorials"]
+  Adv --> TA["Text Adventure"]
+  Adv --> LL["llms.txt Gen"]
+
+  TA --> Split["Next Steps"]
+  LL --> Split
+
+  Split --> HowTo["How-To Guides"]
+  Split --> Concepts["Concepts"]
+
+  HowTo --> Reference["Reference"]
+  Concepts --> Cheatsheet["Cheatsheet"]
+  Cheatsheet --> Reference
 ```
 
 Start at the top and work your way down. Each tutorial builds on the previous one.

--- a/vignettes/mermaid.html
+++ b/vignettes/mermaid.html
@@ -1,0 +1,38 @@
+<style>
+.mermaid-diagram svg {
+  max-width: 100%;
+  height: auto;
+}
+</style>
+<script src="https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/beautiful-mermaid@0.1.3/dist/beautiful-mermaid.browser.global.js"></script>
+<script>
+document.addEventListener("DOMContentLoaded", async () => {
+  const api = window.beautifulMermaid;
+  if (!api || typeof api.renderMermaid !== "function") {
+    return;
+  }
+
+  const blocks = document.querySelectorAll(
+    "pre > code.language-mermaid, pre > code.mermaid"
+  );
+
+  for (const block of blocks) {
+    const source = block.textContent.trim();
+    if (!source) {
+      continue;
+    }
+
+    try {
+      const svg = await api.renderMermaid(source);
+      const wrapper = document.createElement("div");
+      wrapper.className = "mermaid-diagram";
+      wrapper.innerHTML = svg;
+      const pre = block.parentElement;
+      pre.replaceWith(wrapper);
+    } catch (err) {
+      console.error("Failed to render mermaid diagram", err);
+    }
+  }
+});
+</script>


### PR DESCRIPTION
## Summary
- replace ASCII box/tree diagrams with Mermaid flowcharts in key vignettes
- add a shared header include that renders Mermaid blocks with `beautiful-mermaid`
- wire vignette YAML headers to include the Mermaid renderer script

## Context
- reviewed the last merged PR (#87, module piping `%>>%`) first to avoid overlap
- this PR is docs-only in vignettes

## Test plan
- [x] `Rscript -e "rmarkdown::render('vignettes/getting-started.Rmd', output_file='getting-started-test.html', output_dir=tempdir(), quiet=TRUE)"`
- [x] `Rscript -e "rmarkdown::render('vignettes/cheatsheet.Rmd', output_file='cheatsheet-test.html', output_dir=tempdir(), quiet=TRUE)"`
- [x] verified no remaining ASCII tree/box diagrams in `vignettes/` via `rg`
