### PR TITLE
[codex] ellmer-first core refactor

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     cachem,
     cli,
     digest,
-    ellmer,
+    ellmer (>= 0.4.0.9000),
     glue,
     jsonlite,
     methods,
@@ -60,6 +60,8 @@ Suggests:
     vcr (>= 2.0.0),
     vitals,
     yardstick
+Remotes:
+    tidyverse/ellmer
 Collate:
     'accessors.R'
     'assertion-helpers.R'

--- a/R/async.R
+++ b/R/async.R
@@ -40,24 +40,13 @@ run_async <- function(module, ..., .llm = NULL) {
     cli::cli_abort("{.arg module} must be a dsprrr Module object")
   }
 
-  llm <- .llm %||% module$chat %||% get_default_chat(create = TRUE)
-
   inputs <- list(...)
-  prompt <- module$signature@instructions
-
-  # Build prompt using module's private method (accessed via environment)
-  # We need to build the prompt the same way forward() does
-  input_text <- build_simple_prompt(inputs, module$signature@inputs)
-
-  if (nchar(prompt) > 0) {
-    full_prompt <- paste(prompt, input_text, sep = "\n\n")
-  } else {
-    full_prompt <- input_text
-  }
+  request <- build_module_request(module, inputs)
+  llm <- resolve_module_llm(module, .llm = .llm)
 
   # Use ellmer's async method
   llm$chat_structured_async(
-    full_prompt,
+    request$payload,
     type = module$signature@output_type
   )
 }
@@ -87,22 +76,12 @@ stream_async <- function(module, ..., .llm = NULL) {
     cli::cli_abort("{.arg module} must be a dsprrr Module object")
   }
 
-  llm <- .llm %||% module$chat %||% get_default_chat(create = TRUE)
-
   inputs <- list(...)
-
-  # Build prompt
-  input_text <- build_simple_prompt(inputs, module$signature@inputs)
-  prompt <- module$signature@instructions
-
-  if (nchar(prompt) > 0) {
-    full_prompt <- paste(prompt, input_text, sep = "\n\n")
-  } else {
-    full_prompt <- input_text
-  }
+  request <- build_module_request(module, inputs)
+  llm <- resolve_module_llm(module, .llm = .llm)
 
   # Use ellmer's async stream method
-  llm$stream_async(full_prompt)
+  llm$stream_async(request$payload)
 }
 
 #' Build a simple prompt from inputs

--- a/R/cache.R
+++ b/R/cache.R
@@ -438,8 +438,9 @@ is_ellmer_type <- function(x) {
 extract_llm_temperature <- function(llm) {
   tryCatch(
     {
-      # Access provider's temperature setting from internal api_args
-      llm$.__enclos_env__$private$api_args$temperature
+      provider <- llm$.__enclos_env__$private$provider
+      args <- provider@extra_args %||% list()
+      args$temperature %||% provider@params$temperature
     },
     error = function(e) NULL
   )

--- a/R/ellmer.R
+++ b/R/ellmer.R
@@ -1,3 +1,9 @@
+#' Deep-copy an ellmer type object
+#' @noRd
+copy_ellmer_type <- function(type) {
+  unserialize(serialize(type, NULL))
+}
+
 #' Convert a DSPrrr Module to an ellmer Tool
 #'
 #' @description
@@ -87,18 +93,11 @@ as_ellmer_tool <- function(
   for (input_spec in sig_inputs) {
     input_name <- input_spec$name
     input_desc <- input_spec$description %||% paste("The", input_name, "value")
-    input_type <- input_spec$type
+    ellmer_type <- copy_ellmer_type(input_spec$type)
 
-    # Map to ellmer type_ functions based on input type class
-    type_class <- class(input_type)[1]
-    ellmer_type <- switch(
-      type_class,
-      "ellmer_type_number" = ellmer::type_number(input_desc),
-      "ellmer_type_integer" = ellmer::type_integer(input_desc),
-      "ellmer_type_boolean" = ellmer::type_boolean(input_desc),
-      # Default to string for unknown types
-      ellmer::type_string(input_desc)
-    )
+    if (is.null(ellmer_type@description) && !is.null(input_desc)) {
+      ellmer_type@description <- input_desc
+    }
 
     arg_specs[[input_name]] <- ellmer_type
   }
@@ -136,14 +135,7 @@ as_ellmer_tool <- function(
       )
     )
 
-    # Format result for LLM consumption
-    if (is.list(result) && !is.null(names(result))) {
-      jsonlite::toJSON(result, auto_unbox = TRUE)
-    } else if (is.character(result)) {
-      result
-    } else {
-      as.character(result)
-    }
+    result
   })
 
   # Create the function with proper signature

--- a/R/inspect.R
+++ b/R/inspect.R
@@ -332,28 +332,7 @@ extract_turn_text <- function(turn) {
   }
 
   tryCatch(
-    {
-      # ellmer turns have @contents which is a list of Content objects
-      if (!is.null(turn@contents) && length(turn@contents) > 0) {
-        # ContentText has @text property
-        texts <- vapply(
-          turn@contents,
-          function(c) {
-            if (inherits(c, "ContentText")) {
-              c@text
-            } else if (!is.null(c$text)) {
-              c$text
-            } else {
-              ""
-            }
-          },
-          character(1)
-        )
-        paste(texts, collapse = "\n")
-      } else {
-        NA_character_
-      }
-    },
+    render_turn_text(turn),
     error = function(e) {
       # Warn in verbose mode to help with debugging during development
       if (getOption("dsprrr.verbose", FALSE)) {

--- a/R/module-base.R
+++ b/R/module-base.R
@@ -535,7 +535,10 @@ Module <- R6::R6Class(
           vapply(
             traces,
             function(x) {
-              duration <- tryCatch(x$assistant_turn@duration, error = function(e) NULL)
+              duration <- tryCatch(
+                x$assistant_turn@duration,
+                error = function(e) NULL
+              )
               duration %||% ((trace_latency_ms(x) %||% 0) / 1000)
             },
             numeric(1)
@@ -779,7 +782,7 @@ Module <- R6::R6Class(
 
         prompt_text <- trace_prompt_text(last_trace)
 
-        if (!is.null(prompt_text) && nzchar(prompt_text)) {
+        if (!is.na(prompt_text) && nzchar(prompt_text)) {
           # Truncate if very long
           if (nchar(prompt_text) > 300) {
             prompt_text <- paste0(

--- a/R/module-base.R
+++ b/R/module-base.R
@@ -36,7 +36,7 @@ Module <- R6::R6Class(
       }
 
       self$signature <- signature
-      self$config <- config
+      self$config <- normalize_module_config(config)
       self$chat <- chat
       self$state <- list(
         traces = list(),
@@ -442,56 +442,42 @@ Module <- R6::R6Class(
           timestamp = .POSIXct(numeric(0)),
           latency_ms = numeric(0),
           input_tokens = integer(0),
+          cached_input_tokens = integer(0),
           output_tokens = integer(0),
           total_tokens = integer(0),
           cost = numeric(0),
           model = character(0),
-          prompt_length = integer(0)
+          prompt_length = integer(0),
+          prompt = character(0),
+          response = character(0)
         ))
       }
 
       # Convert list of traces to tibble
       tibble::tibble(
         timestamp = vapply(traces, function(x) x$timestamp, .POSIXct(1)),
-        latency_ms = vapply(
-          traces,
-          function(x) x$latency_ms %||% NA_real_,
-          numeric(1)
-        ),
+        latency_ms = vapply(traces, trace_latency_ms, numeric(1)),
         input_tokens = vapply(
           traces,
-          function(x) {
-            if (is.list(x$tokens)) {
-              as.integer(x$tokens$input_tokens %||% NA)
-            } else {
-              NA_integer_
-            }
-          },
+          function(x) trace_tokens(x)$input_tokens,
+          integer(1)
+        ),
+        cached_input_tokens = vapply(
+          traces,
+          function(x) trace_tokens(x)$cached_input_tokens,
           integer(1)
         ),
         output_tokens = vapply(
           traces,
-          function(x) {
-            if (is.list(x$tokens)) {
-              as.integer(x$tokens$output_tokens %||% NA)
-            } else {
-              NA_integer_
-            }
-          },
+          function(x) trace_tokens(x)$output_tokens,
           integer(1)
         ),
         total_tokens = vapply(
           traces,
-          function(x) {
-            if (is.list(x$tokens)) {
-              as.integer(x$tokens$total_tokens %||% NA)
-            } else {
-              NA_integer_
-            }
-          },
+          function(x) trace_tokens(x)$total_tokens,
           integer(1)
         ),
-        cost = vapply(traces, function(x) x$cost %||% NA_real_, numeric(1)),
+        cost = vapply(traces, trace_cost, numeric(1)),
         model = vapply(
           traces,
           function(x) x$model %||% NA_character_,
@@ -500,10 +486,13 @@ Module <- R6::R6Class(
         prompt_length = vapply(
           traces,
           function(x) {
-            if (!is.null(x$prompt)) nchar(x$prompt) else NA_integer_
+            prompt <- trace_prompt_text(x)
+            if (!is.na(prompt)) nchar(prompt) else NA_integer_
           },
           integer(1)
-        )
+        ),
+        prompt = vapply(traces, trace_prompt_text, character(1)),
+        response = vapply(traces, trace_response_text, character(1))
       )
     },
 
@@ -522,22 +511,18 @@ Module <- R6::R6Class(
         ))
       }
 
-      # Extract metrics from ellmer AssistantTurn objects
-      # AssistantTurn@tokens is c(input, output, cached_input)
-      # AssistantTurn@cost and @duration are also available
-      extract_tokens <- function(trace) {
-        turn <- trace$assistant_turn
-        if (is.null(turn) || is.null(turn@tokens)) {
-          return(c(input = 0, output = 0, cached = 0))
-        }
-        c(
-          input = turn@tokens[1] %||% 0,
-          output = turn@tokens[2] %||% 0,
-          cached = turn@tokens[3] %||% 0
-        )
-      }
-
-      all_tokens <- vapply(traces, extract_tokens, numeric(3))
+      all_tokens <- vapply(
+        traces,
+        function(trace) {
+          tokens <- trace_tokens(trace)
+          c(
+            input = tokens$input_tokens %||% 0,
+            output = tokens$output_tokens %||% 0,
+            cached = tokens$cached_input_tokens %||% 0
+          )
+        },
+        numeric(3)
+      )
 
       list(
         n_traces = length(traces),
@@ -550,42 +535,19 @@ Module <- R6::R6Class(
           vapply(
             traces,
             function(x) {
-              if (!is.null(x$assistant_turn)) {
-                x$assistant_turn@duration %||% 0
-              } else {
-                0
-              }
+              duration <- tryCatch(x$assistant_turn@duration, error = function(e) NULL)
+              duration %||% ((trace_latency_ms(x) %||% 0) / 1000)
             },
             numeric(1)
           ),
           na.rm = TRUE
         ),
         total_latency_ms = sum(
-          vapply(
-            traces,
-            function(x) {
-              if (!is.null(x$assistant_turn)) {
-                (x$assistant_turn@duration %||% 0) * 1000
-              } else {
-                0
-              }
-            },
-            numeric(1)
-          ),
+          vapply(traces, trace_latency_ms, numeric(1)),
           na.rm = TRUE
         ),
         total_cost = sum(
-          vapply(
-            traces,
-            function(x) {
-              if (!is.null(x$assistant_turn)) {
-                x$assistant_turn@cost %||% 0
-              } else {
-                0
-              }
-            },
-            numeric(1)
-          ),
+          vapply(traces, trace_cost, numeric(1)),
           na.rm = TRUE
         )
       )
@@ -815,32 +777,7 @@ Module <- R6::R6Class(
         cli::cli_h3("Last Prompt")
         last_trace <- self$state$traces[[length(self$state$traces)]]
 
-        # Try to extract prompt
-        prompt_text <- NULL
-        if (!is.null(last_trace$prompt)) {
-          prompt_text <- last_trace$prompt
-        } else if (!is.null(last_trace$user_turn)) {
-          # Try to extract from ellmer Turn
-          tryCatch(
-            {
-              if (
-                !is.null(last_trace$user_turn@contents) &&
-                  length(last_trace$user_turn@contents) > 0
-              ) {
-                contents <- last_trace$user_turn@contents
-                texts <- vapply(
-                  contents,
-                  function(c) {
-                    if (inherits(c, "ContentText")) c@text else ""
-                  },
-                  character(1)
-                )
-                prompt_text <- paste(texts, collapse = "\n")
-              }
-            },
-            error = function(e) NULL
-          )
-        }
+        prompt_text <- trace_prompt_text(last_trace)
 
         if (!is.null(prompt_text) && nzchar(prompt_text)) {
           # Truncate if very long
@@ -857,19 +794,9 @@ Module <- R6::R6Class(
 
         # Show response preview
         cli::cli_h3("Last Response")
-        if (!is.null(last_trace$output)) {
-          response_text <- if (is.character(last_trace$output)) {
-            last_trace$output
-          } else if (is.list(last_trace$output)) {
-            jsonlite::toJSON(
-              last_trace$output,
-              auto_unbox = TRUE,
-              pretty = FALSE
-            )
-          } else {
-            as.character(last_trace$output)
-          }
+        response_text <- trace_response_text(last_trace)
 
+        if (!is.na(response_text) && nzchar(response_text)) {
           if (nchar(response_text) > 200) {
             response_text <- paste0(substr(response_text, 1, 200), "...")
           }
@@ -919,18 +846,12 @@ Module <- R6::R6Class(
     #' @return If callback is NULL, returns a coro generator. Otherwise, returns
     #'   the full response text invisibly after streaming completes.
     stream = function(..., .llm = NULL, callback = NULL) {
-      llm <- .llm %||% self$chat %||% get_default_chat(create = TRUE)
-
       inputs <- list(...)
-      prompt <- private$build_prompt(inputs)
-
-      # Add instructions if present
-      if (nchar(self$signature@instructions) > 0) {
-        prompt <- paste(self$signature@instructions, prompt, sep = "\n\n")
-      }
+      request <- build_module_request(self, inputs)
+      llm <- resolve_module_llm(self, .llm = .llm)
 
       # Get stream generator from ellmer
-      gen <- llm$stream(prompt)
+      gen <- llm$stream(request$payload)
 
       if (!is.null(callback)) {
         # Consume stream with callback
@@ -1062,6 +983,15 @@ Module <- R6::R6Class(
 )
 
 Module$set("public", "apply_optimization_params", function(params) {
+  runtime_params <- intersect(names(params), runtime_param_names())
+  if (length(runtime_params) > 0) {
+    self$config$params <- self$config$params %||% list()
+    for (name in runtime_params) {
+      self$config$params[[name]] <- params[[name]]
+      self$config[[name]] <- params[[name]]
+    }
+  }
+
   invisible(self)
 })
 

--- a/R/module-multichain.R
+++ b/R/module-multichain.R
@@ -206,10 +206,12 @@ MultiChainComparisonModule <- R6::R6Class(
         total_tokens <- total_tokens + comparison_metadata$total_tokens
       }
       if (!is.null(comparison_metadata$input_tokens)) {
-        total_input_tokens <- total_input_tokens + comparison_metadata$input_tokens
+        total_input_tokens <- total_input_tokens +
+          comparison_metadata$input_tokens
       }
       if (!is.null(comparison_metadata$output_tokens)) {
-        total_output_tokens <- total_output_tokens + comparison_metadata$output_tokens
+        total_output_tokens <- total_output_tokens +
+          comparison_metadata$output_tokens
       }
       if (
         !is.null(comparison_metadata$cost) && !is.na(comparison_metadata$cost)
@@ -479,7 +481,10 @@ MultiChainComparisonModule <- R6::R6Class(
       )
 
       llm <- resolve_module_llm(self, .llm = .llm)
-      start_turn_count <- tryCatch(length(llm$get_turns()), error = function(e) 0L)
+      start_turn_count <- tryCatch(
+        length(llm$get_turns()),
+        error = function(e) 0L
+      )
 
       # Build comparison signature
       comparison_sig <- private$build_comparison_signature()
@@ -536,7 +541,12 @@ MultiChainComparisonModule <- R6::R6Class(
         turns = tryCatch(
           {
             current_turns <- llm$get_turns()
-            current_turns[seq.int(start_turn_count + 1L, length(current_turns))]
+            new_start <- start_turn_count + 1L
+            if (new_start <= length(current_turns)) {
+              current_turns[seq.int(new_start, length(current_turns))]
+            } else {
+              list()
+            }
           },
           error = function(e) list(user_turn, assistant_turn)
         ),

--- a/R/module-multichain.R
+++ b/R/module-multichain.R
@@ -92,8 +92,7 @@ MultiChainComparisonModule <- R6::R6Class(
         self$inner_module <- inner_module
       } else {
         # Default: use ChainOfThought for better reasoning
-        cot_sig <- with_reasoning(sig)
-        self$inner_module <- module(cot_sig, type = "predict", chat = chat)
+        self$inner_module <- module(sig, type = "chain_of_thought", chat = chat)
       }
 
       self$M <- as.integer(M)
@@ -130,14 +129,26 @@ MultiChainComparisonModule <- R6::R6Class(
       start_time <- Sys.time()
       attempts <- list()
       total_tokens <- 0
+      total_input_tokens <- 0
+      total_output_tokens <- 0
       total_cost <- 0
+      attempt_llm <- resolve_module_llm(
+        self,
+        .llm = .llm,
+        extra_params = list(temperature = self$temperature)
+      )
 
       # Phase 1: Generate M reasoning chains
       for (i in seq_len(self$M)) {
         # Run inner module
         result <- tryCatch(
           {
-            self$inner_module$forward(batch, .llm = .llm, trace = FALSE, ...)
+            self$inner_module$forward(
+              batch,
+              .llm = attempt_llm,
+              trace = FALSE,
+              ...
+            )
           },
           error = function(e) {
             cli::cli_warn(c(
@@ -155,6 +166,12 @@ MultiChainComparisonModule <- R6::R6Class(
           # Accumulate costs
           if (!is.null(metadata$total_tokens)) {
             total_tokens <- total_tokens + metadata$total_tokens
+          }
+          if (!is.null(metadata$input_tokens)) {
+            total_input_tokens <- total_input_tokens + metadata$input_tokens
+          }
+          if (!is.null(metadata$output_tokens)) {
+            total_output_tokens <- total_output_tokens + metadata$output_tokens
           }
           if (!is.null(metadata$cost) && !is.na(metadata$cost)) {
             total_cost <- total_cost + metadata$cost
@@ -188,6 +205,12 @@ MultiChainComparisonModule <- R6::R6Class(
       if (!is.null(comparison_metadata$total_tokens)) {
         total_tokens <- total_tokens + comparison_metadata$total_tokens
       }
+      if (!is.null(comparison_metadata$input_tokens)) {
+        total_input_tokens <- total_input_tokens + comparison_metadata$input_tokens
+      }
+      if (!is.null(comparison_metadata$output_tokens)) {
+        total_output_tokens <- total_output_tokens + comparison_metadata$output_tokens
+      }
       if (
         !is.null(comparison_metadata$cost) && !is.na(comparison_metadata$cost)
       ) {
@@ -209,7 +232,10 @@ MultiChainComparisonModule <- R6::R6Class(
         n_successful_attempts = length(attempts),
         n_failed_attempts = self$M - length(attempts),
         n_llm_calls = length(attempts) + 1, # M attempts + 1 comparison
+        input_tokens = total_input_tokens,
+        output_tokens = total_output_tokens,
         total_tokens = total_tokens,
+        cost = total_cost,
         total_cost = total_cost,
         latency_ms = latency_ms
       )
@@ -220,11 +246,22 @@ MultiChainComparisonModule <- R6::R6Class(
           timestamp = end_time,
           inputs = inputs,
           output = final_output,
+          prompt = comparison_metadata$prompt %||% NA_character_,
           attempts = attempts,
           comparison_output = final_output,
           M = self$M,
           n_successful_attempts = length(attempts),
           n_failed_attempts = self$M - length(attempts),
+          user_turn = comparison_metadata$user_turn %||% NULL,
+          assistant_turn = comparison_metadata$assistant_turn %||% NULL,
+          turns = comparison_metadata$turns %||% list(),
+          latency_ms = latency_ms,
+          tokens = list(
+            input_tokens = total_input_tokens,
+            output_tokens = total_output_tokens,
+            total_tokens = total_tokens
+          ),
+          cost = total_cost,
           model = comparison_metadata$model
         )
         self$state$traces <- append(self$state$traces, list(trace_entry))
@@ -328,11 +365,16 @@ MultiChainComparisonModule <- R6::R6Class(
     #' @description
     #' Apply optimization parameters
     apply_optimization_params = function(params) {
+      super$apply_optimization_params(params)
+
       if (!is.null(params$M)) {
         self$M <- as.integer(params$M)
       }
       if (!is.null(params$temperature)) {
         self$temperature <- params$temperature
+        self$config$params <- self$config$params %||% list()
+        self$config$params$temperature <- params$temperature
+        self$config$temperature <- params$temperature
       }
       # Forward other params to inner module
       inner_params <- params[!names(params) %in% c("M", "temperature")]
@@ -436,8 +478,8 @@ MultiChainComparisonModule <- R6::R6Class(
         }
       )
 
-      # Get LLM
-      llm <- .llm %||% self$chat %||% private$get_default_llm()
+      llm <- resolve_module_llm(self, .llm = .llm)
+      start_turn_count <- tryCatch(length(llm$get_turns()), error = function(e) 0L)
 
       # Build comparison signature
       comparison_sig <- private$build_comparison_signature()
@@ -456,6 +498,10 @@ MultiChainComparisonModule <- R6::R6Class(
         1000
 
       # Get token info
+      user_turn <- tryCatch(
+        llm$last_turn(role = "user"),
+        error = function(e) NULL
+      )
       assistant_turn <- tryCatch(
         llm$last_turn(role = "assistant"),
         error = function(e) NULL
@@ -485,6 +531,17 @@ MultiChainComparisonModule <- R6::R6Class(
         timestamp = end_time,
         model = model,
         prompt = as.character(comparison_prompt),
+        user_turn = user_turn,
+        assistant_turn = assistant_turn,
+        turns = tryCatch(
+          {
+            current_turns <- llm$get_turns()
+            current_turns[seq.int(start_turn_count + 1L, length(current_turns))]
+          },
+          error = function(e) list(user_turn, assistant_turn)
+        ),
+        input_tokens = token_info$input_tokens,
+        output_tokens = token_info$output_tokens,
         total_tokens = token_info$total_tokens,
         cost = cost,
         latency_ms = latency_ms
@@ -499,36 +556,11 @@ MultiChainComparisonModule <- R6::R6Class(
 
     #' Get default LLM client
     get_default_llm = function() {
-      # Check for configured provider
-      provider <- self$config$provider %||%
-        Sys.getenv("DSPRRR_PROVIDER", "openai")
-      provider <- switch(provider, anthropic = "claude", provider)
-
-      model_name <- self$config$model
-
-      llm <- switch(
-        provider,
-        openai = ellmer::chat_openai(
-          model = model_name %||% "gpt-4o-mini",
-          api_args = list(temperature = self$temperature)
-        ),
-        claude = ellmer::chat_claude(
-          model = model_name %||% "claude-sonnet-4-20250514",
-          max_tokens = self$config$max_tokens %||% 4096,
-          api_args = list(temperature = self$temperature)
-        ),
-        gemini = ellmer::chat_google_gemini(
-          model = model_name %||% "gemini-2.0-flash",
-          api_args = list(temperature = self$temperature)
-        ),
-        ollama = ellmer::chat_ollama(
-          model = model_name %||% "llama3.2:3b",
-          api_args = list(temperature = self$temperature)
-        ),
-        cli::cli_abort("Unknown provider: {provider}")
+      resolve_module_llm(
+        self,
+        create = TRUE,
+        extra_params = list(temperature = self$temperature)
       )
-
-      llm
     }
   )
 )

--- a/R/module-multichain.R
+++ b/R/module-multichain.R
@@ -140,12 +140,18 @@ MultiChainComparisonModule <- R6::R6Class(
 
       # Phase 1: Generate M reasoning chains
       for (i in seq_len(self$M)) {
+        # Clone chat per attempt so each chain starts with fresh state
+        iter_llm <- tryCatch(
+          attempt_llm$clone(deep = TRUE),
+          error = function(e) attempt_llm
+        )
+
         # Run inner module
         result <- tryCatch(
           {
             self$inner_module$forward(
               batch,
-              .llm = attempt_llm,
+              .llm = iter_llm,
               trace = FALSE,
               ...
             )

--- a/R/module-predict.R
+++ b/R/module-predict.R
@@ -65,7 +65,10 @@ PredictModule <- R6::R6Class(
       request <- build_module_request(self, inputs)
       prompt <- request$prompt
       llm <- resolve_module_llm(self, .llm = .llm)
-      start_turn_count <- tryCatch(length(llm$get_turns()), error = function(e) 0L)
+      start_turn_count <- tryCatch(
+        length(llm$get_turns()),
+        error = function(e) 0L
+      )
 
       # Record start time
       start_time <- Sys.time()
@@ -104,7 +107,12 @@ PredictModule <- R6::R6Class(
       turns <- tryCatch(
         {
           current_turns <- llm$get_turns()
-          current_turns[seq.int(start_turn_count + 1L, length(current_turns))]
+          new_start <- start_turn_count + 1L
+          if (new_start <= length(current_turns)) {
+            current_turns[seq.int(new_start, length(current_turns))]
+          } else {
+            list()
+          }
         },
         error = function(e) list(user_turn, assistant_turn)
       )

--- a/R/module-predict.R
+++ b/R/module-predict.R
@@ -62,11 +62,10 @@ PredictModule <- R6::R6Class(
         inputs <- batch
       }
 
-      # Build prompt
-      prompt <- private$build_prompt(inputs)
-
-      # Get LLM client: prefer passed .llm, then stored chat, then auto-detect
-      llm <- .llm %||% self$chat %||% private$get_default_llm()
+      request <- build_module_request(self, inputs)
+      prompt <- request$prompt
+      llm <- resolve_module_llm(self, .llm = .llm)
+      start_turn_count <- tryCatch(length(llm$get_turns()), error = function(e) 0L)
 
       # Record start time
       start_time <- Sys.time()
@@ -76,10 +75,8 @@ PredictModule <- R6::R6Class(
         {
           private$call_llm(
             llm = llm,
-            prompt = prompt,
+            request = request,
             output_type = self$signature@output_type,
-            instructions = self$signature@instructions,
-            inputs = inputs,
             .cache = .cache
           )
         },
@@ -103,6 +100,13 @@ PredictModule <- R6::R6Class(
       user_turn <- tryCatch(
         llm$last_turn(role = "user"),
         error = function(e) NULL
+      )
+      turns <- tryCatch(
+        {
+          current_turns <- llm$get_turns()
+          current_turns[seq.int(start_turn_count + 1L, length(current_turns))]
+        },
+        error = function(e) list(user_turn, assistant_turn)
       )
 
       # Extract token info from ellmer's AssistantTurn (has @tokens vector)
@@ -157,8 +161,14 @@ PredictModule <- R6::R6Class(
           timestamp = end_time,
           inputs = inputs,
           output = result,
+          prompt = request$full_prompt,
+          instructions = self$signature@instructions,
           user_turn = user_turn,
           assistant_turn = assistant_turn,
+          turns = turns,
+          latency_ms = latency_ms,
+          tokens = token_info,
+          cost = cost,
           model = model
         )
 
@@ -168,10 +178,7 @@ PredictModule <- R6::R6Class(
         }
 
         self$state$traces <- append(self$state$traces, list(trace_entry))
-
         # Also add to global prompt history for inspect_history()
-        # Include the prompt text in the trace for history extraction
-        trace_entry$prompt <- prompt
         add_to_global_history(trace_entry, source = "PredictModule")
       }
 
@@ -300,6 +307,8 @@ PredictModule <- R6::R6Class(
     #' @description
     #' Apply optimisation parameters (instructions/template) to the module
     apply_optimization_params = function(params) {
+      super$apply_optimization_params(params)
+
       if (!is.null(params$id)) {
         self$config$current_variant <- params$id
       }
@@ -324,25 +333,7 @@ PredictModule <- R6::R6Class(
     # Build prompt from inputs
     # Supports both glue-style { } and ellmer-style {{ }} delimiters
     build_prompt = function(inputs) {
-      prompt_parts <- character()
-
-      # Add demonstrations if present
-      if (length(self$demos) > 0) {
-        demo_text <- private$format_demos()
-        prompt_parts <- c(prompt_parts, demo_text, "")
-      }
-
-      # Add the main template with inputs
-      if (nchar(self$template) > 0) {
-        filled_template <- private$interpolate_template(self$template, inputs)
-        prompt_parts <- c(prompt_parts, filled_template)
-      } else {
-        # Auto-generate template from inputs
-        input_text <- private$format_inputs(inputs)
-        prompt_parts <- c(prompt_parts, input_text)
-      }
-
-      paste(prompt_parts, collapse = "\n")
+      build_prompt(self, inputs)
     },
 
     # Interpolate template with inputs, supporting both { } and {{ }} syntax
@@ -439,139 +430,23 @@ PredictModule <- R6::R6Class(
 
     # Get default LLM client
     get_default_llm = function() {
-      # Check for configured provider
-      provider <- self$config$provider %||%
-        Sys.getenv("DSPRRR_PROVIDER", "openai")
-      provider <- switch(provider, anthropic = "claude", provider)
-
-      # Get model name for reasoning model detection
-      model_name <- self$config$model
-
-      build_api_args <- function(model) {
-        args <- self$config$api_args
-        if (is.null(args)) {
-          args <- list()
-        }
-
-        # Check if this is a reasoning model
-        is_reasoning <- is_reasoning_model(model)
-
-        append_arg <- function(name, value, allow_zero = TRUE) {
-          if (is.null(value)) {
-            return()
-          }
-          if (!allow_zero && identical(value, 0)) {
-            return()
-          }
-          if (is.null(args[[name]])) {
-            args[[name]] <<- value
-          }
-        }
-
-        if (is_reasoning) {
-          # Reasoning models use reasoning_effort instead of temperature/top_p
-          # ellmer passes this via params(reasoning_effort = ...)
-          append_arg("reasoning_effort", self$config$reasoning_effort)
-        } else {
-          # Traditional models use temperature and top_p
-          append_arg("temperature", self$config$temperature, allow_zero = FALSE)
-          append_arg("top_p", self$config$top_p)
-        }
-
-        # These parameters work for all models
-        append_arg("frequency_penalty", self$config$frequency_penalty)
-        append_arg("presence_penalty", self$config$presence_penalty)
-        append_arg("max_output_tokens", self$config$max_output_tokens)
-
-        args
-      }
-
-      llm <- switch(
-        provider,
-        openai = ellmer::chat_openai(
-          model = model_name %||% "gpt-4o-mini",
-          api_args = build_api_args(model_name %||% "gpt-4o-mini")
-        ),
-        claude = ellmer::chat_claude(
-          model = model_name %||% "claude-sonnet-4-20250514",
-          max_tokens = self$config$max_tokens %||% 4096,
-          api_args = build_api_args(model_name %||% "claude-sonnet-4-20250514")
-        ),
-        gemini = ellmer::chat_google_gemini(
-          model = model_name %||% "gemini-2.0-flash",
-          api_args = build_api_args(model_name %||% "gemini-2.0-flash")
-        ),
-        ollama = ellmer::chat_ollama(
-          model = model_name %||% "llama3.2:3b",
-          api_args = build_api_args(model_name %||% "llama3.2:3b")
-        ),
-        cli::cli_abort("Unknown provider: {provider}")
-      )
-
-      llm
+      resolve_module_llm(self, create = TRUE)
     },
 
     # Call LLM with structured output
     # Supports multimodal inputs (images, PDFs) via ellmer Content objects
     call_llm = function(
       llm,
-      prompt,
+      request,
       output_type,
-      instructions = "",
-      inputs = list(),
       .cache = NULL
     ) {
-      # Check for Content objects in inputs (images, PDFs)
-      content_inputs <- Filter(
-        function(x) {
-          inherits(x, "Content") ||
-            inherits(x, "ContentImageRemote") ||
-            inherits(x, "ContentImageInline") ||
-            inherits(x, "ContentPDF")
-        },
-        inputs
+      call_llm_request(
+        llm = llm,
+        request = request,
+        output_type = output_type,
+        .cache = .cache
       )
-
-      if (length(content_inputs) > 0) {
-        # Multimodal request - build content list
-        # Instructions go in system turn, prompt and content in user turn
-        full_prompt <- if (nchar(instructions) > 0) {
-          paste(instructions, prompt, sep = "\n\n")
-        } else {
-          prompt
-        }
-
-        # Build content list: text prompt followed by multimodal content
-        contents <- c(
-          list(ellmer::ContentText(full_prompt)),
-          unname(content_inputs)
-        )
-
-        # Make multimodal API call
-        result <- llm$chat_structured(
-          contents,
-
-          type = output_type,
-          echo = "none"
-        )
-      } else {
-        # Text-only request (current path)
-        full_prompt <- if (nchar(instructions) > 0) {
-          paste(instructions, prompt, sep = "\n\n")
-        } else {
-          prompt
-        }
-
-        # Use cached wrapper for LLM call
-        result <- cached_chat_structured(
-          llm = llm,
-          prompt = full_prompt,
-          output_type = output_type,
-          .cache = .cache
-        )
-      }
-
-      result
     }
   ),
 

--- a/R/module-react.R
+++ b/R/module-react.R
@@ -125,21 +125,16 @@ ReactModule <- R6::R6Class(
         inputs <- batch
       }
 
-      # Get LLM client
-      llm <- .llm %||% self$chat %||% private$get_default_llm()
+      request <- build_module_request(self, inputs)
+      llm <- resolve_module_llm(self, .llm = .llm)
+      start_turn_count <- tryCatch(length(llm$get_turns()), error = function(e) 0L)
 
       # Register all tools on the Chat
       for (tool in self$tools) {
         llm$register_tool(tool)
       }
 
-      # Build initial prompt
-      prompt <- private$build_prompt(inputs)
-
-      # Add instructions if present
-      if (nchar(self$signature@instructions) > 0) {
-        prompt <- paste(self$signature@instructions, prompt, sep = "\n\n")
-      }
+      prompt <- request$full_prompt
 
       # Record start time
       start_time <- Sys.time()
@@ -245,6 +240,13 @@ ReactModule <- R6::R6Class(
         llm$last_turn(role = "user"),
         error = function(e) NULL
       )
+      turns <- tryCatch(
+        {
+          current_turns <- llm$get_turns()
+          current_turns[seq.int(start_turn_count + 1L, length(current_turns))]
+        },
+        error = function(e) c(list(user_turn), all_turns, list(final_turn))
+      )
 
       # Aggregate token info from all turns
       total_input <- 0
@@ -302,11 +304,22 @@ ReactModule <- R6::R6Class(
           timestamp = end_time,
           inputs = inputs,
           output = result,
+          prompt = request$full_prompt,
+          instructions = self$signature@instructions,
           user_turn = user_turn,
           assistant_turn = final_turn,
+          turns = turns,
           all_turns = all_turns,
           tool_calls = tool_calls,
           iterations = iterations,
+          latency_ms = latency_ms,
+          tokens = list(
+            input_tokens = total_input,
+            output_tokens = total_output,
+            cached_input_tokens = total_cached,
+            total_tokens = total_input + total_output
+          ),
+          cost = total_cost,
           model = model
         )
 

--- a/R/module-react.R
+++ b/R/module-react.R
@@ -127,7 +127,10 @@ ReactModule <- R6::R6Class(
 
       request <- build_module_request(self, inputs)
       llm <- resolve_module_llm(self, .llm = .llm)
-      start_turn_count <- tryCatch(length(llm$get_turns()), error = function(e) 0L)
+      start_turn_count <- tryCatch(
+        length(llm$get_turns()),
+        error = function(e) 0L
+      )
 
       # Register all tools on the Chat
       for (tool in self$tools) {
@@ -243,7 +246,12 @@ ReactModule <- R6::R6Class(
       turns <- tryCatch(
         {
           current_turns <- llm$get_turns()
-          current_turns[seq.int(start_turn_count + 1L, length(current_turns))]
+          new_start <- start_turn_count + 1L
+          if (new_start <= length(current_turns)) {
+            current_turns[seq.int(new_start, length(current_turns))]
+          } else {
+            list()
+          }
         },
         error = function(e) c(list(user_turn), all_turns, list(final_turn))
       )

--- a/R/module.R
+++ b/R/module.R
@@ -133,7 +133,7 @@ module <- function(
   )
 
   # Create the appropriate R6 module based on type
-  switch(
+  mod <- switch(
     type,
     predict = PredictModule$new(
       signature = signature,
@@ -219,4 +219,9 @@ module <- function(
     },
     cli::cli_abort("Unknown module type: {type}")
   )
+
+  mod$config <- normalize_module_config(mod$config)
+  mod$config$.module_kind <- type
+
+  mod
 }

--- a/R/optimize.R
+++ b/R/optimize.R
@@ -259,6 +259,19 @@ module_parameters <- function(
   config_values <- module$config
   if (length(config_values) > 0) {
     for (name in names(config_values)) {
+      if (identical(name, "params") && is.list(config_values[[name]])) {
+        for (param_name in names(config_values[[name]])) {
+          param_value <- config_values[[name]][[param_name]]
+          if (is.atomic(param_value) && length(param_value) == 1) {
+            param_values[[param_name]] <- c(
+              param_values[[param_name]],
+              param_value
+            )
+          }
+        }
+        next
+      }
+
       value <- config_values[[name]]
       if (is.atomic(value) && length(value) == 1) {
         param_values[[name]] <- c(param_values[[name]], value)

--- a/R/orchestration.R
+++ b/R/orchestration.R
@@ -66,47 +66,23 @@ pin_module_config <- function(
     cli::cli_abort("{.arg module} must be a DSPrrr Module object")
   }
 
-  # Extract configuration
-  config_data <- list(
-    # Signature details
-    signature = list(
-      inputs = lapply(module$signature@inputs, function(inp) {
-        list(
-          name = inp$name,
-          description = inp$description,
-          type = format_ellmer_type(inp$type)
-        )
-      }),
-      output_type = format_ellmer_type(
-        module$signature@output_type,
-        verbose = TRUE
-      ),
-      instructions = module$signature@instructions
-    ),
-
-    # Module configuration
-    config = module$config,
-
-    # Optimization state (if compiled)
-    optimization = if (module$is_compiled()) {
-      list(
-        compiled = TRUE,
-        best_score = module$state$best_score,
-        best_trial = module$state$best_trial,
-        best_params = module$state$best_params,
-        n_trials = nrow(module$state$trials)
-      )
+  config_data <- serialize_module_config_v2(module)
+  config_data$metadata$created_at <- Sys.time()
+  config_data$metadata$dsprrr_version <- as.character(
+    utils::packageVersion("dsprrr")
+  )
+  config_data$metadata$r_version <- R.version.string
+  config_data$metadata$module_type <- class(module)[1]
+  config_data$optimization <- list(
+    compiled = isTRUE(config_data$state$compiled),
+    best_score = config_data$state$best_score,
+    best_trial = config_data$state$best_trial,
+    best_params = config_data$state$best_params,
+    n_trials = if (is.data.frame(config_data$state$trials)) {
+      nrow(config_data$state$trials)
     } else {
-      list(compiled = FALSE)
-    },
-
-    # Metadata
-    metadata = list(
-      module_type = class(module)[1],
-      created_at = Sys.time(),
-      dsprrr_version = as.character(utils::packageVersion("dsprrr")),
-      r_version = R.version.string
-    )
+      0L
+    }
   )
 
   # Write to pins
@@ -122,8 +98,8 @@ pin_module_config <- function(
 
   cli::cli_inform(c(
     "v" = "Pinned module configuration: {.val {name}}",
-    "i" = "Module type: {.cls {config_data$metadata$module_type}}",
-    "i" = "Compiled: {.val {config_data$optimization$compiled}}"
+    "i" = "Module kind: {.val {config_data$module_kind}}",
+    "i" = "Compiled: {.val {isTRUE(config_data$state$compiled)}}"
   ))
 
   invisible(name)
@@ -155,54 +131,230 @@ pin_module_config <- function(
 #' result <- run(mod, text = "This is great!", .llm = llm)
 #' }
 restore_module_config <- function(config, signature = NULL) {
-  if (is.null(signature)) {
-    # Reconstruct signature from stored config
-    inputs <- lapply(config$signature$inputs, function(inp) {
-      input(
-        name = inp$name,
-        description = inp$description
-      )
-    })
-
-    # Use default string output type if we can't reconstruct the exact type
-    output_type <- ellmer::type_string()
-
-    signature <- Signature(
-      inputs = inputs,
-      output_type = output_type,
-      instructions = config$signature$instructions %||% ""
-    )
+  if (!identical(config$format_version, 2L)) {
+    cli::cli_abort(c(
+      "Unsupported pinned module format",
+      "i" = "Legacy pinned configs are not supported in phase 1",
+      "i" = "Re-pin this module using the v2 format with {.code pin_module_config()}"
+    ))
   }
 
-  # Create the module
-  mod <- module(
-    signature = signature,
-    type = "predict",
-    template = config$config$template %||% "",
-    demos = config$config$demos %||% list()
-  )
-
-  # Restore configuration
-  for (key in names(config$config)) {
-    mod$config[[key]] <- config$config[[key]]
+  config_to_restore <- config
+  if (!is.null(signature)) {
+    if (!inherits(signature, "dsprrr::Signature")) {
+      cli::cli_abort("{.arg signature} must be a Signature object")
+    }
+    config_to_restore$signature <- serialize_signature_v2(signature)
   }
 
-  # Restore optimization state if present
-  if (isTRUE(config$optimization$compiled)) {
-    mod$state$compiled <- TRUE
-    mod$state$best_score <- config$optimization$best_score
-    mod$state$best_trial <- config$optimization$best_trial
-    mod$state$best_params <- config$optimization$best_params
-    mod$config$compiled <- TRUE
-  }
+  mod <- restore_module_from_v2(config_to_restore)
 
   cli::cli_inform(c(
     "v" = "Restored module from configuration",
-    "i" = "Module type: {.cls {config$metadata$module_type}}",
+    "i" = "Module kind: {.val {config$module_kind}}",
     "i" = "Original dsprrr version: {.val {config$metadata$dsprrr_version}}"
   ))
 
   mod
+}
+
+serialize_module_config_v2 <- function(module) {
+  kind <- module_kind(module)
+  supported <- c("predict", "react", "chain_of_thought", "multichain")
+  if (!kind %in% supported) {
+    cli::cli_abort(c(
+      "Unsupported module type for v2 persistence",
+      "x" = "Got {.val {kind}}",
+      "i" = "Phase 1 supports: {.val {supported}}"
+    ))
+  }
+
+  if (identical(kind, "react") && length(module$tools %||% list()) > 0) {
+    cli::cli_abort(c(
+      "React tools are not serialised in v2 persistence",
+      "i" = "Reattach tools after restore, or pin a React module with no tools"
+    ))
+  }
+
+  fields <- list()
+  if (inherits(module, "PredictModule")) {
+    fields$template <- module$template
+    fields$demos <- module$demos
+  }
+  if (inherits(module, "ReactModule")) {
+    fields$max_iterations <- module$max_iterations
+    fields$tools <- list()
+  }
+  if (inherits(module, "MultiChainComparisonModule")) {
+    fields$M <- module$M
+    fields$temperature <- module$temperature
+    fields$comparison_template <- module$comparison_template
+    fields$inner_module <- serialize_module_config_v2(module$inner_module)
+  }
+
+  list(
+    format_version = 2L,
+    module_kind = kind,
+    signature = serialize_signature_v2(module$signature),
+    config = sanitize_module_config_v2(module$config),
+    state = serialize_module_state_v2(module$state),
+    fields = fields,
+    metadata = list(
+      module_class = class(module)[1]
+    )
+  )
+}
+
+serialize_signature_v2 <- function(signature) {
+  list(
+    inputs = lapply(signature@inputs, serialize_input_v2),
+    output_type = copy_ellmer_type(signature@output_type),
+    instructions = signature@instructions
+  )
+}
+
+serialize_input_v2 <- function(inp) {
+  extra <- inp[setdiff(names(inp), c("name", "type", "description"))]
+  list(
+    name = inp$name,
+    description = inp$description,
+    type = copy_ellmer_type(inp$type),
+    extra = extra
+  )
+}
+
+deserialize_signature_v2 <- function(signature) {
+  Signature(
+    inputs = lapply(signature$inputs, deserialize_input_v2),
+    output_type = copy_ellmer_type(signature$output_type),
+    instructions = signature$instructions %||% ""
+  )
+}
+
+deserialize_input_v2 <- function(inp) {
+  structure(
+    c(
+      list(
+        name = inp$name,
+        type = copy_ellmer_type(inp$type),
+        description = inp$description
+      ),
+      inp$extra %||% list()
+    ),
+    class = "dsprrr_input"
+  )
+}
+
+sanitize_module_config_v2 <- function(config) {
+  config <- normalize_module_config(config %||% list())
+  config <- config[setdiff(names(config), c(".module_kind", legacy_chat_config_fields()))]
+  cleaned <- lapply(config, sanitize_persisted_value_v2)
+  cleaned[!vapply(cleaned, is.null, logical(1))]
+}
+
+sanitize_persisted_value_v2 <- function(value) {
+  if (
+    inherits(value, "Chat") ||
+      inherits(value, "ToolDef") ||
+      inherits(value, "ellmer::ToolDef")
+  ) {
+    return(NULL)
+  }
+
+  if (is.function(value)) {
+    return(NULL)
+  }
+
+  if (is.list(value) && !is.data.frame(value)) {
+    cleaned <- lapply(value, sanitize_persisted_value_v2)
+    cleaned[!vapply(cleaned, is.null, logical(1))]
+  } else {
+    value
+  }
+}
+
+serialize_module_state_v2 <- function(state) {
+  list(
+    compiled = isTRUE(state$compiled),
+    best_score = state$best_score,
+    best_trial = state$best_trial,
+    best_params = state$best_params,
+    trials = state$trials,
+    last_grid = state$last_grid,
+    optimization_history = state$optimization_history
+  )
+}
+
+restore_module_from_v2 <- function(config) {
+  kind <- config$module_kind
+  supported <- c("predict", "react", "chain_of_thought", "multichain")
+  if (!kind %in% supported) {
+    cli::cli_abort(c(
+      "Unsupported module type in pinned config",
+      "x" = "Got {.val {kind}}",
+      "i" = "Phase 1 supports: {.val {supported}}"
+    ))
+  }
+
+  signature <- deserialize_signature_v2(config$signature)
+  fields <- config$fields %||% list()
+  module_config <- normalize_module_config(config$config %||% list())
+
+  mod <- switch(
+    kind,
+    predict = PredictModule$new(
+      signature = signature,
+      template = fields$template %||% "",
+      demos = fields$demos %||% list(),
+      config = module_config
+    ),
+    react = ReactModule$new(
+      signature = signature,
+      tools = list(),
+      max_iterations = fields$max_iterations %||% 10L,
+      template = fields$template %||% "",
+      demos = fields$demos %||% list(),
+      config = module_config
+    ),
+    chain_of_thought = PredictModule$new(
+      signature = signature,
+      template = fields$template %||% "",
+      demos = fields$demos %||% list(),
+      config = module_config
+    ),
+    multichain = {
+      if (is.null(fields$inner_module)) {
+        cli::cli_abort(c(
+          "Pinned multichain config is incomplete",
+          "i" = "Missing serialized inner module definition"
+        ))
+      }
+
+      MultiChainComparisonModule$new(
+        signature = signature,
+        inner_module = restore_module_from_v2(fields$inner_module),
+        M = fields$M %||% 3L,
+        temperature = fields$temperature %||% 0.7,
+        comparison_template = fields$comparison_template,
+        config = module_config
+      )
+    }
+  )
+
+  mod$config$.module_kind <- kind
+  restore_module_state_v2(mod, config$state %||% list())
+  mod
+}
+
+restore_module_state_v2 <- function(module, state) {
+  module$state$compiled <- isTRUE(state$compiled)
+  module$state$best_score <- state$best_score
+  module$state$best_trial <- state$best_trial
+  module$state$best_params <- state$best_params
+  module$state$trials <- state$trials %||% tibble::tibble()
+  module$state$last_grid <- state$last_grid %||% tibble::tibble()
+  module$state$optimization_history <- state$optimization_history %||% list()
+  invisible(module)
 }
 
 

--- a/R/orchestration.R
+++ b/R/orchestration.R
@@ -247,7 +247,10 @@ deserialize_input_v2 <- function(inp) {
 
 sanitize_module_config_v2 <- function(config) {
   config <- normalize_module_config(config %||% list())
-  config <- config[setdiff(names(config), c(".module_kind", legacy_chat_config_fields()))]
+  config <- config[setdiff(
+    names(config),
+    c(".module_kind", legacy_chat_config_fields())
+  )]
   cleaned <- lapply(config, sanitize_persisted_value_v2)
   cleaned[!vapply(cleaned, is.null, logical(1))]
 }

--- a/R/run.R
+++ b/R/run.R
@@ -241,6 +241,223 @@ run.PredictModule <- function(
   }
 }
 
+#' Normalize module runtime configuration
+#' @noRd
+normalize_module_config <- function(config) {
+  if (is.null(config)) {
+    config <- list()
+  }
+
+  if (!is.list(config)) {
+    cli::cli_abort("{.arg config} must be a list")
+  }
+
+  params <- config$params %||% list()
+  for (name in runtime_param_names()) {
+    if (is.null(params[[name]]) && !is.null(config[[name]])) {
+      params[[name]] <- config[[name]]
+    }
+  }
+
+  if (length(params) > 0) {
+    config$params <- params
+  }
+
+  config
+}
+
+#' Runtime parameter names forwarded through ellmer
+#' @noRd
+runtime_param_names <- function() {
+  c(
+    "temperature",
+    "top_p",
+    "reasoning_effort",
+    "frequency_penalty",
+    "presence_penalty",
+    "max_output_tokens",
+    "service_tier"
+  )
+}
+
+#' Legacy config fields that should no longer create Chat clients
+#' @noRd
+legacy_chat_config_fields <- function() {
+  c("provider", "model", "api_args", "base_url", "credentials", "max_tokens")
+}
+
+#' Infer the logical module kind
+#' @noRd
+module_kind <- function(module) {
+  module$config$.module_kind %||% switch(
+    class(module)[1],
+    "ReactModule" = "react",
+    "MultiChainComparisonModule" = "multichain",
+    "PredictModule" = "predict",
+    "predict"
+  )
+}
+
+#' Resolve the Chat to use for module execution
+#' @noRd
+resolve_module_llm <- function(
+  module,
+  .llm = NULL,
+  create = TRUE,
+  extra_params = NULL
+) {
+  ignored_fields <- intersect(names(module$config %||% list()), legacy_chat_config_fields())
+  llm <- .llm %||% module$chat %||% get_default_chat(create = FALSE)
+
+  if (is.null(llm)) {
+    if (length(ignored_fields) > 0) {
+      cli::cli_abort(c(
+        "Module config no longer creates Chat clients",
+        "i" = "Ignored fields: {.field {ignored_fields}}",
+        "i" = "Attach a Chat with {.code module(..., chat = chat)} or pass {.code .llm = chat}",
+        "i" = "Or configure a default Chat with {.code set_default_chat()} or {.code dsp_configure()}"
+      ))
+    }
+
+    if (!create) {
+      return(NULL)
+    }
+
+    llm <- get_default_chat(create = TRUE)
+  } else if (length(ignored_fields) > 0) {
+    cli::cli_warn(
+      c(
+        "Ignoring module config fields that no longer create Chats",
+        "i" = "Ignored fields: {.field {ignored_fields}}",
+        "i" = "Runtime now comes from {.arg .llm}, {.code module$chat}, or the default Chat"
+      ),
+      .frequency = "once",
+      .frequency_id = paste0("legacy-chat-config-", module_kind(module))
+    )
+  }
+
+  params <- module_runtime_params(module, extra_params = extra_params)
+  if (length(params) == 0) {
+    return(llm)
+  }
+
+  apply_chat_params(llm, params)
+}
+
+#' Collect runtime params from module config
+#' @noRd
+module_runtime_params <- function(module, extra_params = NULL) {
+  config <- normalize_module_config(module$config %||% list())
+  params <- config$params %||% list()
+
+  if (!is.null(extra_params) && length(extra_params) > 0) {
+    for (name in names(extra_params)) {
+      params[[name]] <- extra_params[[name]]
+    }
+  }
+
+  params[!vapply(params, is.null, logical(1))]
+}
+
+#' Clone a Chat and apply runtime params to its provider
+#' @noRd
+apply_chat_params <- function(chat, params) {
+  if (is.null(chat) || length(params) == 0) {
+    return(chat)
+  }
+
+  cloned <- tryCatch(
+    {
+      if (is.function(chat$clone)) {
+        chat$clone(deep = TRUE)
+      } else {
+        chat
+      }
+    },
+    error = function(e) chat
+  )
+
+  provider <- tryCatch(
+    cloned$.__enclos_env__$private$provider,
+    error = function(e) NULL
+  )
+  if (is.null(provider)) {
+    return(cloned)
+  }
+
+  existing_args <- tryCatch(provider@extra_args, error = function(e) list())
+  if (is.null(existing_args)) {
+    existing_args <- list()
+  }
+
+  for (name in names(params)) {
+    existing_args[[name]] <- params[[name]]
+  }
+
+  tryCatch(
+    {
+      cloned$.__enclos_env__$private$provider@extra_args <- existing_args
+    },
+    error = function(e) NULL
+  )
+
+  cloned
+}
+
+#' Determine if a value is an ellmer content object
+#' @noRd
+is_content_input <- function(x) {
+  inherits(x, "Content") || any(grepl("^Content", class(x)))
+}
+
+#' Build the canonical request payload for a module execution
+#' @noRd
+build_module_request <- function(module, inputs) {
+  prompt <- build_prompt(module, inputs)
+  instructions <- module$signature@instructions %||% ""
+  full_prompt <- if (nzchar(instructions) && nzchar(prompt)) {
+    paste(instructions, prompt, sep = "\n\n")
+  } else if (nzchar(instructions)) {
+    instructions
+  } else {
+    prompt
+  }
+
+  content_inputs <- unname(Filter(is_content_input, inputs))
+  payload <- if (length(content_inputs) > 0) {
+    c(list(ellmer::ContentText(full_prompt)), content_inputs)
+  } else {
+    full_prompt
+  }
+
+  list(
+    prompt = prompt,
+    instructions = instructions,
+    full_prompt = full_prompt,
+    payload = payload,
+    is_multimodal = length(content_inputs) > 0
+  )
+}
+
+#' Execute a structured ellmer call from a prepared request
+#' @noRd
+call_llm_request <- function(llm, request, output_type, .cache = NULL) {
+  if (isTRUE(request$is_multimodal)) {
+    llm$chat_structured(
+      request$payload,
+      type = output_type,
+      echo = "none"
+    )
+  } else {
+    cached_chat_structured(
+      llm = llm,
+      prompt = request$full_prompt,
+      output_type = output_type,
+      .cache = .cache
+    )
+  }
+}
+
 #' Process a single batch item
 #'
 #' Core processing logic shared by both parallel and sequential execution.
@@ -262,7 +479,8 @@ process_batch_item <- function(
   .return_format,
   .cache = NULL
 ) {
-  prompt <- build_prompt(module, input_set)
+  request <- build_module_request(module, input_set)
+  prompt <- request$prompt
 
   if (.verbose) {
     cli::cli_h3("Prompt {index}")
@@ -271,12 +489,10 @@ process_batch_item <- function(
 
   start_time <- Sys.time()
 
-  response <- call_llm(
+  response <- call_llm_request(
     llm = llm,
-    prompt = prompt,
+    request = request,
     output_type = module$signature@output_type,
-    instructions = module$signature@instructions,
-    verbose = .verbose,
     .cache = .cache
   )
 
@@ -287,17 +503,11 @@ process_batch_item <- function(
   if (.return_format == "simple") {
     extract_simple_output(response, module$signature@output_type)
   } else {
-    # Build full prompt (with instructions) for mock chat
-    instructions <- module$signature@instructions
-    full_prompt <- if (nchar(instructions) > 0) {
-      paste(instructions, prompt, sep = "\n\n")
-    } else {
-      prompt
-    }
+    instructions <- request$instructions
 
     list(
       output = response,
-      chat = mock_batch_chat(full_prompt, response, llm),
+      chat = mock_batch_chat(request$payload, response, llm),
       metadata = list(
         latency_ms = latency_ms,
         prompt_length = nchar(prompt),
@@ -322,11 +532,24 @@ process_batch_item <- function(
 #' @return A cloned Chat with UserTurn and AssistantTurn representing the exchange
 #' @noRd
 mock_batch_chat <- function(prompt, response, chat) {
-  mock <- chat$clone()
-
-  user_turn <- ellmer::UserTurn(
-    contents = list(ellmer::ContentText(as.character(prompt)))
+  mock <- tryCatch(
+    {
+      if (is.function(chat$clone)) chat$clone() else chat
+    },
+    error = function(e) chat
   )
+
+  prompt_contents <- if (
+    is.list(prompt) &&
+      length(prompt) > 0 &&
+      all(vapply(prompt, is_content_input, logical(1)))
+  ) {
+    prompt
+  } else {
+    list(ellmer::ContentText(as.character(prompt)))
+  }
+
+  user_turn <- ellmer::UserTurn(contents = prompt_contents)
 
   # Serialize response to JSON if it's structured data
   response_text <- if (is.character(response) && length(response) == 1) {
@@ -339,7 +562,9 @@ mock_batch_chat <- function(prompt, response, chat) {
     contents = list(ellmer::ContentText(response_text))
   )
 
-  mock$set_turns(list(user_turn, assistant_turn))
+  if (is.function(mock$set_turns)) {
+    mock$set_turns(list(user_turn, assistant_turn))
+  }
   mock
 }
 
@@ -483,7 +708,7 @@ run_batch_sequential <- function(
   .progress,
   .cache = NULL
 ) {
-  shared_llm <- .llm %||% module$chat %||% get_default_llm(module)
+  shared_llm <- resolve_module_llm(module, .llm = .llm)
   results <- vector("list", n)
 
   # Create progress bar if requested
@@ -497,7 +722,7 @@ run_batch_sequential <- function(
   }
 
   for (i in seq_len(n)) {
-    prompt <- build_prompt(module, input_sets[[i]])
+    prompt <- build_module_request(module, input_sets[[i]])$prompt
 
     results[[i]] <- tryCatch(
       {
@@ -554,21 +779,13 @@ run_batch_ellmer_parallel <- function(
   .cache = NULL
 ) {
   # Build prompts for all inputs (as list, required by ellmer::parallel_chat_structured)
-  prompts <- lapply(
-    input_sets,
-    function(input_set) {
-      prompt <- build_prompt(module, input_set)
-      instructions <- module$signature@instructions
-      if (nchar(instructions) > 0) {
-        paste(instructions, prompt, sep = "\n\n")
-      } else {
-        prompt
-      }
-    }
-  )
+  requests <- lapply(input_sets, function(input_set) {
+    build_module_request(module, input_set)
+  })
+  prompts <- lapply(requests, `[[`, "payload")
 
   # Get the Chat provider - need to clone for parallel use
-  chat <- .llm %||% module$chat %||% get_default_llm(module)
+  chat <- resolve_module_llm(module, .llm = .llm)
 
   # Check if ellmer has parallel_chat_structured
   if (!exists("parallel_chat_structured", envir = asNamespace("ellmer"))) {
@@ -704,9 +921,9 @@ run_batch_ellmer_parallel <- function(
           chat = mock_batch_chat(prompts[[i]], response, chat),
           metadata = list(
             latency_ms = total_latency / n,
-            prompt_length = nchar(prompts[[i]]),
-            prompt = prompts[[i]],
-            instructions = module$signature@instructions,
+            prompt_length = nchar(requests[[i]]$prompt),
+            prompt = requests[[i]]$prompt,
+            instructions = requests[[i]]$instructions,
             timestamp = end_time,
             batch_index = i,
             parallel_method = "ellmer"
@@ -732,11 +949,9 @@ run_batch_parallel <- function(
   .cache = NULL
 ) {
   llm_factory <- if (!is.null(.llm)) {
-    function() .llm
-  } else if (!is.null(module$chat)) {
-    # Use the module's stored Chat - note: each worker gets the same reference
-    # For true parallel isolation, users should not provide a Chat
-    function() module$chat
+    function() resolve_module_llm(module, .llm = .llm)
+  } else if (!is.null(module$chat) || !is.null(get_default_chat(create = FALSE))) {
+    function() resolve_module_llm(module)
   } else {
     function() get_default_llm(module)
   }
@@ -899,13 +1114,19 @@ build_prompt <- function(module, inputs) {
 
   # Add the main template with inputs
   if (nchar(module$template) > 0) {
-    filled_template <- glue::glue_data(
-      .x = inputs,
-      module$template,
-      .open = "{",
-      .close = "}",
-      .envir = parent.frame()
-    )
+    if (grepl("\\{\\{[^}]+\\}\\}", module$template)) {
+      filled_template <- rlang::inject(
+        ellmer::interpolate(module$template, !!!inputs)
+      )
+    } else {
+      filled_template <- glue::glue_data(
+        .x = inputs,
+        module$template,
+        .open = "{",
+        .close = "}",
+        .envir = parent.frame()
+      )
+    }
     prompt_parts <- c(prompt_parts, filled_template)
   } else {
     # Auto-generate template from inputs
@@ -929,7 +1150,10 @@ format_demos <- function(demos, signature) {
     # Format inputs
     if (!is.null(demo$inputs)) {
       for (name in names(demo$inputs)) {
-        demo_lines <- c(demo_lines, paste0(name, ": ", demo$inputs[[name]]))
+        demo_lines <- c(
+          demo_lines,
+          paste0(name, ": ", format_prompt_value(demo$inputs[[name]]))
+        )
       }
     }
 
@@ -954,7 +1178,7 @@ format_inputs <- function(inputs, sig_inputs) {
   input_lines <- character()
 
   for (name in names(inputs)) {
-    value <- inputs[[name]]
+    value <- format_prompt_value(inputs[[name]])
     # Find the corresponding signature input for description
     sig_input <- Find(function(x) x$name == name, sig_inputs)
 
@@ -979,6 +1203,20 @@ format_output <- function(output) {
   }
 }
 
+#' Format a value for prompt rendering
+#' @noRd
+format_prompt_value <- function(value) {
+  if (is_content_input(value)) {
+    return(paste0("<", class(value)[1], ">"))
+  }
+
+  if (is.list(value) && !is.null(names(value))) {
+    return(jsonlite::toJSON(value, auto_unbox = TRUE, pretty = FALSE))
+  }
+
+  paste(value, collapse = ", ")
+}
+
 #' Get default LLM configuration
 #'
 #' Checks module's stored Chat, then auto-detects from environment
@@ -988,13 +1226,7 @@ format_output <- function(output) {
 #' @return An ellmer Chat object
 #' @noRd
 get_default_llm <- function(module) {
-  # Check for Chat stored on module
-  if (!is.null(module$chat)) {
-    return(module$chat)
-  }
-
-  # Use the new auto-detection from chat-default.R
-  get_default_chat(create = TRUE)
+  resolve_module_llm(module, create = TRUE)
 }
 
 #' Call the LLM with structured output
@@ -1006,28 +1238,43 @@ call_llm <- function(
   output_type,
   instructions = "",
   verbose = FALSE,
+  inputs = list(),
   .cache = NULL
 ) {
-  # Build the full prompt with instructions
-  full_prompt <- if (nchar(instructions) > 0) {
-    paste(instructions, prompt, sep = "\n\n")
-  } else {
-    prompt
-  }
-
-  # Make the API call through cached wrapper
-  tryCatch(
-    {
-      # Use cached_chat_structured to respect caching configuration
-      result <- cached_chat_structured(
-        llm = llm,
-        prompt = full_prompt,
-        output_type = output_type,
-        .cache = .cache
-      )
-
-      result
+  request <- list(
+    prompt = prompt,
+    instructions = instructions,
+    full_prompt = if (nchar(instructions) > 0) {
+      paste(instructions, prompt, sep = "\n\n")
+    } else {
+      prompt
     },
+    payload = if (length(Filter(is_content_input, inputs)) > 0) {
+      c(
+        list(ellmer::ContentText(if (nchar(instructions) > 0) {
+          paste(instructions, prompt, sep = "\n\n")
+        } else {
+          prompt
+        })),
+        unname(Filter(is_content_input, inputs))
+      )
+    } else {
+      if (nchar(instructions) > 0) {
+        paste(instructions, prompt, sep = "\n\n")
+      } else {
+        prompt
+      }
+    },
+    is_multimodal = length(Filter(is_content_input, inputs)) > 0
+  )
+
+  tryCatch(
+    call_llm_request(
+      llm = llm,
+      request = request,
+      output_type = output_type,
+      .cache = .cache
+    ),
     error = function(e) {
       cli::cli_abort(
         "LLM call failed: {e$message}",

--- a/R/run.R
+++ b/R/run.R
@@ -275,6 +275,7 @@ runtime_param_names <- function() {
     "reasoning_effort",
     "frequency_penalty",
     "presence_penalty",
+    "max_tokens",
     "max_output_tokens",
     "service_tier"
   )
@@ -283,19 +284,20 @@ runtime_param_names <- function() {
 #' Legacy config fields that should no longer create Chat clients
 #' @noRd
 legacy_chat_config_fields <- function() {
-  c("provider", "model", "api_args", "base_url", "credentials", "max_tokens")
+  c("provider", "model", "api_args", "base_url", "credentials")
 }
 
 #' Infer the logical module kind
 #' @noRd
 module_kind <- function(module) {
-  module$config$.module_kind %||% switch(
-    class(module)[1],
-    "ReactModule" = "react",
-    "MultiChainComparisonModule" = "multichain",
-    "PredictModule" = "predict",
-    "predict"
-  )
+  module$config$.module_kind %||%
+    switch(
+      class(module)[1],
+      "ReactModule" = "react",
+      "MultiChainComparisonModule" = "multichain",
+      "PredictModule" = "predict",
+      "predict"
+    )
 }
 
 #' Resolve the Chat to use for module execution
@@ -306,7 +308,10 @@ resolve_module_llm <- function(
   create = TRUE,
   extra_params = NULL
 ) {
-  ignored_fields <- intersect(names(module$config %||% list()), legacy_chat_config_fields())
+  ignored_fields <- intersect(
+    names(module$config %||% list()),
+    legacy_chat_config_fields()
+  )
   llm <- .llm %||% module$chat %||% get_default_chat(create = FALSE)
 
   if (is.null(llm)) {
@@ -371,10 +376,30 @@ apply_chat_params <- function(chat, params) {
       if (is.function(chat$clone)) {
         chat$clone(deep = TRUE)
       } else {
+        cli::cli_warn(
+          c(
+            "Chat object does not support cloning",
+            "i" = "Runtime parameters will be applied to the original Chat",
+            "i" = "This may cause unexpected behavior in batch/optimization contexts"
+          ),
+          .frequency = "once",
+          .frequency_id = "chat-clone-unsupported"
+        )
         chat
       }
     },
-    error = function(e) chat
+    error = function(e) {
+      cli::cli_warn(
+        c(
+          "Failed to clone Chat for parameter isolation",
+          "x" = e$message,
+          "i" = "Runtime parameters will be applied to the original Chat"
+        ),
+        .frequency = "once",
+        .frequency_id = "chat-clone-failed"
+      )
+      chat
+    }
   )
 
   provider <- tryCatch(
@@ -398,7 +423,19 @@ apply_chat_params <- function(chat, params) {
     {
       cloned$.__enclos_env__$private$provider@extra_args <- existing_args
     },
-    error = function(e) NULL
+    error = function(e) {
+      param_names <- paste(names(params), collapse = ", ")
+      cli::cli_warn(
+        c(
+          "Failed to apply runtime parameters to Chat provider",
+          "x" = "Parameters not applied: {.field {param_names}}",
+          "i" = "The module will run with the provider's default settings",
+          "i" = "Error: {e$message}"
+        ),
+        .frequency = "once",
+        .frequency_id = "chat-params-failed"
+      )
+    }
   )
 
   cloned
@@ -950,7 +987,9 @@ run_batch_parallel <- function(
 ) {
   llm_factory <- if (!is.null(.llm)) {
     function() resolve_module_llm(module, .llm = .llm)
-  } else if (!is.null(module$chat) || !is.null(get_default_chat(create = FALSE))) {
+  } else if (
+    !is.null(module$chat) || !is.null(get_default_chat(create = FALSE))
+  ) {
     function() resolve_module_llm(module)
   } else {
     function() get_default_llm(module)
@@ -1251,11 +1290,13 @@ call_llm <- function(
     },
     payload = if (length(Filter(is_content_input, inputs)) > 0) {
       c(
-        list(ellmer::ContentText(if (nchar(instructions) > 0) {
-          paste(instructions, prompt, sep = "\n\n")
-        } else {
-          prompt
-        })),
+        list(ellmer::ContentText(
+          if (nchar(instructions) > 0) {
+            paste(instructions, prompt, sep = "\n\n")
+          } else {
+            prompt
+          }
+        )),
         unname(Filter(is_content_input, inputs))
       )
     } else {

--- a/R/traces.R
+++ b/R/traces.R
@@ -57,15 +57,31 @@ export_traces <- function(
 
   # Add optional fields
   if (include_prompts) {
-    result$prompt <- vapply(
+    result$prompt <- vapply(traces, trace_prompt_text, character(1))
+    result$prompt_markdown <- vapply(
       traces,
-      function(x) x$prompt %||% NA_character_,
+      trace_prompt_markdown,
       character(1)
     )
+    result$prompt_html <- vapply(traces, trace_prompt_html, character(1))
   }
 
   if (include_outputs) {
     result$output <- lapply(traces, function(x) x$output)
+    result$turns <- lapply(traces, function(x) {
+      x$turns %||% Filter(Negate(is.null), list(x$user_turn, x$assistant_turn))
+    })
+    result$response_text <- vapply(traces, trace_response_text, character(1))
+    result$response_markdown <- vapply(
+      traces,
+      trace_response_markdown,
+      character(1)
+    )
+    result$response_html <- vapply(
+      traces,
+      trace_response_html,
+      character(1)
+    )
   }
 
   result

--- a/R/utils.R
+++ b/R/utils.R
@@ -220,7 +220,12 @@ render_turn_content <- function(turn, format = c("text", "markdown", "html")) {
     return(NA_character_)
   }
 
-  parts <- vapply(contents, render_content_summary, character(1), format = format)
+  parts <- vapply(
+    contents,
+    render_content_summary,
+    character(1),
+    format = format
+  )
   parts <- parts[nzchar(parts)]
 
   if (length(parts) == 0) {
@@ -232,7 +237,10 @@ render_turn_content <- function(turn, format = c("text", "markdown", "html")) {
 
 #' Summarise a single ellmer content object
 #' @noRd
-render_content_summary <- function(content, format = c("text", "markdown", "html")) {
+render_content_summary <- function(
+  content,
+  format = c("text", "markdown", "html")
+) {
   format <- match.arg(format)
 
   wrap <- function(text) {
@@ -246,14 +254,20 @@ render_content_summary <- function(content, format = c("text", "markdown", "html
     }
   }
 
-  is_content_class <- function(name) any(grepl(paste0(name, "$"), class(content)))
+  is_content_class <- function(name) {
+    any(grepl(paste0(name, "$"), class(content)))
+  }
 
   if (is_content_class("ContentText")) {
     return(content@text %||% "")
   }
 
   if (is_content_class("ContentToolRequest")) {
-    args <- jsonlite::toJSON(content@arguments, auto_unbox = TRUE, pretty = FALSE)
+    args <- jsonlite::toJSON(
+      content@arguments,
+      auto_unbox = TRUE,
+      pretty = FALSE
+    )
     return(wrap(paste0("[tool request] ", content@name, " ", args)))
   }
 
@@ -267,7 +281,10 @@ render_content_summary <- function(content, format = c("text", "markdown", "html
     return(wrap(paste0("[tool result] ", tool_name, " ", result)))
   }
 
-  if (is_content_class("ContentImageRemote") || is_content_class("ContentImageInline")) {
+  if (
+    is_content_class("ContentImageRemote") ||
+      is_content_class("ContentImageInline")
+  ) {
     label <- paste0("[image] ", class(content)[1])
     return(wrap(label))
   }
@@ -286,7 +303,9 @@ trace_tokens <- function(trace) {
     return(list(
       input_tokens = as.integer(trace$tokens$input_tokens %||% NA_integer_),
       output_tokens = as.integer(trace$tokens$output_tokens %||% NA_integer_),
-      cached_input_tokens = as.integer(trace$tokens$cached_input_tokens %||% NA_integer_),
+      cached_input_tokens = as.integer(
+        trace$tokens$cached_input_tokens %||% NA_integer_
+      ),
       total_tokens = as.integer(trace$tokens$total_tokens %||% NA_integer_)
     ))
   }
@@ -305,7 +324,9 @@ trace_tokens <- function(trace) {
   list(
     input_tokens = as.integer(trace$input_tokens %||% NA_integer_),
     output_tokens = as.integer(trace$output_tokens %||% NA_integer_),
-    cached_input_tokens = as.integer(trace$cached_input_tokens %||% NA_integer_),
+    cached_input_tokens = as.integer(
+      trace$cached_input_tokens %||% NA_integer_
+    ),
     total_tokens = as.integer(trace$total_tokens %||% NA_integer_)
   )
 }
@@ -313,13 +334,19 @@ trace_tokens <- function(trace) {
 #' Extract cost from a trace entry
 #' @noRd
 trace_cost <- function(trace) {
-  trace$cost %||% trace$total_cost %||% tryCatch(trace$assistant_turn@cost, error = function(e) NA_real_)
+  trace$cost %||%
+    trace$total_cost %||%
+    tryCatch(trace$assistant_turn@cost, error = function(e) NA_real_)
 }
 
 #' Extract latency from a trace entry
 #' @noRd
 trace_latency_ms <- function(trace) {
-  trace$latency_ms %||% tryCatch((trace$assistant_turn@duration %||% NA_real_) * 1000, error = function(e) NA_real_)
+  trace$latency_ms %||%
+    tryCatch(
+      (trace$assistant_turn@duration %||% NA_real_) * 1000,
+      error = function(e) NA_real_
+    )
 }
 
 #' Extract prompt text from a trace entry

--- a/R/utils.R
+++ b/R/utils.R
@@ -20,8 +20,11 @@ is_ellmer_type <- function(x) {
 #' @export
 #' @keywords internal
 eval_vignette <- function() {
-  # Skip during R CMD check (cassettes may not match current code)
+  # Skip during R CMD check or CI (cassettes may not match current code)
   if (nzchar(Sys.getenv("_R_CHECK_PACKAGE_NAME_"))) {
+    return(FALSE)
+  }
+  if (nzchar(Sys.getenv("CI"))) {
     return(FALSE)
   }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -171,3 +171,203 @@ provider_defaults <- function(provider) {
   )
   defaults[[tolower(provider)]] %||% list(temperature = 0.7)
 }
+
+#' Render an ellmer Turn as plain text
+#' @noRd
+render_turn_text <- function(turn) {
+  render_turn_content(turn, format = "text")
+}
+
+#' Render an ellmer Turn as markdown
+#' @noRd
+render_turn_markdown <- function(turn) {
+  render_turn_content(turn, format = "markdown")
+}
+
+#' Render an ellmer Turn as HTML
+#' @noRd
+render_turn_html <- function(turn) {
+  render_turn_content(turn, format = "html")
+}
+
+#' Render an ellmer Turn with fallbacks for non-text content
+#' @noRd
+render_turn_content <- function(turn, format = c("text", "markdown", "html")) {
+  format <- match.arg(format)
+
+  if (is.null(turn)) {
+    return(NA_character_)
+  }
+
+  rendered <- tryCatch(
+    {
+      switch(
+        format,
+        text = ellmer::contents_text(turn),
+        markdown = ellmer::contents_markdown(turn),
+        html = ellmer::contents_html(turn)
+      )
+    },
+    error = function(e) NULL
+  )
+
+  if (!is.null(rendered) && length(rendered) == 1 && nzchar(rendered)) {
+    return(as.character(rendered))
+  }
+
+  contents <- tryCatch(turn@contents, error = function(e) list())
+  if (length(contents) == 0) {
+    return(NA_character_)
+  }
+
+  parts <- vapply(contents, render_content_summary, character(1), format = format)
+  parts <- parts[nzchar(parts)]
+
+  if (length(parts) == 0) {
+    NA_character_
+  } else {
+    paste(parts, collapse = if (identical(format, "html")) "" else "\n")
+  }
+}
+
+#' Summarise a single ellmer content object
+#' @noRd
+render_content_summary <- function(content, format = c("text", "markdown", "html")) {
+  format <- match.arg(format)
+
+  wrap <- function(text) {
+    if (identical(format, "html")) {
+      safe_text <- gsub("&", "&amp;", text, fixed = TRUE)
+      safe_text <- gsub("<", "&lt;", safe_text, fixed = TRUE)
+      safe_text <- gsub(">", "&gt;", safe_text, fixed = TRUE)
+      paste0("<p>", safe_text, "</p>")
+    } else {
+      text
+    }
+  }
+
+  is_content_class <- function(name) any(grepl(paste0(name, "$"), class(content)))
+
+  if (is_content_class("ContentText")) {
+    return(content@text %||% "")
+  }
+
+  if (is_content_class("ContentToolRequest")) {
+    args <- jsonlite::toJSON(content@arguments, auto_unbox = TRUE, pretty = FALSE)
+    return(wrap(paste0("[tool request] ", content@name, " ", args)))
+  }
+
+  if (is_content_class("ContentToolResult")) {
+    result <- if (!is.null(content@error)) {
+      paste0("error: ", content@error)
+    } else {
+      format_output(content@value)
+    }
+    tool_name <- tryCatch(content@request@name, error = function(e) "tool")
+    return(wrap(paste0("[tool result] ", tool_name, " ", result)))
+  }
+
+  if (is_content_class("ContentImageRemote") || is_content_class("ContentImageInline")) {
+    label <- paste0("[image] ", class(content)[1])
+    return(wrap(label))
+  }
+
+  if (is_content_class("ContentPDF")) {
+    return(wrap("[pdf]"))
+  }
+
+  wrap(paste0("[content] ", class(content)[1]))
+}
+
+#' Extract token metrics from a trace entry
+#' @noRd
+trace_tokens <- function(trace) {
+  if (is.list(trace$tokens)) {
+    return(list(
+      input_tokens = as.integer(trace$tokens$input_tokens %||% NA_integer_),
+      output_tokens = as.integer(trace$tokens$output_tokens %||% NA_integer_),
+      cached_input_tokens = as.integer(trace$tokens$cached_input_tokens %||% NA_integer_),
+      total_tokens = as.integer(trace$tokens$total_tokens %||% NA_integer_)
+    ))
+  }
+
+  assistant_turn <- trace$assistant_turn
+  if (!is.null(assistant_turn) && !is.null(assistant_turn@tokens)) {
+    tokens <- assistant_turn@tokens
+    return(list(
+      input_tokens = as.integer(tokens[1] %||% NA_integer_),
+      output_tokens = as.integer(tokens[2] %||% NA_integer_),
+      cached_input_tokens = as.integer(tokens[3] %||% NA_integer_),
+      total_tokens = as.integer(sum(tokens[1:2], na.rm = TRUE))
+    ))
+  }
+
+  list(
+    input_tokens = as.integer(trace$input_tokens %||% NA_integer_),
+    output_tokens = as.integer(trace$output_tokens %||% NA_integer_),
+    cached_input_tokens = as.integer(trace$cached_input_tokens %||% NA_integer_),
+    total_tokens = as.integer(trace$total_tokens %||% NA_integer_)
+  )
+}
+
+#' Extract cost from a trace entry
+#' @noRd
+trace_cost <- function(trace) {
+  trace$cost %||% trace$total_cost %||% tryCatch(trace$assistant_turn@cost, error = function(e) NA_real_)
+}
+
+#' Extract latency from a trace entry
+#' @noRd
+trace_latency_ms <- function(trace) {
+  trace$latency_ms %||% tryCatch((trace$assistant_turn@duration %||% NA_real_) * 1000, error = function(e) NA_real_)
+}
+
+#' Extract prompt text from a trace entry
+#' @noRd
+trace_prompt_text <- function(trace) {
+  trace$prompt %||% render_turn_text(trace$user_turn)
+}
+
+#' Extract prompt markdown from a trace entry
+#' @noRd
+trace_prompt_markdown <- function(trace) {
+  render_turn_markdown(trace$user_turn)
+}
+
+#' Extract prompt HTML from a trace entry
+#' @noRd
+trace_prompt_html <- function(trace) {
+  render_turn_html(trace$user_turn)
+}
+
+#' Extract response text from a trace entry
+#' @noRd
+trace_response_text <- function(trace) {
+  if (!is.null(trace$assistant_turn)) {
+    render_turn_text(trace$assistant_turn)
+  } else if (!is.null(trace$output)) {
+    format_output(trace$output)
+  } else {
+    NA_character_
+  }
+}
+
+#' Extract response markdown from a trace entry
+#' @noRd
+trace_response_markdown <- function(trace) {
+  if (!is.null(trace$assistant_turn)) {
+    render_turn_markdown(trace$assistant_turn)
+  } else {
+    NA_character_
+  }
+}
+
+#' Extract response HTML from a trace entry
+#' @noRd
+trace_response_html <- function(trace) {
+  if (!is.null(trace$assistant_turn)) {
+    render_turn_html(trace$assistant_turn)
+  } else {
+    NA_character_
+  }
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -2,6 +2,9 @@
 #' @noRd
 
 .onLoad <- function(libname, pkgname) {
+  registerS3method("print", "dsprrr_batch_result", print.dsprrr_batch_result)
+  registerS3method("print", "dsprrr_trace_summary", print.dsprrr_trace_summary)
+
   # Register S7 methods for Signature (still S7)
   S7::method(print, Signature) <- print_signature
 

--- a/tests/testthat/test-async.R
+++ b/tests/testthat/test-async.R
@@ -94,3 +94,41 @@ test_that("run_async returns a promise", {
   result <- mod$run_async(text = "Hello")
   expect_s3_class(result, "promise")
 })
+
+test_that("run, run_async, and stream_async share prompt assembly", {
+  captured <- new.env(parent = emptyenv())
+
+  mock_chat <- structure(
+    list(
+      get_turns = function() list(),
+      last_turn = function(...) NULL,
+      chat_structured = function(prompt, type, ...) {
+        captured$run <- prompt
+        "ok"
+      },
+      chat_structured_async = function(prompt, type, ...) {
+        captured$async <- prompt
+        "async"
+      },
+      stream_async = function(prompt, ...) {
+        captured$stream <- prompt
+        "stream"
+      }
+    ),
+    class = "Chat"
+  )
+
+  mod <- module(
+    signature("text -> result", instructions = "Be concise"),
+    type = "predict",
+    template = "Text: {text}",
+    chat = mock_chat
+  )
+
+  run(mod, text = "hello")
+  run_async(mod, text = "hello")
+  stream_async(mod, text = "hello")
+
+  expect_identical(captured$run, captured$async)
+  expect_identical(captured$run, captured$stream)
+})

--- a/tests/testthat/test-ellmer.R
+++ b/tests/testthat/test-ellmer.R
@@ -76,10 +76,38 @@ test_that("as_ellmer_tool function can be invoked with mock LLM", {
   # Actually invoke the tool function (ToolDef IS the function)
   result <- tool(text = "I love this!")
 
-  # Should return JSON-formatted result
-  expect_type(result, "character")
-  parsed <- jsonlite::fromJSON(result)
-  expect_equal(parsed$sentiment, "positive")
+  # Native structured values should flow through unchanged
+  expect_type(result, "list")
+  expect_equal(result$sentiment, "positive")
+})
+
+test_that("as_ellmer_tool preserves structured argument schemas", {
+  skip_if_not_installed("ellmer")
+
+  sig <- Signature(
+    inputs = list(
+      input(
+        "payload",
+        ellmer::type_object(
+          query = ellmer::type_string(),
+          limit = ellmer::type_integer(),
+          ignored = ellmer::type_ignore()
+        )
+      )
+    ),
+    output_type = ellmer::type_string()
+  )
+
+  tool <- as_ellmer_tool(module(sig, type = "predict"), name = "structured")
+
+  payload_type <- tool@arguments@properties$payload
+
+  expect_s3_class(payload_type, "ellmer::TypeObject")
+  expect_true("ignored" %in% names(payload_type@properties))
+  expect_s3_class(
+    payload_type@properties$ignored,
+    "ellmer::TypeIgnore"
+  )
 })
 
 test_that("as_ellmer_tool generates description from signature if not provided", {

--- a/tests/testthat/test-module-multichain.R
+++ b/tests/testthat/test-module-multichain.R
@@ -276,6 +276,12 @@ test_that("MultiChainComparisonModule forward calls inner module M times", {
 })
 
 test_that("MultiChainComparisonModule forward handles partial failures", {
+  # Minimal mock LLM so resolve_module_llm doesn't try to create one
+  mock_llm <- list(
+    get_turns = function() list(),
+    clone = function(deep = FALSE) mock_llm
+  )
+
   # First call succeeds, second fails, third succeeds
   call_count <- 0
   mock_mod <- list(
@@ -328,7 +334,10 @@ test_that("MultiChainComparisonModule forward handles partial failures", {
   )
 
   expect_error(
-    suppressWarnings(mcc_fail$forward(list(question = "test?"))),
+    suppressWarnings(mcc_fail$forward(
+      list(question = "test?"),
+      .llm = mock_llm
+    )),
     "All.*attempts failed"
   )
 })

--- a/tests/testthat/test-orchestration.R
+++ b/tests/testthat/test-orchestration.R
@@ -148,7 +148,11 @@ test_that("restore_module_config accepts custom signature", {
 
 test_that("restore_module_config rejects legacy pinned configs", {
   legacy_config <- list(
-    signature = list(inputs = list(), output_type = "string", instructions = ""),
+    signature = list(
+      inputs = list(),
+      output_type = "string",
+      instructions = ""
+    ),
     config = list()
   )
 

--- a/tests/testthat/test-orchestration.R
+++ b/tests/testthat/test-orchestration.R
@@ -146,6 +146,51 @@ test_that("restore_module_config accepts custom signature", {
   expect_equal(restored$signature@inputs[[1]]$name, "custom_input")
 })
 
+test_that("restore_module_config rejects legacy pinned configs", {
+  legacy_config <- list(
+    signature = list(inputs = list(), output_type = "string", instructions = ""),
+    config = list()
+  )
+
+  expect_error(
+    restore_module_config(legacy_config),
+    "Re-pin this module using the v2 format"
+  )
+})
+
+test_that("pin_module_config round-trips chain_of_thought kind", {
+  skip_if_not_installed("pins")
+
+  mod <- module(signature("question -> answer"), type = "chain_of_thought")
+  board <- pins::board_temp()
+
+  pin_module_config(board, "cot", mod)
+  config <- pins::pin_read(board, "cot")
+  restored <- restore_module_config(config)
+
+  expect_equal(config$module_kind, "chain_of_thought")
+  expect_equal(restored$config$.module_kind, "chain_of_thought")
+  expect_true("reasoning" %in% names(restored$signature@output_type@properties))
+})
+
+test_that("pin_module_config round-trips multichain core state", {
+  skip_if_not_installed("pins")
+
+  mod <- multi_chain_comparison("question -> answer", M = 4, temperature = 0.9)
+  board <- pins::board_temp()
+
+  pin_module_config(board, "mcc", mod)
+  config <- pins::pin_read(board, "mcc")
+  restored <- restore_module_config(config)
+
+  expect_equal(config$module_kind, "multichain")
+  expect_s3_class(restored, "Module")
+  expect_equal(restored$config$.module_kind, "multichain")
+  expect_equal(restored$M, 4)
+  expect_equal(restored$temperature, 0.9)
+  expect_equal(restored$inner_module$config$.module_kind, "chain_of_thought")
+})
+
 # ---- pin_trace tests ----
 
 test_that("pin_trace requires pins package", {

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -167,6 +167,31 @@ test_that("get_default_llm returns ellmer chat object", {
   expect_identical(llm, mock_llm)
 })
 
+test_that("module config no longer synthesizes chats from provider fields", {
+  old_opt <- options(dsprrr.default_chat = NULL)
+  on.exit(options(old_opt), add = TRUE)
+  clear_default_chat()
+
+  old_env <- Sys.getenv(c(
+    "OPENAI_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "GOOGLE_API_KEY"
+  ))
+  on.exit(do.call(Sys.setenv, as.list(old_env)), add = TRUE)
+  Sys.unsetenv(c("OPENAI_API_KEY", "ANTHROPIC_API_KEY", "GOOGLE_API_KEY"))
+
+  mod <- module(
+    signature("text -> result"),
+    type = "predict",
+    config = list(provider = "openai", model = "gpt-4o-mini")
+  )
+
+  expect_error(
+    run(mod, text = "hello"),
+    "no longer creates Chat clients"
+  )
+})
+
 test_that("batch processing works with multiple inputs", {
   sig <- Signature(
     inputs = list(

--- a/tests/testthat/test-traces.R
+++ b/tests/testthat/test-traces.R
@@ -1,0 +1,38 @@
+test_that("export_traces renders turn content with tool fallbacks", {
+  mod <- module(signature("question -> answer"), type = "predict")
+
+  tool_request <- ellmer::ContentToolRequest(
+    id = "tool-1",
+    name = "lookup",
+    arguments = list(question = "What is R?")
+  )
+  tool_result <- ellmer::ContentToolResult(
+    value = list(answer = "A language"),
+    request = tool_request
+  )
+
+  mod$state$traces <- list(
+    list(
+      timestamp = Sys.time(),
+      user_turn = ellmer::UserTurn(
+        contents = list(ellmer::ContentText("Question"), tool_request)
+      ),
+      assistant_turn = ellmer::AssistantTurn(
+        contents = list(tool_result)
+      ),
+      turns = list(),
+      output = list(answer = "A language"),
+      model = "mock-model",
+      latency_ms = 100,
+      tokens = list(input_tokens = 10L, output_tokens = 5L, total_tokens = 15L),
+      cost = 0.001
+    )
+  )
+
+  traces <- export_traces(mod, include_prompts = TRUE, include_outputs = TRUE)
+
+  expect_true(grepl("Question", traces$prompt[[1]], fixed = TRUE))
+  expect_true(grepl("tool result", traces$response_text[[1]], ignore.case = TRUE))
+  expect_true(grepl("lookup", traces$response_text[[1]], fixed = TRUE))
+  expect_true(grepl("<p>", traces$prompt_html[[1]], fixed = TRUE))
+})

--- a/tests/testthat/test-traces.R
+++ b/tests/testthat/test-traces.R
@@ -32,7 +32,11 @@ test_that("export_traces renders turn content with tool fallbacks", {
   traces <- export_traces(mod, include_prompts = TRUE, include_outputs = TRUE)
 
   expect_true(grepl("Question", traces$prompt[[1]], fixed = TRUE))
-  expect_true(grepl("tool result", traces$response_text[[1]], ignore.case = TRUE))
+  expect_true(grepl(
+    "tool result",
+    traces$response_text[[1]],
+    ignore.case = TRUE
+  ))
   expect_true(grepl("lookup", traces$response_text[[1]], fixed = TRUE))
   expect_true(grepl("<p>", traces$prompt_html[[1]], fixed = TRUE))
 })

--- a/vignettes/compilation-optimization.Rmd
+++ b/vignettes/compilation-optimization.Rmd
@@ -524,7 +524,8 @@ grid_teleprompter <- GridSearchTeleprompter(
 optimized_qa <- compile_module(
   program = qa_module,
   teleprompter = grid_teleprompter,
-  trainset = qa_trainset
+  trainset = qa_trainset,
+  .llm = llm
 )
 
 # Check which variant performed best
@@ -622,7 +623,8 @@ grid_optimizer <- GridSearchTeleprompter(
 optimized_grid <- compile_module(
   program = email_classifier,
   teleprompter = grid_optimizer,
-  trainset = email_trainset
+  trainset = email_trainset,
+  .llm = llm
 )
 
 # Step 4: Use the optimized module
@@ -853,7 +855,8 @@ grid_optimizer <- GridSearchTeleprompter(
 best_analyzer <- compile_module(
   program = doc_analyzer,
   teleprompter = grid_optimizer,
-  trainset = doc_trainset
+  trainset = doc_trainset,
+  .llm = llm
 )
 
 # 5. Use the optimized analyzer


### PR DESCRIPTION
## Summary
- make `ellmer` the sole runtime layer for module execution and standardize runtime params on `config$params`
- add v2-only, lossless persistence for core module kinds with explicit legacy-pin rejection
- preserve ellmer schemas and native structured tool returns, and pivot trace rendering to ellmer turns/contents

## Why
This is phase 1 of the ellmer-first refactor. `dsprrr` should stop owning provider-specific runtime behavior and instead rely on `ellmer` for chat execution, content handling, and schema/tool interoperability.

## Impact
- module execution now resolves chats only from explicit `.llm`, `module$chat`, or the default/env chat
- legacy config fields no longer synthesize chats
- persisted module configs now use the v2 format only
- traces and exports are based on ellmer turns/content with better tool and multimodal rendering

## Validation
- `tests/testthat/test-async.R`
- `tests/testthat/test-streaming.R`
- `tests/testthat/test-ellmer.R`
- `tests/testthat/test-orchestration.R`
- `tests/testthat/test-traces.R`
- `tests/testthat/test-run.R`
- `tests/testthat/test-predict.R`
- `tests/testthat/test-module-multichain.R`
