### PR TITLE
fix: ReactModule forward() now tracks tool calls from ellmer's internal loop

### DIFF
--- a/R/module-react-doc.R
+++ b/R/module-react-doc.R
@@ -8,7 +8,8 @@
 #' @details
 #' Create a ReAct module with `module(type = "react", tools = list(...))`.
 #' If you pass `tools` with `type = "predict"`, the module automatically
-#' upgrades to `react`. The module runs a loop of tool calls up to
+#' upgrades to `react`. ellmer executes the tool-calling loop internally; dsprrr
+#' records the observed tool-call rounds and warns if they exceed
 #' `max_iterations`, then produces output based on the module signature.
 #'
 #' @examples

--- a/R/module-react.R
+++ b/R/module-react.R
@@ -20,14 +20,16 @@ ReactModule <- R6::R6Class(
     #' @field tools List of ToolDef objects for the module
     tools = NULL,
 
-    #' @field max_iterations Maximum number of ReAct iterations
+    #' @field max_iterations Maximum expected number of ReAct tool iterations
     max_iterations = 10L,
 
     #' @description
     #' Initialize a new ReactModule
     #' @param signature S7 Signature object
     #' @param tools List of ellmer ToolDef objects
-    #' @param max_iterations Maximum iterations for ReAct loop (default: 10)
+    #' @param max_iterations Maximum expected tool-call iterations before
+    #'   warning. ellmer executes the tool loop internally, so this is checked
+    #'   after the chat call completes.
     #' @param template Optional glue template string
     #' @param demos Optional list of demonstrations
     #' @param config Optional configuration list
@@ -145,7 +147,9 @@ ReactModule <- R6::R6Class(
         tryCatch(
           {
             fn <- chat$get_turns
-            if (!is.function(fn)) return(list())
+            if (!is.function(fn)) {
+              return(list())
+            }
             fn()
           },
           error = function(e) list()
@@ -180,7 +184,9 @@ ReactModule <- R6::R6Class(
       all_turns <- list()
 
       for (turn in new_turns) {
-        if (turn@role != "assistant") next
+        if (turn@role != "assistant") {
+          next
+        }
         all_turns <- c(all_turns, list(turn))
 
         turn_tool_calls <- list()
@@ -204,7 +210,9 @@ ReactModule <- R6::R6Class(
         }
       }
 
-      if (iterations == 0L) iterations <- 1L
+      if (iterations == 0L) {
+        iterations <- 1L
+      }
 
       if (iterations > self$max_iterations) {
         cli::cli_warn(c(

--- a/R/module-react.R
+++ b/R/module-react.R
@@ -139,64 +139,54 @@ ReactModule <- R6::R6Class(
 
       prompt <- request$full_prompt
 
-      # Record start time
       start_time <- Sys.time()
 
-      # Track iterations and tool calls
-      iterations <- 0L
-      tool_calls <- list()
-      all_turns <- list()
-
-      # ReAct loop
-      repeat {
-        iterations <- iterations + 1L
-
-        if (iterations > self$max_iterations) {
-          cli::cli_warn(c(
-            "Maximum iterations ({self$max_iterations}) reached",
-            "i" = "Increase max_iterations if more reasoning steps are needed"
-          ))
-          break
-        }
-
-        # Make LLM call (non-structured to allow tool use)
+      get_turns_safe <- function(chat) {
         tryCatch(
           {
-            llm$chat(prompt, echo = "none")
+            fn <- chat$get_turns
+            if (!is.function(fn)) return(list())
+            fn()
           },
-          error = function(e) {
-            cli::cli_abort(
-              "LLM call failed in ReAct loop: {e$message}",
-              parent = e
-            )
-          }
+          error = function(e) list()
         )
+      }
 
-        # Get the last assistant turn
-        last_turn <- llm$last_turn(role = "assistant")
-        all_turns <- c(all_turns, list(last_turn))
+      n_turns_before <- length(get_turns_safe(llm))
 
-        # Check if there's a tool request in the response
-        has_tool_request <- any(vapply(
-          last_turn@contents,
-          function(c) {
-            inherits(c, "ContentToolRequest")
-          },
-          logical(1)
-        ))
-
-        if (!has_tool_request) {
-          # No more tool calls - we're done with reasoning
-          break
+      tryCatch(
+        {
+          llm$chat(prompt, echo = "none")
+        },
+        error = function(e) {
+          cli::cli_abort(
+            "LLM call failed in ReAct loop: {e$message}",
+            parent = e
+          )
         }
+      )
 
-        # Extract tool calls for tracing
-        for (content in last_turn@contents) {
+      all_conversation_turns <- get_turns_safe(llm)
+      new_turns <- all_conversation_turns[seq(
+        n_turns_before + 1L,
+        length(all_conversation_turns)
+      )]
+
+      tool_calls <- list()
+      iterations <- 0L
+      all_turns <- list()
+
+      for (turn in new_turns) {
+        if (turn@role != "assistant") next
+        all_turns <- c(all_turns, list(turn))
+
+        turn_tool_calls <- list()
+        for (content in turn@contents) {
           if (inherits(content, "ContentToolRequest")) {
-            tool_calls <- c(
-              tool_calls,
+            turn_tool_calls <- c(
+              turn_tool_calls,
               list(list(
-                iteration = iterations,
+                iteration = iterations + 1L,
                 tool_name = content@name,
                 tool_id = content@id,
                 arguments = content@arguments
@@ -205,9 +195,19 @@ ReactModule <- R6::R6Class(
           }
         }
 
-        # Continue the conversation (empty prompt continues with tool results)
-        # ellmer automatically handles tool execution and result injection
-        prompt <- ""
+        if (length(turn_tool_calls) > 0) {
+          iterations <- iterations + 1L
+          tool_calls <- c(tool_calls, turn_tool_calls)
+        }
+      }
+
+      if (iterations == 0L) iterations <- 1L
+
+      if (iterations > self$max_iterations) {
+        cli::cli_warn(c(
+          "Tool-calling loop ran {iterations} iterations (max: {self$max_iterations})",
+          "i" = "Increase max_iterations if more reasoning steps are needed"
+        ))
       }
 
       # Get final structured output

--- a/R/module-react.R
+++ b/R/module-react.R
@@ -167,10 +167,13 @@ ReactModule <- R6::R6Class(
       )
 
       all_conversation_turns <- get_turns_safe(llm)
-      new_turns <- all_conversation_turns[seq(
-        n_turns_before + 1L,
-        length(all_conversation_turns)
-      )]
+      n_turns_after <- length(all_conversation_turns)
+
+      new_turns <- if (n_turns_after > n_turns_before) {
+        all_conversation_turns[seq(n_turns_before + 1L, n_turns_after)]
+      } else {
+        list()
+      }
 
       tool_calls <- list()
       iterations <- 0L

--- a/R/module-react.R
+++ b/R/module-react.R
@@ -182,7 +182,7 @@ ReactModule <- R6::R6Class(
 
         turn_tool_calls <- list()
         for (content in turn@contents) {
-          if (inherits(content, "ContentToolRequest")) {
+          if (inherits(content, "ellmer::ContentToolRequest")) {
             turn_tool_calls <- c(
               turn_tool_calls,
               list(list(

--- a/man/module-react.Rd
+++ b/man/module-react.Rd
@@ -11,7 +11,8 @@ tool calls, and observations before producing a final structured answer.
 \details{
 Create a ReAct module with \code{module(type = "react", tools = list(...))}.
 If you pass \code{tools} with \code{type = "predict"}, the module automatically
-upgrades to \code{react}. The module runs a loop of tool calls up to
+upgrades to \code{react}. ellmer executes the tool-calling loop internally; dsprrr
+records the observed tool-call rounds and warns if they exceed
 \code{max_iterations}, then produces output based on the module signature.
 }
 \examples{

--- a/tests/testthat/test-module-react.R
+++ b/tests/testthat/test-module-react.R
@@ -144,6 +144,80 @@ test_that("ReactModule max_iterations is configurable", {
   expect_equal(mod$max_iterations, 20L)
 })
 
+test_that("ReactModule forward tracks tool calls from ellmer turns", {
+  turns <- list()
+
+  last_turn <- function(role = c("assistant", "user"), ...) {
+    role <- match.arg(role)
+    role_turns <- Filter(function(turn) identical(turn@role, role), turns)
+
+    if (length(role_turns) == 0) {
+      stop("no turns")
+    }
+
+    role_turns[[length(role_turns)]]
+  }
+
+  mock_llm <- structure(
+    list(
+      register_tool = function(tool) invisible(NULL),
+      get_turns = function(...) turns,
+      last_turn = last_turn,
+      chat = function(prompt, echo = "none", ...) {
+        user_turn <- ellmer::UserTurn(
+          contents = list(ellmer::ContentText(prompt))
+        )
+        first_tool_turn <- ellmer::AssistantTurn(
+          contents = list(ellmer::ContentToolRequest(
+            id = "call_1",
+            name = "lookup",
+            arguments = list(query = "alpha")
+          ))
+        )
+        second_tool_turn <- ellmer::AssistantTurn(
+          contents = list(ellmer::ContentToolRequest(
+            id = "call_2",
+            name = "summarize",
+            arguments = list(value = "beta")
+          ))
+        )
+
+        turns <<- c(
+          turns,
+          list(user_turn, first_tool_turn, second_tool_turn)
+        )
+        invisible(NULL)
+      },
+      chat_structured = function(prompt, type, echo = "none", ...) {
+        final_turn <- ellmer::AssistantTurn(
+          contents = list(ellmer::ContentText("{\"answer\":\"done\"}"))
+        )
+        turns <<- c(turns, list(final_turn))
+        list(answer = "done")
+      },
+      get_model = function() "mock-model"
+    ),
+    class = "Chat"
+  )
+
+  sig <- signature("question -> answer")
+  mod <- module(sig, type = "react")
+
+  result <- mod$forward(list(question = "test"), .llm = mock_llm, trace = TRUE)
+  metadata <- result$metadata[[1]]
+
+  expect_equal(metadata$iterations, 2L)
+  expect_length(metadata$tool_calls, 2)
+  expect_equal(
+    vapply(metadata$tool_calls, `[[`, character(1), "tool_name"),
+    c("lookup", "summarize")
+  )
+  expect_equal(metadata$tool_calls[[1]]$arguments$query, "alpha")
+  expect_equal(metadata$tool_calls[[2]]$arguments$value, "beta")
+  expect_equal(metadata$tools_used, c("lookup", "summarize"))
+  expect_equal(mod$state$traces[[1]]$iterations, 2L)
+})
+
 test_that("ReactModule print includes tool info", {
   skip_if_not_installed("ellmer")
 


### PR DESCRIPTION
## Summary

- **Bug**: `ReactModule$forward()` had a broken `repeat` loop that never correctly tracked tool calls. `ellmer::Chat$chat()` runs the full tool-calling loop internally, so `$last_turn(role = "assistant")` always returned the final turn with no tool requests. Result: `iterations` was always 1, `tool_calls` was always empty, and trace metadata was useless.
- **Fix**: Replace the repeat loop with a retroactive turn-walking approach. Record turn count before calling `chat()`, let ellmer handle the full tool loop, then walk the new assistant turns to populate `tool_calls`, `all_turns`, and `iterations` from the conversation history.
- Uses the same `get_turns_safe()` pattern already established in `module-predict.R`

## Test plan

- [ ] Verify `ReactModule` with tool-using agent produces non-empty `tool_calls` in trace metadata
- [ ] Verify `iterations` count matches actual tool-calling rounds
- [ ] Verify existing `ReactModule` tests still pass
- [ ] Verify non-tool-using prompts still work (iterations defaults to 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)