### PR TITLE
fix: inject synthetic turns on cache hits (refactored #99)

### DIFF
--- a/R/cache.R
+++ b/R/cache.R
@@ -641,6 +641,10 @@ cached_chat_structured <- function(
       .dsprrr_env$cache_first_hit_shown <- TRUE
     }
 
+    # Inject synthetic turns so callers see a valid user/assistant exchange
+    # even though the LLM was not actually called.
+    inject_cache_hit_turns(llm, prompt, cached_result)
+
     return(cached_result)
   }
 
@@ -653,4 +657,53 @@ cached_chat_structured <- function(
   cache$set(key, result)
 
   result
+}
+
+#' Inject synthetic turns into a Chat after a cache hit
+#'
+#' When `cached_chat_structured()` returns a cached result the underlying Chat
+#' object has no record of the exchange. This helper appends a synthetic
+#' user/assistant turn pair so that downstream code (trace recording, metadata
+#' extraction via `last_turn()`, `inspect_history()`) sees a valid conversation.
+#'
+#' The function is intentionally defensive: if the Chat lacks `get_turns` or
+#' `set_turns` (e.g. a minimal mock), it silently does nothing.
+#'
+#' @param llm An ellmer Chat object (or mock).
+#' @param prompt Character. The full prompt that was sent (already includes
+#'   instructions if any).
+#' @param result The cached LLM response.
+#'
+#' @noRd
+inject_cache_hit_turns <- function(llm, prompt, result) {
+  # Bail out if the Chat doesn't support turn manipulation
+  set_turns_fn <- tryCatch(llm$set_turns, error = function(e) NULL)
+  if (!is.function(set_turns_fn)) {
+    return(invisible(NULL))
+  }
+
+  get_turns_fn <- tryCatch(llm$get_turns, error = function(e) NULL)
+  existing_turns <- if (is.function(get_turns_fn)) {
+    tryCatch(get_turns_fn(), error = function(e) list())
+  } else {
+    list()
+  }
+
+  # Serialize the cached response for the assistant content
+
+  response_text <- if (is.character(result) && length(result) == 1) {
+    result
+  } else {
+    as.character(jsonlite::toJSON(result, auto_unbox = TRUE))
+  }
+
+  user_turn <- ellmer::UserTurn(
+    contents = list(ellmer::ContentText(as.character(prompt)))
+  )
+  assistant_turn <- ellmer::AssistantTurn(
+    contents = list(ellmer::ContentText(response_text))
+  )
+
+  set_turns_fn(c(existing_turns, list(user_turn, assistant_turn)))
+  invisible(NULL)
 }

--- a/R/cache.R
+++ b/R/cache.R
@@ -676,18 +676,21 @@ cached_chat_structured <- function(
 #'
 #' @noRd
 inject_cache_hit_turns <- function(llm, prompt, result) {
-  # Bail out if the Chat doesn't support turn manipulation
+  # Bail out if the Chat doesn't support turn manipulation.
+  # Both get_turns and set_turns are required — without get_turns we can't
+
+  # preserve existing history, so calling set_turns would silently wipe it.
   set_turns_fn <- tryCatch(llm$set_turns, error = function(e) NULL)
   if (!is.function(set_turns_fn)) {
     return(invisible(NULL))
   }
 
   get_turns_fn <- tryCatch(llm$get_turns, error = function(e) NULL)
-  existing_turns <- if (is.function(get_turns_fn)) {
-    tryCatch(get_turns_fn(), error = function(e) list())
-  } else {
-    list()
+  if (!is.function(get_turns_fn)) {
+    return(invisible(NULL))
   }
+
+  existing_turns <- tryCatch(get_turns_fn(), error = function(e) list())
 
   # Serialize the cached response for the assistant content
 

--- a/tests/testthat/helper-cache.R
+++ b/tests/testthat/helper-cache.R
@@ -13,8 +13,10 @@ local_reset_cache <- function(.env = parent.frame()) {
       # Reset to defaults
       dsprrr:::configure_cache()
       dsprrr:::clear_cache()
+      dsprrr::clear_prompt_history()
     },
     envir = .env
   )
   dsprrr:::clear_cache()
+  dsprrr::clear_prompt_history()
 }

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -746,6 +746,270 @@ test_that("run() respects .cache = FALSE parameter (single input)", {
   expect_equal(call_count, 2) # No new call
 })
 
+# --- Cache-hit synthetic turn injection tests ---------------------------------
+
+test_that("cache hit injects synthetic turns into the Chat object", {
+  local_reset_cache()
+  configure_cache(enable = TRUE, enable_memory = TRUE, enable_disk = FALSE)
+
+  turns <- list()
+  mock_env <- new.env()
+  mock_env$mock_llm <- structure(
+    list(
+      get_model = function() "mock-model",
+      chat_structured = function(prompt, type, echo = "none") {
+        user_turn <- ellmer::UserTurn(
+          contents = list(ellmer::ContentText(prompt))
+        )
+        assistant_turn <- ellmer::AssistantTurn(
+          contents = list(ellmer::ContentText("{\"sentiment\":\"positive\"}"))
+        )
+        turns <<- c(turns, list(user_turn, assistant_turn))
+        list(sentiment = "positive")
+      },
+      `.__enclos_env__` = list(
+        private = list(api_args = list(temperature = 0.7))
+      ),
+      clone = function(...) mock_env$mock_llm,
+      set_turns = function(new_turns) {
+        turns <<- new_turns
+        invisible(NULL)
+      },
+      get_turns = function(...) turns,
+      last_turn = function(role = c("assistant", "user"), ...) {
+        role <- match.arg(role)
+        class_name <- if (role == "assistant") {
+          "ellmer::AssistantTurn"
+        } else {
+          "ellmer::UserTurn"
+        }
+        role_turns <- turns[vapply(
+          turns,
+          inherits,
+          logical(1),
+          what = class_name
+        )]
+        if (length(role_turns) == 0) {
+          stop("no turns")
+        }
+        role_turns[[length(role_turns)]]
+      }
+    ),
+    class = "Chat"
+  )
+
+  sig <- signature("text -> sentiment: enum('positive', 'negative', 'neutral')")
+  mod <- module(sig, type = "predict")
+
+  # First call — cache miss, real LLM call adds turns
+
+  invisible(run(mod, text = "Great!", .llm = mock_env$mock_llm))
+  expect_equal(length(turns), 2) # user + assistant from real call
+
+  # Second call — cache hit, synthetic turns should be injected
+  mod$state$traces <- list()
+  invisible(run(mod, text = "Great!", .llm = mock_env$mock_llm))
+  expect_equal(length(turns), 4) # original 2 + synthetic 2
+
+  # Verify the synthetic turns contain correct content
+  last_user <- turns[[3]]
+  last_assistant <- turns[[4]]
+  expect_s3_class(last_user, "ellmer::UserTurn")
+  expect_s3_class(last_assistant, "ellmer::AssistantTurn")
+  expect_match(last_user@contents[[1]]@text, "Great!")
+  expect_match(last_assistant@contents[[1]]@text, "positive")
+
+  # Verify trace was recorded with turns (not NULL)
+  trace <- mod$state$traces[[1]]
+  expect_s3_class(trace$user_turn, "ellmer::UserTurn")
+  expect_s3_class(trace$assistant_turn, "ellmer::AssistantTurn")
+})
+
+test_that("cache hit preserves pre-existing turn history", {
+  local_reset_cache()
+  configure_cache(enable = TRUE, enable_memory = TRUE, enable_disk = FALSE)
+
+  make_mock_chat <- function(initial_turns = list()) {
+    turns <- initial_turns
+    mock_env <- new.env()
+    mock_env$mock_llm <- structure(
+      list(
+        get_model = function() "mock-model",
+        chat_structured = function(prompt, type, echo = "none") {
+          user_turn <- ellmer::UserTurn(
+            contents = list(ellmer::ContentText(prompt))
+          )
+          assistant_turn <- ellmer::AssistantTurn(
+            contents = list(ellmer::ContentText("{\"sentiment\":\"positive\"}"))
+          )
+          turns <<- c(turns, list(user_turn, assistant_turn))
+          list(sentiment = "positive")
+        },
+        `.__enclos_env__` = list(
+          private = list(api_args = list(temperature = 0.7))
+        ),
+        clone = function(...) mock_env$mock_llm,
+        set_turns = function(new_turns) {
+          turns <<- new_turns
+          invisible(NULL)
+        },
+        get_turns = function(...) turns,
+        last_turn = function(role = c("assistant", "user"), ...) {
+          role <- match.arg(role)
+          class_name <- if (role == "assistant") {
+            "ellmer::AssistantTurn"
+          } else {
+            "ellmer::UserTurn"
+          }
+          role_turns <- turns[vapply(
+            turns,
+            inherits,
+            logical(1),
+            what = class_name
+          )]
+          if (length(role_turns) == 0) {
+            stop("no turns")
+          }
+          role_turns[[length(role_turns)]]
+        }
+      ),
+      class = "Chat"
+    )
+    mock_env$mock_llm
+  }
+
+  sig <- signature("text -> sentiment: enum('positive', 'negative', 'neutral')")
+  mod <- module(sig, type = "predict")
+
+  # Warm cache
+  llm_warm <- make_mock_chat()
+  invisible(run(mod, text = "Great!", .llm = llm_warm))
+
+  # Use a different chat with stale pre-existing history
+  old_user <- ellmer::UserTurn(
+    contents = list(ellmer::ContentText("OLD PROMPT"))
+  )
+  old_assistant <- ellmer::AssistantTurn(
+    contents = list(ellmer::ContentText("OLD RESPONSE"))
+  )
+  llm_with_history <- make_mock_chat(
+    initial_turns = list(old_user, old_assistant)
+  )
+
+  mod$state$traces <- list()
+  invisible(run(mod, text = "Great!", .llm = llm_with_history))
+
+  # Pre-existing turns preserved + new synthetic pair appended
+  expect_equal(length(llm_with_history$get_turns()), 4)
+
+  # Trace points to the new synthetic turns, not the old ones
+  trace <- mod$state$traces[[1]]
+  expect_match(trace$user_turn@contents[[1]]@text, "Great!")
+  expect_false(
+    identical(trace$user_turn@contents[[1]]@text, "OLD PROMPT")
+  )
+  expect_match(trace$assistant_turn@contents[[1]]@text, "positive")
+})
+
+test_that("cache hit works when Chat mock has no get_turns/set_turns", {
+  local_reset_cache()
+  configure_cache(enable = TRUE, enable_memory = TRUE, enable_disk = FALSE)
+
+  mock_env <- new.env()
+  mock_env$mock_llm <- structure(
+    list(
+      get_model = function() "mock-model",
+      chat_structured = function(prompt, type, echo = "none") {
+        list(sentiment = "positive")
+      },
+      `.__enclos_env__` = list(
+        private = list(api_args = list(temperature = 0.7))
+      ),
+      clone = function(...) mock_env$mock_llm
+    ),
+    class = "Chat"
+  )
+
+  sig <- signature("text -> sentiment: enum('positive', 'negative', 'neutral')")
+  mod <- module(sig, type = "predict")
+
+  # Should not error even without get_turns/set_turns
+  expect_no_error(run(mod, text = "Great!", .llm = mock_env$mock_llm))
+
+  # Second call hits cache — still no error
+  expect_no_error(run(mod, text = "Great!", .llm = mock_env$mock_llm))
+})
+
+test_that("synthetic turn tokens/cost/duration are NA (not 0)", {
+  local_reset_cache()
+  configure_cache(enable = TRUE, enable_memory = TRUE, enable_disk = FALSE)
+
+  turns <- list()
+  mock_env <- new.env()
+  mock_env$mock_llm <- structure(
+    list(
+      get_model = function() "mock-model",
+      chat_structured = function(prompt, type, echo = "none") {
+        user_turn <- ellmer::UserTurn(
+          contents = list(ellmer::ContentText(prompt))
+        )
+        assistant_turn <- ellmer::AssistantTurn(
+          contents = list(ellmer::ContentText("{\"answer\":\"42\"}")),
+          tokens = c(10, 5, 0),
+          cost = 0.001,
+          duration = 1.5
+        )
+        turns <<- c(turns, list(user_turn, assistant_turn))
+        list(answer = "42")
+      },
+      `.__enclos_env__` = list(
+        private = list(api_args = list(temperature = 0.7))
+      ),
+      clone = function(...) mock_env$mock_llm,
+      set_turns = function(new_turns) {
+        turns <<- new_turns
+        invisible(NULL)
+      },
+      get_turns = function(...) turns,
+      last_turn = function(role = c("assistant", "user"), ...) {
+        role <- match.arg(role)
+        class_name <- if (role == "assistant") {
+          "ellmer::AssistantTurn"
+        } else {
+          "ellmer::UserTurn"
+        }
+        role_turns <- turns[vapply(
+          turns,
+          inherits,
+          logical(1),
+          what = class_name
+        )]
+        if (length(role_turns) == 0) {
+          stop("no turns")
+        }
+        role_turns[[length(role_turns)]]
+      }
+    ),
+    class = "Chat"
+  )
+
+  sig <- signature("question -> answer: string")
+  mod <- module(sig, type = "predict")
+
+  # Cache miss — real call
+  invisible(run(mod, question = "What?", .llm = mock_env$mock_llm))
+
+  # Cache hit — synthetic turn
+  mod$state$traces <- list()
+  invisible(run(mod, question = "What?", .llm = mock_env$mock_llm))
+
+  # Synthetic assistant turn should have NA tokens/cost/duration (not 0)
+  synthetic_assistant <- turns[[4]]
+  expect_true(all(is.na(synthetic_assistant@tokens)))
+  expect_true(is.na(synthetic_assistant@cost))
+  expect_true(is.na(synthetic_assistant@duration))
+})
+
 test_that("run() respects .cache = FALSE in batch processing", {
   local_reset_cache()
   # Use memory-only cache to avoid disk pollution from previous runs


### PR DESCRIPTION
## Summary

Refactored alternative to #99 that fixes the same issue (#98) with a cleaner architecture.

When `cached_chat_structured()` returns a cached result, the Chat object has no recorded turns, breaking trace recording and metadata extraction. Rather than patching `PredictModule$forward()`, this fix lives in the cache layer itself:

- **`inject_cache_hit_turns()`** in `R/cache.R` — appends synthetic `UserTurn`/`AssistantTurn` on cache hits
- All callers (PredictModule, RAGModule, `run.R`) benefit automatically
- No turn-count heuristic needed — injection happens exactly at cache hit
- Tokens/cost/duration default to `NA` (ellmer defaults), not `0`
- No duplicated prompt reconstruction — `cached_chat_structured()` already receives the full prompt

### Changes vs #99

| Concern | PR #99 | This PR |
|---------|--------|---------|
| Location | `module-predict.R` | `cache.R` |
| Scope | PredictModule only | All callers |
| Detection | Turn-count heuristic | Direct (at cache hit) |
| Token/cost | `0` | `NA` (consistent) |
| Prompt | Reconstructed (duplicated) | Already available |

Fixes #98. Supersedes #99.

## Test plan

- [x] Cache hit injects synthetic turns into the Chat object
- [x] Pre-existing turn history is preserved (appended, not replaced)
- [x] Graceful no-op when Chat mock lacks `get_turns`/`set_turns`
- [x] Synthetic turn tokens/cost/duration are `NA` (not `0`)
- [x] Full test suite passes (2761 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)