### PR TITLE
docs: revamp pkgdown landing page inspired by the new DSPy homepage

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -219,7 +219,7 @@ dsprrr uses ellmer for all LLM calls. The integration is straightforward:
 
 ## Status
 
-Experimental. The API may change. See [PLAN.md](PLAN.md) for the roadmap.
+Experimental. The API may change. See the [open issues](https://github.com/JamesHWade/dsprrr/issues) for the roadmap.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -290,8 +290,8 @@ Documentation](https://jameshwade.github.io/dsprrr/reference/index.html)
 
 ## Status
 
-Experimental. The API may change. See [PLAN.md](PLAN.md) for the
-roadmap.
+Experimental. The API may change. See the [open
+issues](https://github.com/JamesHWade/dsprrr/issues) for the roadmap.
 
 ## Acknowledgments
 

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -52,6 +52,24 @@
   }
 }
 
+// Core primitives section (Signatures / Modules / Optimizers)
+.primitive-row {
+  padding: 1rem 0;
+  border-top: 1px solid var(--bs-border-color);
+
+  h3 {
+    color: var(--bs-primary);
+    font-weight: 600;
+    margin-top: 0;
+  }
+
+  // Keep the descriptive column and its code block vertically centered
+  // together, with comfortable spacing on wider screens.
+  pre {
+    margin-bottom: 0;
+  }
+}
+
 // Section separators
 hr {
   border: none;

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -117,8 +117,9 @@ hr {
   margin: 3rem 0;
 }
 
-// Result callouts in tabs
-.tab-pane p strong:first-child {
+// Result callouts in the "Automatic Optimization" tabs ("**Result**: ...").
+// Scoped to that section so a bold lead-in elsewhere isn't recolored.
+#optimizeTabsContent .tab-pane p strong:first-child {
   color: var(--bs-success);
 }
 

--- a/pkgdown/extra.scss
+++ b/pkgdown/extra.scss
@@ -54,7 +54,7 @@
 
 // Core primitives section (Signatures / Modules / Optimizers)
 .primitive-row {
-  padding: 1rem 0;
+  padding: 1.25rem 0;
   border-top: 1px solid var(--bs-border-color);
 
   h3 {
@@ -63,10 +63,50 @@
     margin-top: 0;
   }
 
+  // The bold lead-in on each primitive ("Declare your task.") echoes
+  // DSPy's primitive taglines.
+  p > strong:first-child {
+    display: block;
+    font-size: 1.05rem;
+    color: var(--bs-emphasis-color);
+    margin-bottom: 0.25rem;
+  }
+
   // Keep the descriptive column and its code block vertically centered
   // together, with comfortable spacing on wider screens.
   pre {
     margin-bottom: 0;
+  }
+}
+
+// "Learn more ->" inline links under primitives and gallery tabs
+.primitive-row a[href$="html"],
+.example-gallery a[href$="html"] {
+  font-weight: 500;
+  text-decoration: none;
+
+  &:hover {
+    text-decoration: underline;
+  }
+}
+
+// Example gallery (Extract / Agent / Pipeline / Multimodal / Optimize)
+.example-gallery {
+  > .tab-pane {
+    // Steady height so switching tabs doesn't jump the page.
+    min-height: 22rem;
+  }
+
+  // The one-line caption above each example.
+  > .tab-pane > p:first-child {
+    color: var(--bs-secondary-color);
+    margin-bottom: 0.75rem;
+  }
+}
+
+@media (max-width: 768px) {
+  .example-gallery > .tab-pane {
+    min-height: 0;
   }
 }
 

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -14,34 +14,78 @@ dsp("question -> answer", question = "What is the capital of France?")
 #> "Paris"
 ```
 
-## The building blocks
+## Compose programs with reusable primitives
 
-Every dsprrr program is built from the same three composable pieces—the triad at the heart of DSPy. Learn these and the rest of the package falls into place.
+Every dsprrr program is built from the same three pieces. Learn these and the rest of the package falls into place.
 
-<div class="row row-cols-1 row-cols-md-3 g-4 my-4">
-<div class="col">
-<div class="card h-100 border-start border-primary border-4">
-<div class="card-body">
-<h5 class="card-title">1. Signatures</h5>
-<p class="card-text">Declare a task's inputs and outputs—<code>"question -> answer"</code>—and let dsprrr build the prompt. No string wrangling.</p>
+<div class="row align-items-center g-4 my-4 primitive-row">
+<div class="col-md-5">
+
+### Signatures
+
+**Declare your task.** Define typed inputs and outputs instead of wrestling with prompt strings. Portable, maintainable, and easy to iterate on.
+
+[Learn about signatures &rarr;](articles/concepts-signatures-modules.html)
+
+</div>
+<div class="col-md-7">
+
+```r
+# Route a support ticket
+sig <- signature(
+  "ticket -> urgency: enum('low', 'high'), team: string"
+)
+```
+
 </div>
 </div>
+
+<div class="row align-items-center g-4 my-4 primitive-row">
+<div class="col-md-5">
+
+### Modules
+
+**Same interface, different strategy.** Modules control how a signature executes—reason step by step, use tools, or run ensembles—without rewriting the task.
+
+[Explore modules &rarr;](articles/advanced-modules.html)
+
 </div>
-<div class="col">
-<div class="card h-100 border-start border-primary border-4">
-<div class="card-body">
-<h5 class="card-title">2. Modules</h5>
-<p class="card-text">Wrap a signature in a strategy—<code>predict</code>, <code>chain_of_thought</code>, <code>react</code>, and more—then chain modules into pipelines with <code>%&gt;&gt;%</code>.</p>
+<div class="col-md-7">
+
+```r
+# Direct completion
+classify <- module(sig, type = "predict")
+
+# Add step-by-step reasoning
+classify <- module(sig, type = "chain_of_thought")
+
+# Add tools and a reasoning loop
+classify <- module(sig, type = "react", tools = list(search))
+```
+
 </div>
 </div>
+
+<div class="row align-items-center g-4 my-4 primitive-row">
+<div class="col-md-5">
+
+### Optimizers
+
+**Compile your program against a metric.** Give dsprrr examples and a scoring function; it tunes prompts and demos automatically until quality converges.
+
+[Try optimizers &rarr;](articles/compilation-optimization.html)
+
 </div>
-<div class="col">
-<div class="card h-100 border-start border-primary border-4">
-<div class="card-body">
-<h5 class="card-title">3. Optimizers</h5>
-<p class="card-text">Improve modules from data and a metric—few-shot demos, instruction search, Bayesian optimization—instead of hand-tuning prompts.</p>
-</div>
-</div>
+<div class="col-md-7">
+
+```r
+tp <- GEPA(metric = metric_exact_match())
+optimized <- compile(tp, mod, trainset)
+
+# Before: 0.41   After: 0.63
+pin_module_config(optimized, "rag-v2")
+```
+
 </div>
 </div>
 

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -226,10 +226,11 @@ result <- run(
   message = "I'm Sarah (sarah@acme.co). Meet Thursday?",
   .llm = chat_openai()
 )
-get_output(result)
-#> $name   "Sarah"
-#> $email  "sarah@acme.co"
-#> $intent "meeting"
+
+# In simple mode (the default), run() returns the parsed output directly
+result$name    #> "Sarah"
+result$email   #> "sarah@acme.co"
+result$intent  #> "meeting"
 ```
 
 [Extract structured data &rarr;](articles/tutorial-structured-outputs.html)

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -171,92 +171,138 @@ dsp("question -> answer", question = "What is 2+2?")
   </div>
 </div>
 
-## Building Modules
+## Define a task. Grow it into a system.
 
-Modules are reusable LLM components with typed inputs and outputs.
+Start with a single signature and grow it into a multi-step program—the
+same building blocks scale from a one-line extractor to a full pipeline.
 
 <ul class="nav nav-tabs" id="moduleTabs" role="tablist">
   <li class="nav-item" role="presentation">
-    <button class="nav-link active" id="classify-tab" data-bs-toggle="tab" data-bs-target="#classify" type="button" role="tab">Classification</button>
+    <button class="nav-link active" id="extract-tab" data-bs-toggle="tab" data-bs-target="#extract" type="button" role="tab">Extract</button>
   </li>
   <li class="nav-item" role="presentation">
-    <button class="nav-link" id="qa-tab" data-bs-toggle="tab" data-bs-target="#qa" type="button" role="tab">Q&A</button>
+    <button class="nav-link" id="agent-tab" data-bs-toggle="tab" data-bs-target="#agent" type="button" role="tab">Agent</button>
   </li>
   <li class="nav-item" role="presentation">
-    <button class="nav-link" id="extract-tab" data-bs-toggle="tab" data-bs-target="#extract" type="button" role="tab">Extraction</button>
+    <button class="nav-link" id="pipeline-tab" data-bs-toggle="tab" data-bs-target="#pipeline" type="button" role="tab">Pipeline</button>
   </li>
   <li class="nav-item" role="presentation">
-    <button class="nav-link" id="agent-tab" data-bs-toggle="tab" data-bs-target="#agent" type="button" role="tab">Agents</button>
+    <button class="nav-link" id="multimodal-tab" data-bs-toggle="tab" data-bs-target="#multimodal" type="button" role="tab">Multimodal</button>
+  </li>
+  <li class="nav-item" role="presentation">
+    <button class="nav-link" id="optimize-tab" data-bs-toggle="tab" data-bs-target="#optimize" type="button" role="tab">Optimize</button>
   </li>
 </ul>
-<div class="tab-content" id="moduleTabsContent">
-  <div class="tab-pane fade show active" id="classify" role="tabpanel">
+<div class="tab-content example-gallery" id="moduleTabsContent">
+  <div class="tab-pane fade show active" id="extract" role="tabpanel">
+
+Signatures define a task and enforce typed outputs.
 
 ```r
-# Sentiment classification with constrained output
-classifier <- signature(
-  "text -> sentiment: enum('positive', 'negative', 'neutral')"
+# Extract several typed fields in one call
+extract <- signature(
+  "message -> name: string, email: string,
+   intent: enum('meeting', 'intro', 'follow-up')"
 ) |> module(type = "predict")
 
-classifier$predict(text = "I love this product!")
-#> "positive"
-
-# Batch processing
-classifier$predict(text = c("Great!", "Terrible!", "It's okay"))
-#> c("positive", "negative", "neutral")
-```
-
-  </div>
-  <div class="tab-pane fade" id="qa" role="tabpanel">
-
-```r
-# Context-aware QA
-qa <- signature("context, question -> answer") |>
-  module(type = "predict")
-
-qa$predict(
-  context = "R was created by Ross Ihaka and Robert Gentleman in 1993.",
-  question = "Who created R?"
+result <- run(
+  extract,
+  message = "I'm Sarah (sarah@acme.co). Meet Thursday?",
+  .llm = chat_openai()
 )
-#> "Ross Ihaka and Robert Gentleman"
+get_output(result)
+#> $name   "Sarah"
+#> $email  "sarah@acme.co"
+#> $intent "meeting"
 ```
 
-  </div>
-  <div class="tab-pane fade" id="extract" role="tabpanel">
-
-```r
-# Structured output with multiple fields
-extractor <- signature(
-  "text -> title: string, entities: array(string), sentiment: enum('pos', 'neg', 'neu')"
-) |> module(type = "predict")
-
-extractor$predict(text = "Apple announced the iPhone 16 today. Investors are excited.")
-#> $title
-#> "Apple iPhone 16 Announcement"
-#> $entities
-#> c("Apple", "iPhone 16")
-#> $sentiment
-#> "pos"
-```
+[Extract structured data &rarr;](articles/tutorial-structured-outputs.html)
 
   </div>
   <div class="tab-pane fade" id="agent" role="tabpanel">
 
-```r
-# ReAct agent with tool use
-library(ellmer)
+Define tools as functions and hand them to a ReAct module.
 
-search_tool <- tool(
-  function(query) wikipedia_search(query),
-  "Search Wikipedia for information"
+```r
+search <- ellmer::tool(
+  function(query) kb_search(query),
+  description = "Search a knowledge base",
+  arguments = list(query = ellmer::type_string())
 )
 
 agent <- signature("question -> answer") |>
-  module(type = "react", tools = list(search_tool))
+  module(type = "react", tools = list(search))
 
-agent$predict(question = "What is the population of Tokyo?")
-#> "Tokyo has a population of approximately 14 million people."
+run(agent, question = "What were R's biggest releases this year?",
+    .llm = chat_openai())
+#> # thought: I should search the knowledge base.
+#> # action: search("R releases 2026") -> ...
+#> Prediction(answer = "R 4.6 added ...")
 ```
+
+[Build a tool-using agent &rarr;](articles/advanced-modules.html)
+
+  </div>
+  <div class="tab-pane fade" id="pipeline" role="tabpanel">
+
+Compose modules into a pipeline with `%>>%`—outputs flow to inputs.
+
+```r
+# Pull claims, then verify each against the source
+find <- signature("article -> claims: array(string)") |>
+  module(type = "chain_of_thought")
+
+verify <- signature("claim, source -> verdict") |>
+  module(type = "chain_of_thought")
+
+factcheck <- find %>>% verify
+
+run(factcheck, article = news_article, .llm = chat_openai())
+#> verdict: "supported"
+```
+
+[Chain modules into pipelines &rarr;](articles/chaining-modules.html)
+
+  </div>
+  <div class="tab-pane fade" id="multimodal" role="tabpanel">
+
+Name an image input in the signature and pass an ellmer content object.
+
+```r
+analyze <- signature("chart, question -> answer") |>
+  module(type = "predict")
+
+run(
+  analyze,
+  chart    = ellmer::ContentImageRemote("quarterly_revenue.png"),
+  question = "Describe the trend and key data points.",
+  .llm     = chat_openai()
+)
+#> "Steady growth, a Q3 dip, then a strong Q4 recovery."
+```
+
+[Work with multimodal inputs &rarr;](articles/advanced-ellmer.html)
+
+  </div>
+  <div class="tab-pane fade" id="optimize" role="tabpanel">
+
+Optimizers improve a program against a metric—no prompt rewriting.
+
+```r
+trainset <- dsp_trainset(
+  message = c("I'm Sarah (sarah@acme.co). Meet Thursday?",
+              "Hi, this is Dev—just saying hello!"),
+  intent  = c("meeting", "intro")
+)
+
+optimized <- compile(GEPA(metric = metric_exact_match()), extract, trainset)
+#> Baseline   62%  (zero-shot)
+#> Optimized  89%  (GEPA compile)
+
+pin_module_config(board, "extract-v2", optimized)
+```
+
+[Optimize with your data &rarr;](articles/compilation-optimization.html)
 
   </div>
 </div>

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -83,7 +83,7 @@ tp <- GEPA(metric = metric_exact_match())
 optimized <- compile(tp, mod, trainset)
 
 # Before: 0.41   After: 0.63
-pin_module_config(optimized, "rag-v2")
+pin_module_config(board, "rag-v2", optimized)
 ```
 
 </div>

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -14,6 +14,37 @@ dsp("question -> answer", question = "What is the capital of France?")
 #> "Paris"
 ```
 
+## The building blocks
+
+Every dsprrr program is built from the same three composable pieces—the triad at the heart of DSPy. Learn these and the rest of the package falls into place.
+
+<div class="row row-cols-1 row-cols-md-3 g-4 my-4">
+<div class="col">
+<div class="card h-100 border-start border-primary border-4">
+<div class="card-body">
+<h5 class="card-title">1. Signatures</h5>
+<p class="card-text">Declare a task's inputs and outputs—<code>"question -> answer"</code>—and let dsprrr build the prompt. No string wrangling.</p>
+</div>
+</div>
+</div>
+<div class="col">
+<div class="card h-100 border-start border-primary border-4">
+<div class="card-body">
+<h5 class="card-title">2. Modules</h5>
+<p class="card-text">Wrap a signature in a strategy—<code>predict</code>, <code>chain_of_thought</code>, <code>react</code>, and more—then chain modules into pipelines with <code>%&gt;&gt;%</code>.</p>
+</div>
+</div>
+</div>
+<div class="col">
+<div class="card h-100 border-start border-primary border-4">
+<div class="card-body">
+<h5 class="card-title">3. Optimizers</h5>
+<p class="card-text">Improve modules from data and a metric—few-shot demos, instruction search, Bayesian optimization—instead of hand-tuning prompts.</p>
+</div>
+</div>
+</div>
+</div>
+
 ## Getting Started: Configure Your LLM
 
 <ul class="nav nav-tabs" id="providerTabs" role="tablist">

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -53,14 +53,23 @@ sig <- signature(
 <div class="col-md-7">
 
 ```r
+sig <- signature(
+  "ticket -> urgency: enum('low', 'high'), team: string"
+)
+
 # Direct completion
 classify <- module(sig, type = "predict")
 
 # Add step-by-step reasoning
 classify <- module(sig, type = "chain_of_thought")
 
-# Add tools and a reasoning loop
-classify <- module(sig, type = "react", tools = list(search))
+# Add a tool-use loop
+lookup_tool <- ellmer::tool(
+  function(query) paste("Found:", query),
+  description = "Look up support policy details",
+  arguments = list(query = ellmer::type_string())
+)
+classify <- module(sig, type = "react", tools = list(lookup_tool))
 ```
 
 </div>
@@ -79,11 +88,18 @@ classify <- module(sig, type = "react", tools = list(search))
 <div class="col-md-7">
 
 ```r
-tp <- GEPA(metric = metric_exact_match())
-optimized <- compile(tp, mod, trainset)
+route_sig <- signature("ticket -> urgency: enum('low', 'high')")
+router <- module(route_sig, type = "predict")
+trainset <- dsp_trainset(
+  ticket  = c("Package lost", "Need a receipt"),
+  urgency = c("high", "low")
+)
 
-# Before: 0.41   After: 0.63
-pin_module_config(board, "rag-v2", optimized)
+tp <- GEPA(metric = metric_exact_match(field = "urgency"))
+optimized <- compile(tp, router, trainset)
+
+board <- pins::board_temp()
+pin_module_config(board, "ticket-router-v2", optimized)
 ```
 
 </div>
@@ -224,6 +240,13 @@ get_output(result)
 Define tools as functions and hand them to a ReAct module.
 
 ```r
+kb_search <- function(query) {
+  paste(
+    "Evaluators compare module outputs with labeled examples.",
+    "Optimizers use those scores to select better prompts and demos."
+  )
+}
+
 search <- ellmer::tool(
   function(query) kb_search(query),
   description = "Search a knowledge base",
@@ -233,11 +256,13 @@ search <- ellmer::tool(
 agent <- signature("question -> answer") |>
   module(type = "react", tools = list(search))
 
-run(agent, question = "What were R's biggest releases this year?",
-    .llm = chat_openai())
-#> # thought: I should search the knowledge base.
-#> # action: search("R releases 2026") -> ...
-#> Prediction(answer = "R 4.6 added ...")
+answer <- run(
+  agent,
+  question = "How do dsprrr optimizers improve a module?",
+  .llm = chat_openai()
+)
+answer$answer
+#> "They score outputs against examples, then keep better prompts and demos."
 ```
 
 [Build a tool-using agent &rarr;](articles/advanced-modules.html)
@@ -248,8 +273,8 @@ run(agent, question = "What were R's biggest releases this year?",
 Compose modules into a pipeline with `%>>%`—outputs flow to inputs.
 
 ```r
-# Pull claims, then verify each against the source
-find <- signature("article -> claims: array(string)") |>
+# Pull a claim, then verify it against the source
+find <- signature("article -> claim: string, source: string") |>
   module(type = "chain_of_thought")
 
 verify <- signature("claim, source -> verdict") |>
@@ -257,8 +282,10 @@ verify <- signature("claim, source -> verdict") |>
 
 factcheck <- find %>>% verify
 
-run(factcheck, article = news_article, .llm = chat_openai())
-#> verdict: "supported"
+news_article <- "Acme reported that revenue grew 12% in Q4."
+verdict <- run(factcheck, article = news_article, .llm = chat_openai())
+verdict$verdict
+#> "supported"
 ```
 
 [Chain modules into pipelines &rarr;](articles/chaining-modules.html)
@@ -269,16 +296,18 @@ run(factcheck, article = news_article, .llm = chat_openai())
 Name an image input in the signature and pass an ellmer content object.
 
 ```r
-analyze <- signature("chart, question -> answer") |>
+analyze <- signature("image, question -> answer") |>
   module(type = "predict")
 
 run(
   analyze,
-  chart    = ellmer::ContentImageRemote("quarterly_revenue.png"),
-  question = "Describe the trend and key data points.",
+  image    = ellmer::ContentImageRemote(
+    "https://www.r-project.org/logo/Rlogo.png"
+  ),
+  question = "What logo is shown?",
   .llm     = chat_openai()
 )
-#> "Steady growth, a Q3 dip, then a strong Q4 recovery."
+#> "The image shows the R project logo."
 ```
 
 [Work with multimodal inputs &rarr;](articles/advanced-ellmer.html)
@@ -289,16 +318,24 @@ run(
 Optimizers improve a program against a metric—no prompt rewriting.
 
 ```r
+extract <- signature(
+  "message -> intent: enum('meeting', 'intro')"
+) |>
+  module(type = "predict")
+
 trainset <- dsp_trainset(
   message = c("I'm Sarah (sarah@acme.co). Meet Thursday?",
               "Hi, this is Dev—just saying hello!"),
   intent  = c("meeting", "intro")
 )
 
-optimized <- compile(GEPA(metric = metric_exact_match()), extract, trainset)
-#> Baseline   62%  (zero-shot)
-#> Optimized  89%  (GEPA compile)
+optimized <- compile(
+  GEPA(metric = metric_exact_match(field = "intent")),
+  extract,
+  trainset
+)
 
+board <- pins::board_temp()
 pin_module_config(board, "extract-v2", optimized)
 ```
 


### PR DESCRIPTION
## Summary

Refreshes the pkgdown landing page (`pkgdown/index.md`) and supporting styles, drawing on the **new DSPy homepage** (sourced from `docs/overrides/home.html` in `stanfordnlp/dspy`, since the live site blocks fetching). The goal is to give newcomers a clear mental model of the framework's primitives before the example-heavy sections, and to mirror DSPy's "declare → compose → optimize" narrative in idiomatic R.

## What changed

**1. New "Compose programs with reusable primitives" section**
Introduces the core triad right after the hero, each primitive with its DSPy-style tagline, a dsprrr code snippet, and a learn-more link:
- **Signatures** — *"Declare your task."*
- **Modules** — *"Same interface, different strategy."*
- **Optimizers** — *"Compile your program against a metric."* (with a before/after metric)

**2. Reworked example gallery → "Define a task. Grow it into a system."**
Replaces the old Classification/Q&A/Extraction/Agents tabs with DSPy's set, each with a one-line caption, real code + output, and a learn-more link:

| Tab | Demonstrates | Key API |
|-----|--------------|---------|
| **Extract** | Multi-field typed output | `signature(...)` + `run()` + `get_output()` |
| **Agent** | Tool-using ReAct loop | `ellmer::tool()` + `module(type = "react")` |
| **Pipeline** | Multi-stage composition | `%>>%` over `chain_of_thought` modules |
| **Multimodal** | Image input | `ellmer::ContentImageRemote()` as a runtime input |
| **Optimize** | Compile against a metric | `dsp_trainset()` + `compile(GEPA(...))` |

**3. Visual polish** (`pkgdown/extra.scss`) — two-column primitive layout, tagline styling, steady-height gallery tabs, and learn-more link styling.

**4. Fixes**
- `README.Rmd` + `README.md`: the Status section linked to a non-existent `PLAN.md`; now points to the GitHub issues.
- Corrected `pin_module_config()` argument order in the optimizer snippet (`board, name, module`).

## API accuracy

Every function and article link was verified against `R/`, `man/`, and `NAMESPACE`. Notably, **dsprrr has no first-class image field in signatures** — multimodal works by naming an `image` input and passing an ellmer `Content` object at runtime, so the Multimodal tab shows that real path (per `vignettes/advanced-ellmer.Rmd`) rather than a fictional image type.

## Not done / please verify

- ⚠️ **`pkgdown::build_site()` was not run** — no R toolchain in the authoring environment. Structure was validated statically (balanced HTML; all 13 tab targets map to panes). **Please render locally to confirm the page looks right.**
- This matches DSPy's information architecture and copy, not its custom hero animation/JS. The page keeps dsprrr's existing Bootstrap tab components.
- The `0.41 → 0.63` / `62% → 89%` figures are illustrative (mirroring DSPy's homepage), not measured runs.

https://claude.ai/code/session_01MbshmSAj9LiAHCQYxNkDJA

---
_Generated by [Claude Code](https://claude.ai/code/session_01MbshmSAj9LiAHCQYxNkDJA)_