### PR TITLE
fix: release-unblock + silent-failure correctness fixes (audit wave 1)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -26,7 +26,7 @@ Imports:
     cachem,
     cli,
     digest,
-    ellmer (>= 0.4.0.9000),
+    ellmer (>= 0.4.1),
     glue,
     jsonlite,
     methods,
@@ -38,8 +38,6 @@ Imports:
     tibble,
     withr
 Suggests:
-    future,
-    lifecycle,
     callr,
     coro,
     dials,
@@ -60,8 +58,6 @@ Suggests:
     vcr (>= 2.0.0),
     vitals,
     yardstick
-Remotes:
-    tidyverse/ellmer
 Collate:
     'accessors.R'
     'assertion-helpers.R'

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,43 @@
+# dsprrr (development version)
+
+First development changelog. dsprrr is experimental; the API may change.
+
+## Bug fixes
+
+* `BootstrapFewShot` now harvests demonstrations when the metric targets a
+  specific output field (e.g. `metric_exact_match(field = "answer")`).
+  Previously the single-module path passed a bare value to the metric, which
+  errored internally and silently bootstrapped zero demos (#dsprrr-s3b).
+
+* Failed items in a batch are now counted and reported. Previously
+  `print()` on a batch result always said "All items completed successfully"
+  because it looked for the error in the wrong place (#dsprrr-8l0).
+
+* Unknown or misspelled types in a signature string (e.g. `"q -> a: interger"`)
+  now raise an error suggesting the closest valid type, instead of silently
+  becoming a string field (#dsprrr-47p).
+
+* `optimize_grid()` now gives a clear error when every trial fails (for
+  example, when the API is unreachable) instead of a cryptic
+  "attempt to select less than one element" (#dsprrr-hew).
+
+* `.cache` is now honored by all module types and pipelines, not only
+  `PredictModule`. Previously it was silently dropped (with a spurious
+  "unknown input" warning) for every other module (#dsprrr-jup).
+
+* Evaluation now treats a failed prediction as a score of 0 rather than
+  dropping it from the mean, so optimizers no longer prefer configurations
+  that fail on most of the data (#dsprrr-tn1).
+
+## Internal
+
+* Tests now isolate the on-disk cache to a temporary directory, so running
+  the test suite no longer writes into the package source tree (#dsprrr-63v).
+
+## Packaging
+
+* Lowered the minimum `ellmer` requirement to the released `>= 0.4.1` and
+  removed the `Remotes:` entry, so the package installs from CRAN-released
+  dependencies (#dsprrr-w0e).
+
+* Removed unused `Suggests`: `future` and `lifecycle`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,11 +4,6 @@ First development changelog. dsprrr is experimental; the API may change.
 
 ## Bug fixes
 
-* `BootstrapFewShot` now harvests demonstrations when the metric targets a
-  specific output field (e.g. `metric_exact_match(field = "answer")`).
-  Previously the single-module path passed a bare value to the metric, which
-  errored internally and silently bootstrapped zero demos (#dsprrr-s3b).
-
 * Failed items in a batch are now counted and reported. Previously
   `print()` on a batch result always said "All items completed successfully"
   because it looked for the error in the wrong place (#dsprrr-8l0).
@@ -21,13 +16,13 @@ First development changelog. dsprrr is experimental; the API may change.
   example, when the API is unreachable) instead of a cryptic
   "attempt to select less than one element" (#dsprrr-hew).
 
-* `.cache` is now honored by all module types and pipelines, not only
-  `PredictModule`. Previously it was silently dropped (with a spurious
-  "unknown input" warning) for every other module (#dsprrr-jup).
-
-* Evaluation now treats a failed prediction as a score of 0 rather than
-  dropping it from the mean, so optimizers no longer prefer configurations
-  that fail on most of the data (#dsprrr-tn1).
+* `.cache` is now a validated, first-class argument to `run()` and `forward()`
+  for every module type, instead of triggering a spurious "unknown input"
+  warning and being dropped for non-`PredictModule` modules (#dsprrr-jup).
+  `PredictModule` (and the wrapper/few-shot modules that delegate to it) honor
+  it for the structured-output cache; modules that drive the LLM directly
+  (e.g. `RAGModule`, `ReActModule`, `RLMModule`) accept `.cache` but do not yet
+  route their own calls through the cache (#dsprrr-aa2).
 
 ## Internal
 

--- a/R/cache.R
+++ b/R/cache.R
@@ -19,7 +19,10 @@ NULL
 #' without writing into the current working directory.
 #' @noRd
 default_disk_cache_path <- function() {
-  Sys.getenv("DSPRRR_CACHE_PATH", unset = ".dsprrr_cache")
+  # Treat an empty-string env var the same as unset, so DSPRRR_CACHE_PATH=""
+  # does not resolve the cache to "" (which would write into the working dir).
+  path <- Sys.getenv("DSPRRR_CACHE_PATH", unset = "")
+  if (nzchar(path)) path else ".dsprrr_cache"
 }
 
 #' Configure dsprrr Cache

--- a/R/cache.R
+++ b/R/cache.R
@@ -12,6 +12,16 @@ NULL
 
 # ── Cache Configuration ──────────────────────────────────────────────────────
 
+#' Default on-disk cache directory
+#'
+#' Honors the `DSPRRR_CACHE_PATH` environment variable so the test suite (and
+#' users with read-only working directories) can redirect the disk cache
+#' without writing into the current working directory.
+#' @noRd
+default_disk_cache_path <- function() {
+  Sys.getenv("DSPRRR_CACHE_PATH", unset = ".dsprrr_cache")
+}
+
 #' Configure dsprrr Cache
 #'
 #' @description
@@ -69,7 +79,7 @@ configure_cache <- function(
   enable = TRUE,
   enable_memory = TRUE,
   enable_disk = TRUE,
-  disk_path = ".dsprrr_cache",
+  disk_path = default_disk_cache_path(),
   memory_max_entries = 1000L,
   disk_max_size = 500 * 1024^2,
   disk_max_age = Inf
@@ -245,7 +255,7 @@ get_cache_config <- function() {
       enable = !env_disabled,
       enable_memory = TRUE,
       enable_disk = TRUE,
-      disk_path = ".dsprrr_cache",
+      disk_path = default_disk_cache_path(),
       memory_max_entries = 1000L,
       disk_max_size = 500 * 1024^2,
       disk_max_age = Inf

--- a/R/module-base.R
+++ b/R/module-base.R
@@ -83,7 +83,8 @@ Module <- R6::R6Class(
       .verbose = FALSE,
       .parallel = FALSE,
       .progress = TRUE,
-      .return_format = "simple"
+      .return_format = "simple",
+      .cache = NULL
     ) {
       inputs <- list(...)
 
@@ -131,7 +132,12 @@ Module <- R6::R6Class(
         results <- vector("list", max_length)
         for (i in seq_len(max_length)) {
           input_set <- lapply(inputs, `[[`, i)
-          result <- self$forward(input_set, .llm = .llm, trace = TRUE)
+          result <- self$forward(
+            input_set,
+            .llm = .llm,
+            trace = TRUE,
+            .cache = .cache
+          )
 
           if (.return_format == "simple") {
             results[[i]] <- result$output[[1]]
@@ -148,7 +154,7 @@ Module <- R6::R6Class(
       }
 
       # Single input processing
-      result <- self$forward(inputs, .llm = .llm, trace = TRUE)
+      result <- self$forward(inputs, .llm = .llm, trace = TRUE, .cache = .cache)
 
       if (.return_format == "simple") {
         return(result$output[[1]])

--- a/R/module-base.R
+++ b/R/module-base.R
@@ -86,6 +86,11 @@ Module <- R6::R6Class(
       .return_format = "simple",
       .cache = NULL
     ) {
+      # Validate .cache here too: callers can reach $run() directly (not only
+      # via the run() generic, which validates separately), so a malformed
+      # value must fail loudly instead of being silently forwarded.
+      validate_cache_arg(.cache)
+
       inputs <- list(...)
 
       # Validate inputs against signature

--- a/R/optimize.R
+++ b/R/optimize.R
@@ -458,6 +458,22 @@ module_trials <- function(
   }
 
   scores <- trials$score
+  if (all(is.na(scores))) {
+    cli::cli_warn(c(
+      "All {nrow(trials)} optimization trial{?s} failed (no valid scores).",
+      "i" = "Check that the LLM is reachable and the metric returns numeric scores.",
+      "i" = "Inspect the {.field trials} list-column for per-trial details."
+    ))
+    return(tibble::tibble(
+      n_trials = nrow(trials),
+      best_trial = NA_integer_,
+      best_score = NA_real_,
+      mean_score = NA_real_,
+      std_error = NA_real_,
+      best_params = list(NULL),
+      trials = list(trials)
+    ))
+  }
   best_idx <- if (objective == "maximize") {
     which.max(scores)
   } else {

--- a/R/run.R
+++ b/R/run.R
@@ -72,6 +72,27 @@ run <- function(module, ...) {
   UseMethod("run")
 }
 
+#' Validate the `.cache` argument
+#'
+#' Shared by [run()] methods so every module type rejects malformed `.cache`
+#' values the same way.
+#' @noRd
+validate_cache_arg <- function(.cache) {
+  if (!is.null(.cache)) {
+    if (!is.logical(.cache) || length(.cache) != 1 || is.na(.cache)) {
+      cache_value <- .cache
+      cli::cli_abort(c(
+        "{.arg .cache} must be {.code TRUE}, {.code FALSE}, or {.code NULL}",
+        "x" = "You provided: {.cls {class(cache_value)}} with value {.val {cache_value}}",
+        "i" = "{.code TRUE} attempts to use cache (if available)",
+        "i" = "{.code FALSE} bypasses cache for this call",
+        "i" = "{.code NULL} uses global cache configuration (default)"
+      ))
+    }
+  }
+  invisible(.cache)
+}
+
 #' @export
 run.Module <- function(
   module,
@@ -82,9 +103,11 @@ run.Module <- function(
   .parallel_method = c("ellmer", "mirai"),
   .progress = TRUE,
   .return_format = "simple",
-  .show_prompt = FALSE
+  .show_prompt = FALSE,
+  .cache = NULL
 ) {
   .parallel_method <- match.arg(.parallel_method)
+  validate_cache_arg(.cache)
 
   # Show prompt preview if requested
   if (.show_prompt) {
@@ -98,7 +121,8 @@ run.Module <- function(
     .verbose = .verbose,
     .parallel = .parallel,
     .progress = .progress,
-    .return_format = .return_format
+    .return_format = .return_format,
+    .cache = .cache
   )
 }
 
@@ -118,18 +142,7 @@ run.PredictModule <- function(
   .parallel_method <- match.arg(.parallel_method)
 
   # Validate .cache parameter
-  if (!is.null(.cache)) {
-    if (!is.logical(.cache) || length(.cache) != 1 || is.na(.cache)) {
-      cache_value <- .cache
-      cli::cli_abort(c(
-        "{.arg .cache} must be {.code TRUE}, {.code FALSE}, or {.code NULL}",
-        "x" = "You provided: {.cls {class(cache_value)}} with value {.val {cache_value}}",
-        "i" = "{.code TRUE} attempts to use cache (if available)",
-        "i" = "{.code FALSE} bypasses cache for this call",
-        "i" = "{.code NULL} uses global cache configuration (default)"
-      ))
-    }
-  }
+  validate_cache_arg(.cache)
 
   # Show prompt preview if requested
   if (.show_prompt) {
@@ -1499,7 +1512,11 @@ print.dsprrr_batch_result <- function(x, ...) {
   n_errors <- sum(vapply(
     x,
     function(item) {
-      isTRUE(item$error) || inherits(item$output, "error")
+      # Errors from create_error_result() are stored in metadata$error with
+      # output = NA; also tolerate other shapes defensively.
+      !is.null(item$metadata$error) ||
+        isTRUE(item$error) ||
+        inherits(item$output, "error")
     },
     logical(1)
   ))

--- a/R/signature-parser.R
+++ b/R/signature-parser.R
@@ -393,6 +393,10 @@ parse_type_string <- function(type_str, field_name = NULL) {
   # Handle common type patterns
   type_str <- trimws(type_str)
 
+  # Catch unknown / misspelled simple types early with a helpful error,
+  # rather than silently falling through to the type_string() default below.
+  validate_type_string(type_str)
+
   # Handle Optional types
   if (grepl("^Optional\\[", type_str)) {
     inner_type_str <- sub("^Optional\\[(.*)\\]$", "\\1", type_str)
@@ -718,8 +722,15 @@ validate_type_string <- function(type_str, context = "output") {
 
   if (!is_known && !grepl("\\[|\\(", type_str)) {
     # Unknown simple type
+    suggestion <- find_closest_match(
+      type_str,
+      c(known_types, known_constructors)
+    )
     cli::cli_abort(c(
       "Unknown type: {.val {type_str}}",
+      if (!is.null(suggestion)) {
+        c("i" = "Did you mean {.code {suggestion}}?")
+      },
       "i" = "Available simple types: {.code string}, {.code number}, {.code integer}, {.code boolean}",
       "i" = "Available complex types: {.code enum('a', 'b')}, {.code array(string)}, {.code object}"
     ))

--- a/man/configure_cache.Rd
+++ b/man/configure_cache.Rd
@@ -8,7 +8,7 @@ configure_cache(
   enable = TRUE,
   enable_memory = TRUE,
   enable_disk = TRUE,
-  disk_path = ".dsprrr_cache",
+  disk_path = default_disk_cache_path(),
   memory_max_entries = 1000L,
   disk_max_size = 500 * 1024^2,
   disk_max_age = Inf

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -26,7 +26,11 @@ withr::defer(
   {
     dsprrr::clear_cache()
     unlink(dsprrr_test_cache_dir, recursive = TRUE)
-    dsprrr::configure_cache()
+    # Restore the production default explicitly. teardown defers run LIFO, so
+    # DSPRRR_CACHE_PATH set by local_envvar() above is still in scope here; a
+    # bare configure_cache() would otherwise re-read it and point disk_path at
+    # the just-unlinked test dir.
+    dsprrr::configure_cache(disk_path = ".dsprrr_cache")
   },
   envir = testthat::teardown_env()
 )

--- a/tests/testthat/setup.R
+++ b/tests/testthat/setup.R
@@ -1,0 +1,32 @@
+# Isolate the on-disk cache during the test suite.
+#
+# Without this, the default disk cache writes into the working directory
+# (tests/testthat/.dsprrr_cache during R CMD check), which pollutes the package
+# source tree and leaks state across runs -- a documented source of flaky tests.
+#
+# We redirect the cache to a temporary directory via DSPRRR_CACHE_PATH (so even
+# bare configure_cache() calls land there) and disable the disk tier by default.
+# Cache-behavior tests that need disk caching opt back in with their own
+# tempdirs, which take precedence over this default.
+
+dsprrr_test_cache_dir <- file.path(tempdir(), "dsprrr-test-cache")
+dir.create(dsprrr_test_cache_dir, showWarnings = FALSE, recursive = TRUE)
+
+withr::local_envvar(
+  DSPRRR_CACHE_PATH = dsprrr_test_cache_dir,
+  .local_envir = testthat::teardown_env()
+)
+
+dsprrr::configure_cache(
+  enable_disk = FALSE,
+  disk_path = dsprrr_test_cache_dir
+)
+
+withr::defer(
+  {
+    dsprrr::clear_cache()
+    unlink(dsprrr_test_cache_dir, recursive = TRUE)
+    dsprrr::configure_cache()
+  },
+  envir = testthat::teardown_env()
+)

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -1123,3 +1123,17 @@ test_that("dsprrr_sitrep shows disabled cache", {
 
   expect_false(result$cache_enabled)
 })
+
+test_that(".cache is accepted and validated for non-Predict modules (dsprrr-jup)", {
+  # Regression: only run.PredictModule declared .cache; for every other module
+  # type and pipelines it fell into ... -> treated as an unknown signature input
+  # (spurious warning) and dropped.
+  mod <- module_fn("text -> answer", function(text) paste("Echo:", text))
+
+  expect_no_warning(res <- run(mod, text = "hi", .cache = FALSE))
+  expect_equal(res$answer, "Echo: hi")
+
+  # Invalid .cache values are rejected the same way as for PredictModule.
+  expect_error(run(mod, text = "hi", .cache = "yes"), "must be")
+  expect_error(run(mod, text = "hi", .cache = NA), "must be")
+})

--- a/tests/testthat/test-optimize.R
+++ b/tests/testthat/test-optimize.R
@@ -248,3 +248,22 @@ test_that("module_metric_summary handles modules without trials", {
   metrics <- module_metrics(mod)
   expect_equal(nrow(metrics), 0)
 })
+
+test_that("module_trials() warns and returns an inspectable summary when all trials fail (dsprrr-hew)", {
+  # Regression: which.max() on all-NA scores returns integer(0), so indexing
+  # threw "attempt to select less than one element" instead of a clear message.
+  mod <- module(signature("question -> answer"), type = "predict")
+  mod$state$trials <- tibble::tibble(
+    trial_id = 1:3,
+    score = NA_real_,
+    parameters = list(list(a = 1), list(a = 2), list(a = 3))
+  )
+
+  expect_warning(
+    summary <- module_trials(mod),
+    "trial.*failed"
+  )
+  expect_equal(summary$n_trials, 3L)
+  expect_true(is.na(summary$best_score))
+  expect_true(is.na(summary$best_trial))
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1065,3 +1065,37 @@ test_that("mock_batch_chat handles character response directly", {
 
   expect_true(inherits(result, "Chat"))
 })
+
+test_that("print.dsprrr_batch_result counts failed items (dsprrr-8l0)", {
+  # Regression: the error predicate read item$error / inherits(item$output,
+  # "error"), but create_error_result() stores the message in metadata$error
+  # with output = NA, so n_errors was always 0 and failures printed as success.
+  result <- structure(
+    list(
+      list(output = "ok", chat = NULL, metadata = list()),
+      list(
+        output = NA,
+        chat = NULL,
+        metadata = list(error = "intentional failure", batch_index = 2L)
+      )
+    ),
+    class = c("dsprrr_batch_result", "list")
+  )
+
+  out <- cli::cli_fmt(print(result))
+  expect_true(any(grepl("Errors", out)))
+  expect_true(any(grepl("1 of 2", out)))
+  expect_false(any(grepl("All items completed successfully", out)))
+})
+
+test_that("print.dsprrr_batch_result reports success when there are no errors", {
+  result <- structure(
+    list(
+      list(output = "a", chat = NULL, metadata = list()),
+      list(output = "b", chat = NULL, metadata = list())
+    ),
+    class = c("dsprrr_batch_result", "list")
+  )
+  out <- cli::cli_fmt(print(result))
+  expect_true(any(grepl("All items completed successfully", out)))
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -1082,6 +1082,9 @@ test_that("print.dsprrr_batch_result counts failed items (dsprrr-8l0)", {
     class = c("dsprrr_batch_result", "list")
   )
 
+  # print.dsprrr_batch_result emits only via cli, so cli::cli_fmt() captures it
+  # reliably. Do NOT switch to capture.output(type = "message"): cli writes to
+  # stdout, so that pattern silently captures nothing.
   out <- cli::cli_fmt(print(result))
   expect_true(any(grepl("Errors", out)))
   expect_true(any(grepl("1 of 2", out)))

--- a/tests/testthat/test-signature-parser.R
+++ b/tests/testthat/test-signature-parser.R
@@ -356,3 +356,29 @@ test_that("find_closest_match works correctly", {
   # No close match
   expect_null(dsprrr:::find_closest_match("zzzzz", candidates))
 })
+
+test_that("unknown / misspelled types raise an error instead of silently becoming strings (dsprrr-47p)", {
+  # Regression: validate_type_string() existed but was never called, so typo'd
+  # types silently fell through to the type_string() default.
+  expect_error(parse_signature("question -> answer: interger"), "Unknown type")
+  expect_error(
+    parse_signature("question -> answer: frobnicate"),
+    "Unknown type"
+  )
+  expect_error(parse_signature("question -> answer: numbr"), "Unknown type")
+
+  # The error suggests the closest valid type.
+  expect_error(parse_signature("q -> a: integ"), "Did you mean")
+})
+
+test_that("valid types still parse after type validation is wired in", {
+  expect_no_error(parse_signature("q -> a: string"))
+  expect_no_error(parse_signature("q -> a: integer"))
+  expect_no_error(parse_signature("q -> a: number"))
+  expect_no_error(parse_signature("q -> a: boolean"))
+  expect_no_error(parse_signature("q -> a: enum('x', 'y')"))
+  expect_no_error(parse_signature("q -> a: array(string)"))
+  # Python-style aliases remain valid.
+  expect_no_error(parse_signature("q -> a: str"))
+  expect_no_error(parse_signature("q -> a: int"))
+})


### PR DESCRIPTION
First wave of fixes from a full codebase audit. These are the highest-value, lowest-risk findings: they unblock a CRAN release and stop four silent failures, with no changes to optimizer behavior (that's coming in a separate, more carefully validated wave).

## Release readiness (`dsprrr-w0e`)
- Lower the `ellmer` requirement to the released `>= 0.4.1` and drop the CRAN-forbidden `Remotes: tidyverse/ellmer` entry. The package could not be submitted to CRAN with either in place; ellmer 0.4.1 exports every symbol used.
- Remove unused `Suggests`: `future` and `lifecycle` (zero references anywhere).
- Add `NEWS.md`.

## Correctness
- **`print.dsprrr_batch_result` always reported success on failed batches** (`dsprrr-8l0`). The error predicate read `item$error` / `inherits(item$output, "error")`, but `create_error_result()` stores the message in `metadata$error` with `output = NA`, so `n_errors` was always 0.
- **Unknown/misspelled signature types silently became string fields** (`dsprrr-47p`). `validate_type_string()` was fully written (with a closest-match suggestion) but never called. Now `signature("q -> a: interger")` errors and suggests `integer`.
- **`module_trials()` crashed with a cryptic base-R error when all trials failed** (`dsprrr-hew`). `which.max()` on all-`NA` scores returns `integer(0)`, so indexing threw "attempt to select less than one element". Now it warns and returns an inspectable summary.
- **`.cache` was silently dropped for every non-`PredictModule` module and pipelines** (`dsprrr-jup`). Only `run.PredictModule` declared `.cache`; elsewhere it fell into `...`, was flagged as an unknown signature input (spurious warning), and ignored. Now `run.Module` and the base `$run()` accept, validate, and forward it.

## Test isolation (`dsprrr-63v`)
- Add `tests/testthat/setup.R` and a `DSPRRR_CACHE_PATH` env var so the disk cache is redirected to a temp dir during the suite. Previously tests wrote `.dsprrr_cache` into the package source tree (which CRAN flags) and leaked state across runs.

## Testing
- Full suite: **3008 passing**, no new failures. (9 pre-existing failures in `print`-output-capture tests are unrelated — they capture the message stream while cli writes to stdout in this local config; verified identical on a clean tree.)
- New regression tests for each fix.
- `air format --check .` passes.

## Follow-up
Filed as beads issues from the same audit, in priority order: the optimizer-correctness cluster (`dsprrr-s3b` BootstrapFewShot zero-demos, `dsprrr-tn1` failure-blind mean, `dsprrr-pcd` per-attempt diversity), silent-failure handling in `evaluate()`/batch (`dsprrr-hqp`, `dsprrr-lr7`), and ~30 more across API consistency, tests, parser, metrics, and packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)