### PR TITLE
Fix enum output handling in vitals solver (closes #96)

### DIFF
--- a/R/vitals.R
+++ b/R/vitals.R
@@ -42,20 +42,23 @@ as_vitals_solver <- function(
   sig_input_names <- vapply(sig_inputs, function(x) x$name, character(1))
   output_type <- module$signature@output_type
 
-  # Check if output type is simple string (single string field in TypeObject)
-  is_simple_string <- FALSE
-  if (inherits(output_type, "ellmer::TypeObject")) {
+  # Check if output type produces a scalar string value that can be compared
+
+  # directly by vitals scorers like detect_match(). Types that produce scalar
+
+  # strings don't need JSON serialization; complex types (multi-field objects)
+  # are JSON-encoded for scorer compatibility.
+  is_scalar_output <- inherits(output_type, "ellmer::TypeEnum") ||
+    (inherits(output_type, "ellmer::TypeBasic") &&
+      identical(output_type@type, "string"))
+
+  if (!is_scalar_output && inherits(output_type, "ellmer::TypeObject")) {
     props <- output_type@properties
     if (length(props) == 1) {
       prop <- props[[1]]
-      if (
-        inherits(prop, "ellmer::TypeBasic") && identical(prop@type, "string")
-      ) {
-        is_simple_string <- TRUE
-      }
+      is_scalar_output <- inherits(prop, "ellmer::TypeBasic") &&
+        identical(prop@type, "string")
     }
-  } else if (inherits(output_type, "ellmer::TypeBasic")) {
-    is_simple_string <- identical(output_type@type, "string")
   }
 
   # Capture extra args for run_dataset
@@ -105,8 +108,8 @@ as_vitals_solver <- function(
     )
 
     # Extract results in vitals format
-    if (is_simple_string) {
-      # For simple strings, extract the string value
+    if (is_scalar_output) {
+      # For scalar outputs (strings, enums), extract the value directly
       result_values <- vapply(
         results$result,
         function(r) {

--- a/tests/testthat/test-vitals.R
+++ b/tests/testthat/test-vitals.R
@@ -129,6 +129,36 @@ test_that("as_vitals_solver handles multi-input modules", {
   expect_true(all(result$result == "answer"))
 })
 
+test_that("as_vitals_solver returns plain strings for enum outputs", {
+  sig <- Signature(
+    inputs = list(input(name = "text", class = S7::class_character)),
+    output_type = ellmer::type_enum(
+      values = c("positive", "negative", "neutral")
+    ),
+    instructions = "Classify sentiment"
+  )
+  mod <- module(signature = sig, type = "predict")
+
+  mock_llm <- structure(
+    list(
+      chat_structured = function(prompt, ...) "positive",
+      clone = function(...) mock_llm,
+      set_turns = function(turns) invisible(NULL),
+      get_turns = function(...) list()
+    ),
+    class = "Chat"
+  )
+
+  solver <- as_vitals_solver(mod, .llm = mock_llm, .parallel = FALSE)
+  result <- solver(list(tibble::tibble(text = "I love this!")))
+
+  # Enum values should be returned as plain strings, not JSON-encoded
+
+  # (i.e., "positive" not "\"positive\"")
+  expect_equal(result$result[[1]], "positive")
+  expect_equal(nchar(result$result[[1]]), nchar("positive"))
+})
+
 # --- as_dsprrr_metric tests ---
 
 test_that("as_dsprrr_metric wraps vitals scorers", {

--- a/vignettes/vitals-recipes.Rmd
+++ b/vignettes/vitals-recipes.Rmd
@@ -281,7 +281,7 @@ if (nrow(failures) > 0) {
     input_text <- failures$input[[i]]$text
     cat("Input:", input_text, "\n")
     cat("Expected:", failures$target[i], "\n")
-    cat("Got:", failures$answer[i], "\n\n")
+    cat("Got:", failures$result[i], "\n\n")
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes #96 — two bugs in the vitals integration that caused enum-based modules (e.g., sentiment classification) to always report 0% accuracy:

- **`as_vitals_solver()` JSON-serialized enum outputs**: `TypeEnum` values like `"positive"` were being wrapped as `"\"positive\""` via `jsonlite::toJSON()`, causing `detect_match()` to always fail. Enum types now take the scalar output path alongside plain strings.
- **Vignette Recipe 4 referenced wrong column**: `failures$answer` doesn't exist in vitals samples — the correct column is `failures$result`, which caused the `Unknown or uninitialised column: $answer` warning and empty output.

## Test plan

- [x] Added unit test: `as_vitals_solver returns plain strings for enum outputs`
- [x] Full test suite passes (2742 tests, 0 failures)
- [x] R CMD check passes (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)