### PR TITLE
docs: fix pkgdown onboarding gaps (broken Tutorial 6 code, getting-started, tutorial threading, reference examples)

### DIFF
--- a/R/compile.R
+++ b/R/compile.R
@@ -13,6 +13,17 @@
 #' @param ... Additional arguments including trainset (training data)
 #'
 #' @return An optimized module
+#' @seealso [compile_module()] for the pipe-friendly wrapper with
+#'   validation and friendlier argument order
+#' @examples
+#' \dontrun{
+#' classifier <- module(signature("text -> sentiment"), type = "predict")
+#' trainset <- dsp_trainset(
+#'   text = c("I love it!", "Terrible experience"),
+#'   sentiment = c("positive", "negative")
+#' )
+#' optimized <- compile(LabeledFewShot(k = 2L), classifier, trainset)
+#' }
 #' @export
 compile <- S7::new_generic("compile", c("teleprompter", "program"))
 

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -49,6 +49,29 @@
 #' * [run_dataset()] for batch execution without metrics
 #' * [optimize_grid()] for parameter optimization
 #' * [metric_exact_match()], [metric_contains()] for built-in metrics
+#' @examples
+#' \dontrun{
+#' classifier <- module(
+#'   signature("text -> sentiment: enum('positive', 'negative', 'neutral')"),
+#'   type = "predict"
+#' )
+#'
+#' testset <- dsp_trainset(
+#'   text = c("I love it!", "Awful.", "It's fine."),
+#'   sentiment = c("positive", "negative", "neutral")
+#' )
+#'
+#' result <- evaluate(
+#'   classifier,
+#'   data = testset,
+#'   metric = metric_exact_match(field = "sentiment"),
+#'   .llm = ellmer::chat_openai()
+#' )
+#'
+#' result$mean_score # accuracy across the test set
+#' result$scores # per-example scores
+#' result$n_errors # examples where the metric failed
+#' }
 #' @export
 evaluate <- function(module, ...) {
   UseMethod("evaluate")

--- a/R/teleprompter-gepa.R
+++ b/R/teleprompter-gepa.R
@@ -56,15 +56,23 @@
 #' )
 #'
 #' \dontrun{
-#' # Feedback-aware metrics give the reflection step concrete guidance
+#' # Feedback-aware metrics give the reflection step concrete guidance.
+#' # During evaluation the metric receives the full expected row, so
+#' # extract the target field explicitly:
 #' feedback_metric <- metric_with_feedback(
 #'   function(prediction, expected) {
-#'     if (identical(as.character(prediction), as.character(expected))) {
+#'     if (identical(as.character(prediction), expected$answer)) {
 #'       list(score = 1, feedback = "Correct.")
 #'     } else {
 #'       list(
 #'         score = 0,
-#'         feedback = paste0("Expected '", expected, "' but got '", prediction, "'.")
+#'         feedback = paste0(
+#'           "Expected '",
+#'           expected$answer,
+#'           "' but got '",
+#'           prediction,
+#'           "'."
+#'         )
 #'       )
 #'     }
 #'   },

--- a/R/teleprompter-gepa.R
+++ b/R/teleprompter-gepa.R
@@ -46,6 +46,39 @@
 #' @param verbose Whether to print progress messages.
 #' @param track_stats Whether to record generation statistics.
 #'
+#' @examples
+#' # A small GEPA run: 6 candidates evolved over 2 generations
+#' tp <- GEPA(
+#'   metric = metric_exact_match(field = "answer"),
+#'   population_size = 6L,
+#'   generations = 2L,
+#'   seed = 42
+#' )
+#'
+#' \dontrun{
+#' # Feedback-aware metrics give the reflection step concrete guidance
+#' feedback_metric <- metric_with_feedback(
+#'   function(prediction, expected) {
+#'     if (identical(as.character(prediction), as.character(expected))) {
+#'       list(score = 1, feedback = "Correct.")
+#'     } else {
+#'       list(
+#'         score = 0,
+#'         feedback = paste0("Expected '", expected, "' but got '", prediction, "'.")
+#'       )
+#'     }
+#'   },
+#'   field = "answer"
+#' )
+#' tp <- GEPA(metric = feedback_metric, seed = 42)
+#'
+#' qa <- module(signature("question -> answer"), type = "predict")
+#' trainset <- dsp_trainset(
+#'   question = c("What is 2 + 2?", "What is the capital of France?"),
+#'   answer = c("4", "Paris")
+#' )
+#' optimized <- compile(tp, qa, trainset)
+#' }
 #' @export
 GEPA <- S7::new_class(
   "GEPA",

--- a/R/teleprompter.R
+++ b/R/teleprompter.R
@@ -80,6 +80,20 @@ compile_default <- function(teleprompter, program, trainset, ...) {
 #' @param sample Whether to randomly sample examples. Default is TRUE.
 #' @param seed Random seed for reproducibility. Default is 123.
 #'
+#' @examples
+#' # A teleprompter that adds 2 labeled training examples as demonstrations
+#' tp <- LabeledFewShot(k = 2L, seed = 42L)
+#' tp@k
+#'
+#' \dontrun{
+#' # Compile a module with few-shot demos drawn from the training set
+#' classifier <- module(signature("text -> sentiment"), type = "predict")
+#' trainset <- dsp_trainset(
+#'   text = c("I love it!", "Terrible experience", "It's okay"),
+#'   sentiment = c("positive", "negative", "neutral")
+#' )
+#' optimized <- compile(tp, classifier, trainset)
+#' }
 #' @export
 LabeledFewShot <- S7::new_class(
   "LabeledFewShot",
@@ -192,6 +206,26 @@ compile_labeled <- function(teleprompter, program, trainset, .llm = NULL, ...) {
 #'   grid search. Default is 50.
 #' @param verbose Whether to print progress messages. Default is TRUE.
 #'
+#' @examples
+#' # Search over two instruction variants
+#' variants <- data.frame(
+#'   id = c("terse", "detailed"),
+#'   instructions = c("Be concise.", "Explain your reasoning step by step.")
+#' )
+#' tp <- GridSearchTeleprompter(
+#'   variants = variants,
+#'   metric = metric_exact_match(field = "sentiment")
+#' )
+#'
+#' \dontrun{
+#' # Compile picks the variant that scores best on the training set
+#' classifier <- module(signature("text -> sentiment"), type = "predict")
+#' trainset <- dsp_trainset(
+#'   text = c("I love it!", "Terrible experience"),
+#'   sentiment = c("positive", "negative")
+#' )
+#' optimized <- compile(tp, classifier, trainset)
+#' }
 #' @usage NULL
 #' @export
 GridSearchTeleprompter <- S7::new_class(

--- a/man/GEPA.Rd
+++ b/man/GEPA.Rd
@@ -85,15 +85,23 @@ tp <- GEPA(
 )
 
 \dontrun{
-# Feedback-aware metrics give the reflection step concrete guidance
+# Feedback-aware metrics give the reflection step concrete guidance.
+# During evaluation the metric receives the full expected row, so
+# extract the target field explicitly:
 feedback_metric <- metric_with_feedback(
   function(prediction, expected) {
-    if (identical(as.character(prediction), as.character(expected))) {
+    if (identical(as.character(prediction), expected$answer)) {
       list(score = 1, feedback = "Correct.")
     } else {
       list(
         score = 0,
-        feedback = paste0("Expected '", expected, "' but got '", prediction, "'.")
+        feedback = paste0(
+          "Expected '",
+          expected$answer,
+          "' but got '",
+          prediction,
+          "'."
+        )
       )
     }
   },

--- a/man/GEPA.Rd
+++ b/man/GEPA.Rd
@@ -75,3 +75,37 @@ per-component selection in multi-step programs or inference-time
 search. Expect qualitatively similar behavior, not identical results.
 }
 }
+\examples{
+# A small GEPA run: 6 candidates evolved over 2 generations
+tp <- GEPA(
+  metric = metric_exact_match(field = "answer"),
+  population_size = 6L,
+  generations = 2L,
+  seed = 42
+)
+
+\dontrun{
+# Feedback-aware metrics give the reflection step concrete guidance
+feedback_metric <- metric_with_feedback(
+  function(prediction, expected) {
+    if (identical(as.character(prediction), as.character(expected))) {
+      list(score = 1, feedback = "Correct.")
+    } else {
+      list(
+        score = 0,
+        feedback = paste0("Expected '", expected, "' but got '", prediction, "'.")
+      )
+    }
+  },
+  field = "answer"
+)
+tp <- GEPA(metric = feedback_metric, seed = 42)
+
+qa <- module(signature("question -> answer"), type = "predict")
+trainset <- dsp_trainset(
+  question = c("What is 2 + 2?", "What is the capital of France?"),
+  answer = c("4", "Paris")
+)
+optimized <- compile(tp, qa, trainset)
+}
+}

--- a/man/GridSearchTeleprompter.Rd
+++ b/man/GridSearchTeleprompter.Rd
@@ -28,3 +28,24 @@ grid search. Default is 50.}
 A teleprompter that performs grid search over different instruction
 and template variants to find the best performing configuration.
 }
+\examples{
+# Search over two instruction variants
+variants <- data.frame(
+  id = c("terse", "detailed"),
+  instructions = c("Be concise.", "Explain your reasoning step by step.")
+)
+tp <- GridSearchTeleprompter(
+  variants = variants,
+  metric = metric_exact_match(field = "sentiment")
+)
+
+\dontrun{
+# Compile picks the variant that scores best on the training set
+classifier <- module(signature("text -> sentiment"), type = "predict")
+trainset <- dsp_trainset(
+  text = c("I love it!", "Terrible experience"),
+  sentiment = c("positive", "negative")
+)
+optimized <- compile(tp, classifier, trainset)
+}
+}

--- a/man/LabeledFewShot.Rd
+++ b/man/LabeledFewShot.Rd
@@ -34,3 +34,18 @@ A simple teleprompter that adds labeled examples from the training set
 as demonstrations to the module. This is the simplest form of few-shot
 learning.
 }
+\examples{
+# A teleprompter that adds 2 labeled training examples as demonstrations
+tp <- LabeledFewShot(k = 2L, seed = 42L)
+tp@k
+
+\dontrun{
+# Compile a module with few-shot demos drawn from the training set
+classifier <- module(signature("text -> sentiment"), type = "predict")
+trainset <- dsp_trainset(
+  text = c("I love it!", "Terrible experience", "It's okay"),
+  sentiment = c("positive", "negative", "neutral")
+)
+optimized <- compile(tp, classifier, trainset)
+}
+}

--- a/man/compile.Rd
+++ b/man/compile.Rd
@@ -24,3 +24,17 @@ This file defines the compile generic and its methods for optimizing
 DSPrrr modules using teleprompters.
 Compile Generic
 }
+\examples{
+\dontrun{
+classifier <- module(signature("text -> sentiment"), type = "predict")
+trainset <- dsp_trainset(
+  text = c("I love it!", "Terrible experience"),
+  sentiment = c("positive", "negative")
+)
+optimized <- compile(LabeledFewShot(k = 2L), classifier, trainset)
+}
+}
+\seealso{
+\code{\link[=compile_module]{compile_module()}} for the pipe-friendly wrapper with
+validation and friendlier argument order
+}

--- a/man/evaluate.Rd
+++ b/man/evaluate.Rd
@@ -63,6 +63,30 @@ Generic evaluation entry point for DSPrrr modules. Executes the module on a
 dataset, applies a metric to each example, and returns aggregate statistics
 together with the predictions and metadata required for downstream analysis.
 }
+\examples{
+\dontrun{
+classifier <- module(
+  signature("text -> sentiment: enum('positive', 'negative', 'neutral')"),
+  type = "predict"
+)
+
+testset <- dsp_trainset(
+  text = c("I love it!", "Awful.", "It's fine."),
+  sentiment = c("positive", "negative", "neutral")
+)
+
+result <- evaluate(
+  classifier,
+  data = testset,
+  metric = metric_exact_match(field = "sentiment"),
+  .llm = ellmer::chat_openai()
+)
+
+result$mean_score # accuracy across the test set
+result$scores # per-example scores
+result$n_errors # examples where the metric failed
+}
+}
 \seealso{
 \itemize{
 \item \code{\link[=run]{run()}} for executing without metrics

--- a/vignettes/getting-started.Rmd
+++ b/vignettes/getting-started.Rmd
@@ -106,6 +106,10 @@ optimized <- compile_module(
 
 Before you begin:
 
+1. **Get an API key** from an LLM provider supported by
+   [ellmer](https://ellmer.tidyverse.org/)—OpenAI and Anthropic are the most
+   common choices. The tutorials use OpenAI.
+
 2. **Install the packages**:
 ```r
 # install.packages("pak")
@@ -117,6 +121,24 @@ pak::pak("JamesHWade/dsprrr")
 # In your .Renviron file
 OPENAI_API_KEY=sk-your-key-here
 ```
+
+4. **Verify your setup**:
+```r
+library(dsprrr)
+dsprrr_sitrep()
+#> ── Packages ──
+#> ✔ ellmer 0.4.0 (OK)
+#> ✔ dsprrr 0.1.0
+#>
+#> ── Default Chat ──
+#> ✔ OpenAI (gpt-4o-mini)
+#>   Source: Auto-detected from OPENAI_API_KEY
+```
+
+`dsprrr_sitrep()` reports which API keys are visible, which chat provider
+dsprrr will use by default, and whether your installed packages are
+compatible. If something looks wrong, see
+[Troubleshooting](troubleshooting.html).
 
 ## Learning Path
 

--- a/vignettes/tutorial-deploy-to-production.Rmd
+++ b/vignettes/tutorial-deploy-to-production.Rmd
@@ -182,7 +182,7 @@ if (nrow(versions) > 1) {
 Track what your module does in production:
 
 ```{r save-traces}
-#| eval: false
+#| cassette: true
 # Run some predictions
 run(classifier, review = "Great product!", .llm = chat)
 run(classifier, review = "Not worth the money.", .llm = chat)
@@ -197,9 +197,8 @@ pin_trace(board, "sentiment-traces", classifier)
 Load and examine traces:
 
 ```{r analyze-traces}
-#| eval: false
-# Export as tibble
-traces <- export_traces(classifier, format = "tibble")
+# Export as a tibble
+traces <- export_traces(classifier)
 traces
 
 # Summary statistics
@@ -239,7 +238,7 @@ Here's a complete production workflow:
 # 1. Build and optimize
 dev_module <- module(sig, type = "predict")
 dev_module$optimize_grid(
-  devset = trainset,
+  data = trainset,
   metric = metric_exact_match(field = "sentiment"),
   parameters = list(temperature = c(0, 0.3, 0.7))
 )
@@ -251,7 +250,11 @@ optimized <- compile_module(
   trainset = trainset
 )
 
-# 3. Evaluate on test data
+# 3. Evaluate on held-out test data (same columns as the trainset)
+testset <- dsp_trainset(
+  review = c("Exceeded expectations!", "Broke after a week.", "It's fine."),
+  sentiment = c("positive", "negative", "neutral")
+)
 evaluate(optimized, testset, metric = metric_exact_match(field = "sentiment"))
 
 # 4. Save if good enough
@@ -260,9 +263,11 @@ pin_module_config(prod_board, "sentiment-v1", optimized)
 
 # === PRODUCTION ===
 # 1. Load the saved configuration
-prod_module <- restore_module_config(prod_board, "sentiment-v1")
+config <- pins::pin_read(prod_board, "sentiment-v1")
+prod_module <- restore_module_config(config)
 
 # 2. Use it
+customer_review <- "Arrived quickly and works perfectly."
 result <- run(prod_module, review = customer_review, .llm = chat_openai())
 
 # 3. Periodically save traces for monitoring
@@ -297,11 +302,15 @@ Choose based on your deployment environment.
 Set up regular checks:
 
 ```{r monitoring, eval=FALSE}
-# Daily: Check trace summary
-module$trace_summary()
+# Daily: Check trace summary (tokens, cost, errors)
+prod_module$trace_summary()
 
-# Weekly: Evaluate on held-out samples
-evaluate(module, weekly_sample, metric = metric_exact_match())
+# Weekly: Evaluate on a fresh sample of labeled production data
+weekly_sample <- dsp_trainset(
+  review = c("Saved me hours!", "Refund please.", "Average at best."),
+  sentiment = c("positive", "negative", "neutral")
+)
+evaluate(prod_module, weekly_sample, metric = metric_exact_match(field = "sentiment"))
 
 # Monthly: Compare to baseline
 # If accuracy drops, investigate or retrain

--- a/vignettes/tutorial-improve-with-demos.Rmd
+++ b/vignettes/tutorial-improve-with-demos.Rmd
@@ -38,7 +38,7 @@ if (should_eval) {
 
 In [Tutorial 3](tutorial-structured-outputs.html), you built extractors that return structured data. But how do you make them more accurate? The answer: **show the LLM examples of correct behavior**.
 
-This technique—called few-shot learning—is one of the most powerful ways to improve LLM performance.
+This technique—called few-shot learning—is one of the most powerful ways to improve LLM performance. Our running example here is support ticket triage: a classification task ambiguous enough that a handful of labeled examples makes a measurable difference. The same recipe—baseline, examples, re-measure—works for the sentiment classifier from Tutorial 2 and the extractors from Tutorial 3.
 
 **Time**: 25-30 minutes
 

--- a/vignettes/tutorial-optimize-your-module.Rmd
+++ b/vignettes/tutorial-optimize-your-module.Rmd
@@ -40,6 +40,8 @@ In [Tutorial 4](tutorial-improve-with-demos.html), you improved your module with
 
 The answer: **let dsprrr search for you**.
 
+We return to a sentiment classifier—this time for product reviews—so you can see how much headroom parameter tuning adds on top of few-shot demos. This is also the module you'll take to production in [Tutorial 6](tutorial-deploy-to-production.html).
+
 **Time**: 30-35 minutes
 
 ## What You'll Build

--- a/vignettes/tutorial-structured-outputs.Rmd
+++ b/vignettes/tutorial-structured-outputs.Rmd
@@ -38,7 +38,7 @@ if (should_eval) {
 
 In [Tutorial 2](tutorial-build-classifier.html), you built a classifier that returns a single value. But real extraction tasks need multiple fields: names *and* dates, sentiment *and* confidence, entities *and* relationships.
 
-In this tutorial, you'll extract complex, structured data from text.
+In this tutorial, you'll extract complex, structured data from text. We're switching the running example from sentiment labels to news articles and emails because extraction is where multi-field outputs shine—but the workflow you learned in Tutorial 2 (signature → module → run) stays exactly the same. Only the output type grows richer.
 
 **Time**: 25-30 minutes
 


### PR DESCRIPTION
## Summary

A full audit of the pkgdown site found the 6-step tutorial learning path is substantive and cassette-backed, but three gaps undermined onboarding. This PR fixes them. Resolves dsprrr-2xe.

### Tutorial 6 (Production) — broken code fixed, two more steps now execute
- `production-workflow` chunk: `optimize_grid(devset =)` → `data =` (the actual argument), defined the previously-undefined `testset` and `customer_review`, and fixed module restoration to the documented `pin_read()` + `restore_module_config(config)` pattern (it was called with board+name, which is not a supported signature)
- `analyze-traces` chunk: removed nonexistent `format = "tibble"` argument from `export_traces()`
- Steps 7–8 (save/analyze traces) were `eval=false` despite a recorded cassette existing on disk — re-enabled, so the rendered page now shows real trace output instead of pseudocode
- Monitoring example is now self-consistent (uses `prod_module` and a defined `weekly_sample`)

### Getting Started page
- Prerequisites list started at "2." with no first item — added step 1 (get an API key) and a new step 4: verify setup with `dsprrr_sitrep()`, linked to Troubleshooting

### Tutorial narrative threading
Tutorials 3–5 each switch example domains with no explanation. Added bridge paragraphs explaining why the domain changes and how the pattern carries forward, including an explicit T5→T6 hand-off ("this is the module you'll take to production").

### Reference examples
Added `@examples` to previously example-less core API: `evaluate()`, `compile` generic, `LabeledFewShot`, `GridSearchTeleprompter`, and `GEPA` (including a feedback-metric example matching the documented `metric_with_feedback()` protocol). Constructor examples are runnable; LLM-dependent parts are `\dontrun`.

## Verification
- All 5 touched vignettes render successfully from existing VCR cassettes (no re-recording needed)
- All new runnable example code executed without error
- `devtools::check()`: 0 errors, 0 warnings, 2 pre-existing environmental NOTEs

## Follow-up
- dsprrr-i84: record cassettes for getting-started.Rmd so the landing page shows real output (requires API keys)

🤖 Generated with [Claude Code](https://claude.com/claude-code)