### PR TITLE
Clarify Flex and harden executable optimization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -134,9 +134,11 @@ First development changelog. dsprrr is experimental; the API may change.
 
 * Larger executable Flex requests now cross `mcp_repl_runner()` reliably.
   dsprrr realizes `mcptools` wrapper arguments before invocation and compacts
-  large host-generated requests before transport. A plain file preview is
-  accepted only when it contains one bounded current-step Flex frame;
-  ambiguous previews and all RLM previews still fail closed.
+  only host-generated requests that exceed the wire bound, preserving fitting
+  high-entropy requests. Flex control frames are decoded from raw inline output
+  before display truncation. A plain file preview is accepted only when it
+  contains one bounded current-step Flex frame; malformed inline frames,
+  ambiguous previews, and all RLM previews still fail closed.
 
 * Metric correctness and composition are stricter: token F1 uses multiset
   overlap, numeric field equality no longer fails solely because one value is

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,18 +4,18 @@ First development changelog. dsprrr is experimental; the API may change.
 
 ## New features
 
-* `flex()` adds an experimental, structurally optimizable module with two
-  source modes. The safe default is a bounded versioned JSON graph with
+* `flex()` lets GEPA optimize how a module executes—not only its instructions—
+  with two source modes. The safe default is a bounded versioned JSON graph with
   allowlisted Predict and Chain-of-Thought steps, typed references, zero-step
   deterministic plans, and transactional validation. Opt-in executable mode
   evaluates a complete R `forward()` program only in a fresh runner from an
   explicit `interpreter_factory`; a versioned JSON bridge exposes the
   DSPy Flex primitive family and named host tools, enforces runtime predictor
   and direct host-tool limits, validates typed outputs, and requires an
-  advertised sandbox by default. Guest bindings are isolated from bridge state,
-  large values use structured runner results when available, and tools retain
-  their host closure environments while generated source never evaluates in the
-  host R session.
+  advertised sandbox by default. Guest bindings use a separate lexical
+  environment from bridge state, large values use structured runner results
+  when available, and tools retain their host closure environments while
+  generated source never evaluates in the host R session.
 
 * `GEPA()` now searches complete, validated component candidates for ordinary
   programs and programs containing Flex leaves, spanning ordinary instructions
@@ -131,6 +131,12 @@ First development changelog. dsprrr is experimental; the API may change.
   execution supports declarative zero/one-step Flex, while multi-step and
   executable requests fail before provider work until a row-isolated async
   engine is available.
+
+* Larger executable Flex requests now cross `mcp_repl_runner()` reliably.
+  dsprrr realizes `mcptools` wrapper arguments before invocation and compacts
+  large host-generated requests before transport. A plain file preview is
+  accepted only when it contains one bounded current-step Flex frame;
+  ambiguous previews and all RLM previews still fail closed.
 
 * Metric correctness and composition are stricter: token F1 uses multiset
   overlap, numeric field equality no longer fails solely because one value is

--- a/R/flex-code-bridge.R
+++ b/R/flex-code-bridge.R
@@ -249,9 +249,10 @@ flex_code_sandbox_template <- function() {
     base::invisible(envelope)
   }
 
-  # Bridge state lives outside the guest's lexical parent chain. Public DSL
-  # closures can expose replay state through R introspection, but never the
-  # invocation nonce, input context, source, or control-frame encoder.
+  # Keeping bridge state outside the guest's lexical parent chain limits
+  # accidental reachability through public DSL closures. The nonce correlates
+  # one response with the current replay step; it is not a secret or an
+  # authentication boundary for guest code.
   .flex_bridge_env <- new.env(parent = baseenv())
   .flex_bridge_env$.responses <- .flex_responses
   .flex_bridge_env$.call_index <- 0L
@@ -972,7 +973,6 @@ flex_code_execute <- function(
   llm_resolver = NULL,
   ...
 ) {
-  nonce <- rlm_control_nonce()
   wrapper <- flex_code_wrapper()
   output_fields <- names(flex_signature_output_types(outer_signature))
 
@@ -999,11 +999,12 @@ flex_code_execute <- function(
       frame_limit <- flex_code_frame_limit(lease$policy)
 
       repeat {
+        step_nonce <- rlm_control_nonce()
         result <- execute_code_runner(
           runner,
           wrapper,
           context = list(
-            nonce = nonce,
+            nonce = step_nonce,
             inputs = inputs,
             module_src = module_src,
             frame_limit = frame_limit,
@@ -1011,7 +1012,9 @@ flex_code_execute <- function(
             tool_names = as.list(names(tools)),
             responses = responses
           ),
-          .control_nonce = nonce
+          .control_nonce = step_nonce,
+          .control_protocol = "flex",
+          .control_max_bytes = frame_limit
         )
         if (!isTRUE(result$success)) {
           cli::cli_abort(
@@ -1025,7 +1028,7 @@ flex_code_execute <- function(
         }
         control <- flex_code_decode_control(
           list(result$result, result$stdout, result$stderr, result$error),
-          nonce
+          step_nonce
         )
         if (is.null(control)) {
           cli::cli_abort(

--- a/R/mcp-repl-runner.R
+++ b/R/mcp-repl-runner.R
@@ -16,12 +16,13 @@
 #' conservative and can only fail closed; dsprrr never follows a disclosed
 #' sandbox file path from the host process.
 #'
-#' Executable Flex may recover a plain file preview only when its raw response
-#' contains exactly one bounded control frame for the current replay step. The
-#' frame remains untrusted and is still subject to Flex's host-side request,
+#' Executable Flex decodes one bounded current-step frame from raw output before
+#' display truncation. It may also recover that frame from a plain file preview.
+#' The frame remains untrusted and is still subject to Flex's host-side request,
 #' budget, and output validation. Ambiguous previews, pagers, bundles, and MCP
-#' errors fail closed. Large host-generated requests are compressed before
-#' transport and rejected before sending if they still exceed the safe bound.
+#' errors fail closed. Host-generated requests that exceed the wire bound are
+#' compressed before transport and rejected before sending if they still do not
+#' fit.
 #'
 #' @details
 #' By default, `mcp_repl_runner()` starts `mcp-repl` through
@@ -696,17 +697,27 @@ McpReplRunner <- R6::R6Class(
       } else {
         NULL
       }
-      preview_control <- NULL
-      if (
-        identical(control_protocol, "flex") &&
-          identical(transport_issue, "files")
-      ) {
-        preview_control <- mcp_repl_inline_flex_preview(
-          raw_text,
-          nonce = .control_nonce,
-          max_bytes = control_max_bytes
-        )
-        if (!is.null(preview_control)) {
+      flex_control <- NULL
+      if (identical(control_protocol, "flex")) {
+        flex_control <- if (identical(transport_issue, "files")) {
+          mcp_repl_inline_flex_preview(
+            raw_text,
+            nonce = .control_nonce,
+            max_bytes = control_max_bytes
+          )
+        } else if (is.null(transport_issue)) {
+          mcp_repl_inline_flex_control(
+            raw_text,
+            nonce = .control_nonce,
+            max_bytes = control_max_bytes
+          )
+        } else {
+          NULL
+        }
+        if (
+          !is.null(flex_control) &&
+            identical(transport_issue, "files")
+        ) {
           transport_issue <- NULL
         }
       }
@@ -737,12 +748,19 @@ McpReplRunner <- R6::R6Class(
         ))
       }
 
-      control_value <- if (!is.null(preview_control)) {
-        preview_control
+      control_value <- if (identical(control_protocol, "flex")) {
+        flex_control
       } else if (identical(control_protocol, "rlm")) {
         decode_rlm_control(raw_text, .control_nonce)
       } else {
         NULL
+      }
+      if (identical(control_protocol, "flex") && is.null(control_value)) {
+        return(mcp_repl_transport_error_result(
+          "flex-control",
+          stdout = text,
+          duration_ms = duration_ms
+        ))
       }
       list(
         success = TRUE,
@@ -922,7 +940,6 @@ mcp_repl_timeout_ms <- function(timeout) {
   ))
 }
 
-.mcp_repl_compress_input_bytes <- 6000L
 .mcp_repl_request_limit_bytes <- 7000L
 
 mcp_repl_input <- function(code, context) {
@@ -942,14 +959,11 @@ mcp_repl_input <- function(code, context) {
     code,
     "\n"
   )
-  input_bytes <- nchar(input, type = "bytes")
   request_bytes <- mcp_repl_request_bytes(input)
-  if (
-    input_bytes <= .mcp_repl_compress_input_bytes &&
-      request_bytes <= .mcp_repl_request_limit_bytes
-  ) {
+  if (request_bytes <= .mcp_repl_request_limit_bytes) {
     return(input)
   }
+  input_bytes <- nchar(input, type = "bytes")
 
   compressed <- memCompress(charToRaw(enc2utf8(input)), type = "gzip")
   token <- gsub(
@@ -1050,27 +1064,9 @@ mcp_repl_control_max_bytes <- function(max_bytes, runner_limit) {
   as.integer(min(max_bytes, runner_limit))
 }
 
-mcp_repl_inline_flex_preview <- function(text, nonce, max_bytes) {
+mcp_repl_inline_flex_control <- function(text, nonce, max_bytes) {
   text <- paste(text %||% "", collapse = "\n")
   if (!nzchar(text)) {
-    return(NULL)
-  }
-
-  # Only mcp-repl's plain transcript-file marker is recoverable. Ordered
-  # bundles, image bundles, write failures, and middle-truncated previews may
-  # omit or reorder output and therefore stay fail-closed.
-  if (
-    grepl("...[middle truncated;", text, fixed = TRUE) ||
-      grepl("bundle", tolower(text), fixed = TRUE)
-  ) {
-    return(NULL)
-  }
-  file_pattern <- "\\.\\.\\.\\[full output: [^\\r\\n\\]]+\\]\\.\\.\\."
-  file_markers <- regmatches(
-    text,
-    gregexpr(file_pattern, text, perl = TRUE)
-  )[[1L]]
-  if (length(file_markers) < 1L) {
     return(NULL)
   }
 
@@ -1127,6 +1123,30 @@ mcp_repl_inline_flex_preview <- function(text, nonce, max_bytes) {
     return(NULL)
   }
   envelope
+}
+
+mcp_repl_inline_flex_preview <- function(text, nonce, max_bytes) {
+  text <- paste(text %||% "", collapse = "\n")
+
+  # Only mcp-repl's plain transcript-file marker is recoverable. Ordered
+  # bundles, image bundles, write failures, and middle-truncated previews may
+  # omit or reorder output and therefore stay fail-closed.
+  if (
+    grepl("...[middle truncated;", text, fixed = TRUE) ||
+      grepl("bundle", tolower(text), fixed = TRUE)
+  ) {
+    return(NULL)
+  }
+  file_pattern <- "\\.\\.\\.\\[full output: [^\\r\\n\\]]+\\]\\.\\.\\."
+  file_markers <- regmatches(
+    text,
+    gregexpr(file_pattern, text, perl = TRUE)
+  )[[1L]]
+  if (length(file_markers) < 1L) {
+    return(NULL)
+  }
+
+  mcp_repl_inline_flex_control(text, nonce, max_bytes)
 }
 
 mcp_repl_normalize_response <- function(response) {
@@ -1277,6 +1297,10 @@ mcp_repl_transport_error_result <- function(
     `control-frame-limit` = paste(
       "the authenticated RLM control frame exceeded mcp-repl's safe inline",
       "transport limit"
+    ),
+    `flex-control` = paste(
+      "mcp-repl returned executable Flex output whose control frame",
+      "could not be verified"
     ),
     "authenticated RLM output could not be verified"
   )

--- a/R/mcp-repl-runner.R
+++ b/R/mcp-repl-runner.R
@@ -16,6 +16,13 @@
 #' conservative and can only fail closed; dsprrr never follows a disclosed
 #' sandbox file path from the host process.
 #'
+#' Executable Flex may recover a plain file preview only when its raw response
+#' contains exactly one bounded control frame for the current replay step. The
+#' frame remains untrusted and is still subject to Flex's host-side request,
+#' budget, and output validation. Ambiguous previews, pagers, bundles, and MCP
+#' errors fail closed. Large host-generated requests are compressed before
+#' transport and rejected before sending if they still exceed the safe bound.
+#'
 #' @details
 #' By default, `mcp_repl_runner()` starts `mcp-repl` through
 #' [mcptools::mcp_tools()] with:
@@ -52,9 +59,10 @@
 #' @param timeout Maximum execution time in seconds.
 #' @param max_output_chars Maximum number of output characters returned to the
 #'   optimizer.
-#' @param oversized_output mcp-repl oversized-output mode. During authenticated
-#'   RLM traffic, a detected oversized-output preview fails the iteration;
-#'   dsprrr attempts to reset active pager state before returning the failure.
+#' @param oversized_output mcp-repl oversized-output mode. RLM previews fail
+#'   closed. Executable Flex accepts only one bounded current-step frame in a
+#'   plain file preview. dsprrr attempts to reset active pager state before
+#'   returning a failure.
 #' @param extra_args Reserved for future vetted mcp-repl options. It must be
 #'   empty because arbitrary server flags can weaken the managed sandbox policy.
 #'
@@ -598,7 +606,13 @@ McpReplRunner <- R6::R6Class(
       self$connection_owned <- isTRUE(connection_owned)
     },
 
-    execute = function(code, context = list(), .control_nonce = NULL) {
+    execute = function(
+      code,
+      context = list(),
+      .control_nonce = NULL,
+      .control_protocol = NULL,
+      .control_max_bytes = NULL
+    ) {
       private$assert_usable()
       if (!self$started) {
         self$start()
@@ -609,13 +623,42 @@ McpReplRunner <- R6::R6Class(
       if (!is.list(context)) {
         cli::cli_abort("{.arg context} must be a list")
       }
+      control_protocol <- mcp_repl_control_protocol(
+        .control_protocol,
+        .control_nonce
+      )
+      control_max_bytes <- mcp_repl_control_max_bytes(
+        .control_max_bytes,
+        self$control_frame_limit
+      )
 
-      input <- mcp_repl_input(code, context)
+      input <- tryCatch(
+        mcp_repl_input(code, context),
+        dsprrr_mcp_repl_input_size_error = identity
+      )
+      if (inherits(input, "dsprrr_mcp_repl_input_size_error")) {
+        result <- mcp_repl_error_result(
+          conditionMessage(input),
+          error_type = "execution"
+        )
+        result$input_bytes <- input$input_bytes
+        result$request_bytes <- input$request_bytes
+        result$request_limit <- input$request_limit
+        class(result) <- c(
+          "dsprrr_mcp_repl_input_size_error",
+          class(result)
+        )
+        return(result)
+      }
+      timeout_ms <- mcp_repl_timeout_ms(self$timeout)
       started_at <- Sys.time()
       response <- tryCatch(
-        self$repl(
-          input = input,
-          timeout_ms = mcp_repl_timeout_ms(self$timeout)
+        # mcptools-generated wrappers reconstruct their call from
+        # match.call(). Pass realized values so expressions that mention the
+        # R6 `self` binding are not re-evaluated outside this method frame.
+        do.call(
+          self$repl,
+          list(input = input, timeout_ms = timeout_ms)
         ),
         error = function(e) e
       )
@@ -648,10 +691,24 @@ McpReplRunner <- R6::R6Class(
         ))
       }
 
-      transport_issue <- if (!is.null(.control_nonce)) {
+      transport_issue <- if (!is.null(control_protocol)) {
         mcp_repl_rlm_transport_issue(raw_text, self$oversized_output)
       } else {
         NULL
+      }
+      preview_control <- NULL
+      if (
+        identical(control_protocol, "flex") &&
+          identical(transport_issue, "files")
+      ) {
+        preview_control <- mcp_repl_inline_flex_preview(
+          raw_text,
+          nonce = .control_nonce,
+          max_bytes = control_max_bytes
+        )
+        if (!is.null(preview_control)) {
+          transport_issue <- NULL
+        }
       }
       if (!is.null(transport_issue)) {
         if (identical(transport_issue, "pager")) {
@@ -680,11 +737,17 @@ McpReplRunner <- R6::R6Class(
         ))
       }
 
-      control_value <- decode_rlm_control(raw_text, .control_nonce)
+      control_value <- if (!is.null(preview_control)) {
+        preview_control
+      } else if (identical(control_protocol, "rlm")) {
+        decode_rlm_control(raw_text, .control_nonce)
+      } else {
+        NULL
+      }
       list(
         success = TRUE,
-        # Authenticated RLM frames are decoded before ordinary truncation. A
-        # caller that does not supply the internal nonce receives normal text.
+        # Control frames are decoded from raw output before display truncation.
+        # A caller without an internal control protocol receives normal text.
         result = control_value %||% text,
         stdout = text,
         stderr = "",
@@ -705,10 +768,11 @@ McpReplRunner <- R6::R6Class(
 
     reset = function() {
       private$assert_usable()
+      timeout_ms <- mcp_repl_timeout_ms(self$timeout)
       response <- tryCatch(
-        self$repl(
-          input = "\u0004",
-          timeout_ms = mcp_repl_timeout_ms(self$timeout)
+        do.call(
+          self$repl,
+          list(input = "\u0004", timeout_ms = timeout_ms)
         ),
         error = function(e) e
       )
@@ -768,6 +832,7 @@ McpReplRunner <- R6::R6Class(
           sandbox_enforcement = "unverified",
           oversized_output = self$oversized_output,
           rlm_control_frame_limit = self$control_frame_limit,
+          flex_control_frame_limit = self$control_frame_limit,
           host_tools = "unsupported",
           lifecycle = "start-execute-shutdown"
         ))
@@ -784,6 +849,7 @@ McpReplRunner <- R6::R6Class(
         sandbox_enforcement = "operating-system",
         oversized_output = self$oversized_output,
         rlm_control_frame_limit = self$control_frame_limit,
+        flex_control_frame_limit = self$control_frame_limit,
         host_tools = "unsupported",
         lifecycle = "start-execute-shutdown"
       )
@@ -856,6 +922,9 @@ mcp_repl_timeout_ms <- function(timeout) {
   ))
 }
 
+.mcp_repl_compress_input_bytes <- 6000L
+.mcp_repl_request_limit_bytes <- 7000L
+
 mcp_repl_input <- function(code, context) {
   context_json <- jsonlite::toJSON(
     context,
@@ -866,13 +935,198 @@ mcp_repl_input <- function(code, context) {
     digits = NA
   )
   context_literal <- encodeString(as.character(context_json), quote = "\"")
-  paste0(
+  input <- paste0(
     ".context <- jsonlite::fromJSON(",
     context_literal,
     ", simplifyVector = FALSE)\n",
     code,
     "\n"
   )
+  input_bytes <- nchar(input, type = "bytes")
+  request_bytes <- mcp_repl_request_bytes(input)
+  if (
+    input_bytes <= .mcp_repl_compress_input_bytes &&
+      request_bytes <= .mcp_repl_request_limit_bytes
+  ) {
+    return(input)
+  }
+
+  compressed <- memCompress(charToRaw(enc2utf8(input)), type = "gzip")
+  token <- gsub(
+    "[[:space:]]",
+    "",
+    jsonlite::base64_enc(compressed)
+  )
+  wrapped <- paste0(
+    "base::eval(base::parse(text = base::rawToChar(",
+    "base::memDecompress(jsonlite::base64_dec(\"",
+    token,
+    "\"), type = \"gzip\"))), envir = base::globalenv())\n"
+  )
+  wrapped_request_bytes <- mcp_repl_request_bytes(wrapped)
+  if (wrapped_request_bytes > .mcp_repl_request_limit_bytes) {
+    request_limit <- .mcp_repl_request_limit_bytes
+    cli::cli_abort(
+      c(
+        "mcp-repl input exceeds the managed transport limit",
+        "x" = "The compressed request needs {wrapped_request_bytes} bytes; the limit is {request_limit} bytes.",
+        "i" = "Reduce the source or serialized execution context."
+      ),
+      class = "dsprrr_mcp_repl_input_size_error",
+      input_bytes = input_bytes,
+      request_bytes = wrapped_request_bytes,
+      request_limit = .mcp_repl_request_limit_bytes
+    )
+  }
+  wrapped
+}
+
+mcp_repl_request_bytes <- function(input) {
+  request <- list(
+    jsonrpc = "2.0",
+    id = .Machine$integer.max,
+    method = "tools/call",
+    params = list(
+      name = "repl",
+      arguments = list(
+        input = input,
+        timeout_ms = .Machine$integer.max
+      )
+    )
+  )
+  wire <- jsonlite::toJSON(request, auto_unbox = TRUE)
+  nchar(as.character(wire), type = "bytes") + 1L
+}
+
+mcp_repl_control_protocol <- function(protocol, nonce) {
+  if (is.null(protocol)) {
+    if (is.null(nonce)) {
+      return(NULL)
+    }
+    return("rlm")
+  }
+  if (
+    !is.character(protocol) ||
+      length(protocol) != 1L ||
+      is.na(protocol) ||
+      !protocol %in% c("rlm", "flex")
+  ) {
+    cli::cli_abort(
+      "Internal control protocol must be {.val rlm}, {.val flex}, or NULL",
+      class = "dsprrr_code_runner_protocol_error"
+    )
+  }
+  if (
+    !is.character(nonce) ||
+      length(nonce) != 1L ||
+      is.na(nonce) ||
+      !nzchar(nonce)
+  ) {
+    cli::cli_abort(
+      "Internal control nonce must be one non-empty string",
+      class = "dsprrr_code_runner_protocol_error"
+    )
+  }
+  protocol
+}
+
+mcp_repl_control_max_bytes <- function(max_bytes, runner_limit) {
+  if (is.null(max_bytes)) {
+    return(as.integer(runner_limit))
+  }
+  if (
+    !is.numeric(max_bytes) ||
+      length(max_bytes) != 1L ||
+      is.na(max_bytes) ||
+      !is.finite(max_bytes) ||
+      max_bytes < 1 ||
+      max_bytes != floor(max_bytes)
+  ) {
+    cli::cli_abort(
+      "Internal control byte limit must be one positive integer",
+      class = "dsprrr_code_runner_protocol_error"
+    )
+  }
+  as.integer(min(max_bytes, runner_limit))
+}
+
+mcp_repl_inline_flex_preview <- function(text, nonce, max_bytes) {
+  text <- paste(text %||% "", collapse = "\n")
+  if (!nzchar(text)) {
+    return(NULL)
+  }
+
+  # Only mcp-repl's plain transcript-file marker is recoverable. Ordered
+  # bundles, image bundles, write failures, and middle-truncated previews may
+  # omit or reorder output and therefore stay fail-closed.
+  if (
+    grepl("...[middle truncated;", text, fixed = TRUE) ||
+      grepl("bundle", tolower(text), fixed = TRUE)
+  ) {
+    return(NULL)
+  }
+  file_pattern <- "\\.\\.\\.\\[full output: [^\\r\\n\\]]+\\]\\.\\.\\."
+  file_markers <- regmatches(
+    text,
+    gregexpr(file_pattern, text, perl = TRUE)
+  )[[1L]]
+  if (length(file_markers) < 1L) {
+    return(NULL)
+  }
+
+  prefix_locations <- gregexpr(
+    .flex_code_control_prefix,
+    text,
+    fixed = TRUE
+  )[[1L]]
+  if (
+    identical(prefix_locations[[1L]], -1L) ||
+      length(prefix_locations) != 1L
+  ) {
+    return(NULL)
+  }
+  frame_pattern <- paste0(
+    .flex_code_control_prefix,
+    "[A-Za-z0-9+/=]+"
+  )
+  frames <- regmatches(text, gregexpr(frame_pattern, text, perl = TRUE))[[1L]]
+  if (
+    length(frames) != 1L ||
+      !nzchar(frames[[1L]]) ||
+      nchar(frames[[1L]], type = "bytes") > max_bytes
+  ) {
+    return(NULL)
+  }
+
+  token <- sub(
+    .flex_code_control_prefix,
+    "",
+    frames[[1L]],
+    fixed = TRUE
+  )
+  envelope <- tryCatch(
+    jsonlite::fromJSON(
+      rawToChar(jsonlite::base64_dec(token)),
+      simplifyVector = FALSE
+    ),
+    error = function(error) NULL
+  )
+
+  # The nonce is a current-step correlation value, not a secret credential.
+  # Exact framing, schema validation, and the byte bound are all required.
+  valid <- is.list(envelope) &&
+    identical(envelope$.dsprrr_flex_control, TRUE) &&
+    identical(envelope$version, 1L) &&
+    identical(envelope$nonce, nonce) &&
+    is.character(envelope$kind) &&
+    length(envelope$kind) == 1L &&
+    !is.na(envelope$kind) &&
+    envelope$kind %in% c("request", "final", "overflow") &&
+    is.list(envelope$payload)
+  if (!valid) {
+    return(NULL)
+  }
+  envelope
 }
 
 mcp_repl_normalize_response <- function(response) {

--- a/R/module-flex.R
+++ b/R/module-flex.R
@@ -1,10 +1,22 @@
-#' Experimental Flex Module
+#' Optimize a Module's Implementation with Flex
 #'
 #' @description
-#' `flex()` creates an experimental module whose implementation is itself an
-#' optimization parameter. Its safe default is a canonical, declarative JSON
-#' graph. An opt-in `source_format = "r"` mode accepts complete R source and
-#' evaluates it only in a fresh runner returned by `interpreter_factory`.
+#' `flex()` creates an experimental module whose implementation can be
+#' optimized. Use it when the best number, order, or kind of model and tool
+#' calls is unknown. If the program shape is already clear, use a regular
+#' module or an explicit pipeline instead.
+#'
+#' The default `source_format = "json"` represents a bounded predictor graph as
+#' data. Opt-in `source_format = "r"` accepts a complete R `forward()` program
+#' for tasks that need control flow, deterministic computation, dynamic
+#' predictors, or named host tools. Executable source runs only in a fresh
+#' runner returned by `interpreter_factory` and requires an enforced sandbox by
+#' default.
+#'
+#' @details
+#' Most teleprompters optimize instructions or demonstrations inside a fixed
+#' module. [GEPA] can also search each Flex module's complete `module_src`.
+#' Invalid candidates remain auditable but cannot replace the active program.
 #'
 #' Version 1 sources contain `schema_version`, an ordered `steps` array, and an
 #' `outputs` object. Each step has a safe, unique `name`, a `primitive` of
@@ -17,25 +29,24 @@
 #' object signature types. Opaque `TypeJsonSchema` values and empty objects are
 #' rejected because their interfaces cannot be checked safely by this compiler.
 #'
-#' Executable sources use a deliberately small guest DSL: `Predict`,
+#' Executable sources receive a small guest DSL: `Predict`,
 #' `ChainOfThought`, `ReAct`, `ReActV2`, `RLM`, `CodeAct`,
 #' `ProgramOfThought`, `Prediction`, `Tool`, and explicitly supplied named
 #' tools. Predictor and tool calls cross a versioned JSON boundary and run on
 #' the host; optimizer-authored source is never evaluated by the host R session.
 #' Guest bindings have a separate lexical environment from bridge state.
-#' Executable mode requires an explicit zero-argument interpreter factory and,
-#' by default, a runner that advertises an enforced sandbox.
+#' Supplied tools are privileged host capabilities even though generated source
+#' runs in a sandbox.
+#'
+#' After each bridged request, executable source runs again from the beginning
+#' with recorded host responses replayed. Keep guest-side computation pure and
+#' loops bounded because guest side effects can repeat.
 #'
 #' When `module_src` is `NULL`, the baseline is one `Predict` call (or one
 #' `RLM` call when executable mode has tools). `$bind()` and
 #' `$apply_optimization_params()` validate new source transactionally, so an
 #' invalid candidate cannot replace the active implementation. The source is
 #' available through the read-only `$module_src` active binding.
-#'
-#' GEPA treats each Flex source as one component. Candidate programs are
-#' explored from the union of validation-example winners, while component
-#' selection and lineage-aware merges decide what to mutate. Invalid source
-#' candidates are auditable but cannot replace the active implementation.
 #'
 #' Token streaming remains unsupported because Flex creates predictors at run
 #' time. Dataset concurrency is currently available for declarative zero- and
@@ -44,9 +55,10 @@
 #'
 #' @param signature A [Signature] object or DSPy-style signature string.
 #' @param module_src A complete Flex source string, or `NULL` for a baseline.
-#' @param max_predictor_calls Maximum number of predictor calls allowed in one
-#'   invocation, or `NULL` for no limit. Declarative sources are also checked
-#'   against this bound before they are installed.
+#' @param max_predictor_calls Maximum number of predictor invocations allowed
+#'   across the Flex bridge, or `NULL` for no limit. Declarative sources are
+#'   also checked against this bound before they are installed. Configure
+#'   separate limits for work performed inside agentic predictors.
 #' @param config Optional module configuration passed to each fresh predictor.
 #' @param chat Optional ellmer `Chat` used unless `.llm` is supplied at run
 #'   time.
@@ -56,13 +68,14 @@
 #'   runner for every executable Flex invocation. Required when
 #'   `source_format = "r"`; not accepted for declarative JSON.
 #' @param source_format Source language: `"json"`, `"r"`, or `"auto"`.
-#'   Auto selects R when tools or a factory are supplied, JSON for JSON-looking
-#'   source and the safe JSON baseline otherwise.
+#'   Auto selects R when tools or a factory are supplied, or when a non-`NULL`
+#'   source does not look like JSON. It selects JSON for JSON-looking source and
+#'   for the default `NULL` baseline.
 #' @param require_sandbox Whether executable mode must reject runners that do
 #'   not advertise an enforced sandbox. Keep the default for generated or
 #'   otherwise untrusted source.
 #' @param max_tool_calls Maximum number of direct host-tool calls allowed in one
-#'   executable invocation, or `NULL` for no limit. The safe default is 100.
+#'   executable invocation, or `NULL` for no limit. Defaults to 100.
 #'
 #' @return An experimental `FlexModule`.
 #' @export

--- a/R/r-code-runner.R
+++ b/R/r-code-runner.R
@@ -372,7 +372,9 @@ execute_code_runner <- function(
   runner,
   code,
   context = list(),
-  .control_nonce = NULL
+  .control_nonce = NULL,
+  .control_protocol = NULL,
+  .control_max_bytes = NULL
 ) {
   execute_args <- list(code = code, context = context)
   execute_formals <- tryCatch(
@@ -380,11 +382,18 @@ execute_code_runner <- function(
     error = function(e) character()
   )
   accepts_dots <- "..." %in% execute_formals
-  if (
-    !is.null(.control_nonce) &&
-      (".control_nonce" %in% execute_formals || accepts_dots)
-  ) {
-    execute_args$.control_nonce <- .control_nonce
+  control_args <- list(
+    .control_nonce = .control_nonce,
+    .control_protocol = .control_protocol,
+    .control_max_bytes = .control_max_bytes
+  )
+  for (name in names(control_args)) {
+    if (
+      !is.null(control_args[[name]]) &&
+        (name %in% execute_formals || accepts_dots)
+    ) {
+      execute_args[[name]] <- control_args[[name]]
+    }
   }
   result <- tryCatch(
     do.call(runner$execute, execute_args),

--- a/R/teleprompter-gepa-flex.R
+++ b/R/teleprompter-gepa-flex.R
@@ -791,6 +791,24 @@ gepa_signature_contract <- function(signature) {
 }
 
 gepa_flex_tool_contract <- function(tool, name) {
+  if (
+    inherits(tool, "ellmer::ToolDef") ||
+      inherits(tool, "ToolDef")
+  ) {
+    props <- tryCatch(S7::props(tool), error = function(error) list())
+    arguments <- props$arguments %||% NULL
+    return(list(
+      name = name,
+      kind = "tool_def",
+      description = props$description %||% "",
+      arguments_schema = if (is.null(arguments)) {
+        NULL
+      } else {
+        ellmer_type_to_json_schema(arguments)
+      }
+    ))
+  }
+
   if (is.function(tool)) {
     tool_formals <- as.list(formals(tool))
     formal_names <- names(tool_formals)
@@ -814,19 +832,6 @@ gepa_flex_tool_contract <- function(tool, name) {
       defaults = Filter(Negate(is.null), defaults)
     ))
   }
-
-  props <- tryCatch(S7::props(tool), error = function(error) list())
-  arguments <- props$arguments %||% NULL
-  list(
-    name = name,
-    kind = "tool_def",
-    description = props$description %||% "",
-    arguments_schema = if (is.null(arguments)) {
-      NULL
-    } else {
-      ellmer_type_to_json_schema(arguments)
-    }
-  )
 }
 
 gepa_flex_contract <- function(module, program = module) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -111,8 +111,9 @@ optimizers inspired by DSPy:
 - **GEPA**: Reflection-based complete-program optimization with validation-example and multi-objective Pareto selection
 - **AutoResearch and MetaHarness**: Agentic, sandboxed search over multi-module instructions and templates
 
-`flex()` is an experimental module, not an optimizer. It exposes a validated
-JSON predictor plan that GEPA can search as a structural parameter.
+`flex()` gives GEPA a different search target: not only what a predictor says,
+but how the module executes. It can vary predictor choice, control flow,
+deterministic R, and selected tools.
 
 ```{r optimization, eval=FALSE}
 # Compile with few-shot examples
@@ -174,7 +175,7 @@ result <- run(
 | `program_of_thought` | Generate and execute R code |
 | `codeact` | Combine tools with R code execution |
 | `rlm` | Explore large context through an R REPL |
-| `flex` | Execute a structurally optimizable JSON graph or interpreter-backed R program (experimental) |
+| `flex` | Let GEPA optimize how a module uses predictors, R logic, and selected tools (experimental) |
 
 ```{r module-types, eval=FALSE}
 # ReAct agent with tools
@@ -188,70 +189,25 @@ agent <- module(
 mod <- module(signature("question -> answer"), type = "chain_of_thought")
 ```
 
-### Experimental structural programs
+### Optimize the program, not only the prompt
 
-`flex()` makes a complete implementation an optimization parameter. Its safe
-default is a canonical, versioned JSON graph with allowlisted `predict` and
-`chain_of_thought` steps and typed references. Opt-in
-`source_format = "r"` runs complete R source only in a fresh interpreter from
-an explicit factory, with a versioned host bridge for dynamic predictors and
-named tools. Guest bindings are lexically isolated from bridge state, and
-`max_tool_calls` bounds privileged host-tool requests. `module_src` is
-read-only; use `bind()` to validate and replace it transactionally.
+Most optimizers improve instructions inside a workflow you designed. `flex()`
+lets GEPA change the workflow itself: which predictors run, where deterministic
+R is enough, and when to call a selected tool.
 
-```{r flex, eval=FALSE}
-program <- flex("question -> answer")
-program$module_src
+The worked example begins with a support router that asks a model about every
+ticket. In a deterministic GEPA replay, Flex selects a hybrid: known incident
+codes use a catalog lookup; ambiguous prose still uses a predictor. It preserves
+holdout accuracy while cutting predictor calls in half.
 
-optimized <- compile(
-  GEPA(metric = metric_exact_match(field = "answer"), seed = 42L),
-  program,
-  trainset = question_answer_data,
-  .llm = llm
-)
-```
+> Flex did not find a better prompt. It found that half the tickets did not
+> need one.
 
-Executable dsprrr Flex uses a top-level R `forward()` function and requires an
-explicit interpreter factory; DSPy uses a Python module class and provides a
-default Deno/Pyodide interpreter, so sources are not portable between them.
-GEPA searches complete instruction and `module_src` components for ordinary
-and Flex programs. When a `valset` is supplied, training rows drive discovery
-and reflection while validation rows drive selection. Its parent pool unites
-validation-example winners with the multi-metric objective Pareto front;
-metadata records component selection, immediate lineage and ancestry,
-attempted merge counts, and optional retained best outputs. See
-[Structural Optimization with Flex](https://jameshwade.github.io/dsprrr/articles/flex-optimization.html)
-for both source languages and the safety boundary.
-
-### Code-runner lifecycles
-
-`program_of_thought()`, `code_act()`, and `rlm_module()` require exactly one of
-two execution bindings:
-
-- `runner` is a caller-owned object that dsprrr reuses and never closes.
-  Whether execution state persists, and whether `reset()` exists, depends on
-  the backend. Serialize stateful backends and reset them between isolated jobs
-  when the backend supports it.
-- `interpreter_factory` is a zero-argument function. dsprrr calls it once per
-  invocation, uses the fresh runner only for that invocation, and closes it
-  exactly once, including when execution fails.
-
-Executable Flex accepts only `interpreter_factory`, keeping every bridge
-invocation isolated, and requires an advertised sandbox by default.
-
-Factory-backed ProgramOfThought, CodeAct, and RLM support isolated async and
-mirai batch execution; caller-owned runners remain sequential. `stream_async()`
-and `$stream()` reject their direct provider path before creating a factory
-runner or making a provider call. `run_stream()`
-preserves its one-shot `forward()` fallback, but preflights and rejects an
-actual token stream request that would bypass a specialized step.
-
-```{r interpreter-factory, eval=FALSE}
-pot <- program_of_thought(
-  "question -> answer",
-  interpreter_factory = function() r_code_runner(timeout = 30)
-)
-```
+Executable candidates require a fresh OS-sandboxed interpreter. See
+[Flex: Optimize the Whole Program](https://jameshwade.github.io/dsprrr/articles/flex-optimization.html)
+for the complete demo, and [Advanced
+Modules](https://jameshwade.github.io/dsprrr/articles/advanced-modules.html) for
+code-runner ownership and async support.
 
 ## ellmer compatibility
 

--- a/README.md
+++ b/README.md
@@ -169,9 +169,9 @@ several optimizers inspired by DSPy:
 - **AutoResearch and MetaHarness**: Agentic, sandboxed search over
   multi-module instructions and templates
 
-`flex()` is an experimental module, not an optimizer. It exposes a
-validated JSON predictor plan that GEPA can search as a structural
-parameter.
+`flex()` gives GEPA a different search target: not only what a predictor
+says, but how the module executes. It can vary predictor choice, control
+flow, deterministic R, and selected tools.
 
 ``` r
 # Compile with few-shot examples
@@ -235,7 +235,7 @@ result <- run(
 | `program_of_thought` | Generate and execute R code |
 | `codeact` | Combine tools with R code execution |
 | `rlm` | Explore large context through an R REPL |
-| `flex` | Execute a structurally optimizable JSON graph or interpreter-backed R program (experimental) |
+| `flex` | Let GEPA optimize how a module uses predictors, R logic, and selected tools (experimental) |
 
 ``` r
 # ReAct agent with tools
@@ -249,74 +249,27 @@ agent <- module(
 mod <- module(signature("question -> answer"), type = "chain_of_thought")
 ```
 
-### Experimental structural programs
+### Optimize the program, not only the prompt
 
-`flex()` makes a complete implementation an optimization parameter. Its
-safe default is a canonical, versioned JSON graph with allowlisted
-`predict` and `chain_of_thought` steps and typed references. Opt-in
-`source_format = "r"` runs complete R source only in a fresh interpreter
-from an explicit factory, with a versioned host bridge for dynamic
-predictors and named tools. Guest bindings are lexically isolated from
-bridge state, and `max_tool_calls` bounds privileged host-tool requests.
-`module_src` is read-only; use `bind()` to validate and replace it
-transactionally.
+Most optimizers improve instructions inside a workflow you designed.
+`flex()` lets GEPA change the workflow itself: which predictors run,
+where deterministic R is enough, and when to call a selected tool.
 
-``` r
-program <- flex("question -> answer")
-program$module_src
+The worked example begins with a support router that asks a model about
+every ticket. In a deterministic GEPA replay, Flex selects a hybrid:
+known incident codes use a catalog lookup; ambiguous prose still uses a
+predictor. It preserves holdout accuracy while cutting predictor calls
+in half.
 
-optimized <- compile(
-  GEPA(metric = metric_exact_match(field = "answer"), seed = 42L),
-  program,
-  trainset = question_answer_data,
-  .llm = llm
-)
-```
+> Flex did not find a better prompt. It found that half the tickets did
+> not need one.
 
-Executable dsprrr Flex uses a top-level R `forward()` function and
-requires an explicit interpreter factory; DSPy uses a Python module
-class and provides a default Deno/Pyodide interpreter, so sources are
-not portable between them. GEPA searches complete instruction and
-`module_src` components for ordinary and Flex programs. When a `valset`
-is supplied, training rows drive discovery and reflection while
-validation rows drive selection. Its parent pool unites
-validation-example winners with the multi-metric objective Pareto front;
-metadata records component selection, immediate lineage and ancestry,
-attempted merge counts, and optional retained best outputs. See
-[Structural Optimization with
-Flex](https://jameshwade.github.io/dsprrr/articles/flex-optimization.html)
-for both source languages and the safety boundary.
-
-### Code-runner lifecycles
-
-`program_of_thought()`, `code_act()`, and `rlm_module()` require exactly
-one of two execution bindings:
-
-- `runner` is a caller-owned object that dsprrr reuses and never closes.
-  Whether execution state persists, and whether `reset()` exists,
-  depends on the backend. Serialize stateful backends and reset them
-  between isolated jobs when the backend supports it.
-- `interpreter_factory` is a zero-argument function. dsprrr calls it
-  once per invocation, uses the fresh runner only for that invocation,
-  and closes it exactly once, including when execution fails.
-
-Executable Flex accepts only `interpreter_factory`, keeping every bridge
-invocation isolated, and requires an advertised sandbox by default.
-
-Factory-backed ProgramOfThought, CodeAct, and RLM support isolated async
-and mirai batch execution; caller-owned runners remain sequential.
-`stream_async()` and `$stream()` reject their direct provider path
-before creating a factory runner or making a provider call.
-`run_stream()` preserves its one-shot `forward()` fallback, but
-preflights and rejects an actual token stream request that would bypass
-a specialized step.
-
-``` r
-pot <- program_of_thought(
-  "question -> answer",
-  interpreter_factory = function() r_code_runner(timeout = 30)
-)
-```
+Executable candidates require a fresh OS-sandboxed interpreter. See
+[Flex: Optimize the Whole
+Program](https://jameshwade.github.io/dsprrr/articles/flex-optimization.html)
+for the complete demo, and [Advanced
+Modules](https://jameshwade.github.io/dsprrr/articles/advanced-modules.html)
+for code-runner ownership and async support.
 
 ## ellmer compatibility
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -14,8 +14,8 @@ home:
   title: "dsprrr: Programming—not prompting—LLMs in R"
   description: >
     dsprrr brings the power of DSPy to R. Instead of wrestling with prompt strings,
-    declare what you want, compose modules into pipelines, and let optimization find
-    the best prompts automatically.
+    declare what you want, compose modules into pipelines, and optimize prompts,
+    examples, or even the program that executes them.
 
 navbar:
   structure:
@@ -89,7 +89,7 @@ navbar:
           href: articles/how-rlm-works.html
         - text: "---"
         - text: "Deep Dives"
-        - text: "Structural Optimization with Flex"
+        - text: "Flex: Optimize the Whole Program"
           href: articles/flex-optimization.html
         - text: "Advanced Reasoning"
           href: articles/advanced-modules.html

--- a/man/flex.Rd
+++ b/man/flex.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/module-flex.R
 \name{flex}
 \alias{flex}
-\title{Experimental Flex Module}
+\title{Optimize a Module's Implementation with Flex}
 \usage{
 flex(
   signature,
@@ -22,9 +22,10 @@ flex(
 
 \item{module_src}{A complete Flex source string, or \code{NULL} for a baseline.}
 
-\item{max_predictor_calls}{Maximum number of predictor calls allowed in one
-invocation, or \code{NULL} for no limit. Declarative sources are also checked
-against this bound before they are installed.}
+\item{max_predictor_calls}{Maximum number of predictor invocations allowed
+across the Flex bridge, or \code{NULL} for no limit. Declarative sources are
+also checked against this bound before they are installed. Configure
+separate limits for work performed inside agentic predictors.}
 
 \item{config}{Optional module configuration passed to each fresh predictor.}
 
@@ -39,24 +40,37 @@ runner for every executable Flex invocation. Required when
 \code{source_format = "r"}; not accepted for declarative JSON.}
 
 \item{source_format}{Source language: \code{"json"}, \code{"r"}, or \code{"auto"}.
-Auto selects R when tools or a factory are supplied, JSON for JSON-looking
-source and the safe JSON baseline otherwise.}
+Auto selects R when tools or a factory are supplied, or when a non-\code{NULL}
+source does not look like JSON. It selects JSON for JSON-looking source and
+for the default \code{NULL} baseline.}
 
 \item{require_sandbox}{Whether executable mode must reject runners that do
 not advertise an enforced sandbox. Keep the default for generated or
 otherwise untrusted source.}
 
 \item{max_tool_calls}{Maximum number of direct host-tool calls allowed in one
-executable invocation, or \code{NULL} for no limit. The safe default is 100.}
+executable invocation, or \code{NULL} for no limit. Defaults to 100.}
 }
 \value{
 An experimental \code{FlexModule}.
 }
 \description{
-\code{flex()} creates an experimental module whose implementation is itself an
-optimization parameter. Its safe default is a canonical, declarative JSON
-graph. An opt-in \code{source_format = "r"} mode accepts complete R source and
-evaluates it only in a fresh runner returned by \code{interpreter_factory}.
+\code{flex()} creates an experimental module whose implementation can be
+optimized. Use it when the best number, order, or kind of model and tool
+calls is unknown. If the program shape is already clear, use a regular
+module or an explicit pipeline instead.
+
+The default \code{source_format = "json"} represents a bounded predictor graph as
+data. Opt-in \code{source_format = "r"} accepts a complete R \code{forward()} program
+for tasks that need control flow, deterministic computation, dynamic
+predictors, or named host tools. Executable source runs only in a fresh
+runner returned by \code{interpreter_factory} and requires an enforced sandbox by
+default.
+}
+\details{
+Most teleprompters optimize instructions or demonstrations inside a fixed
+module. \link{GEPA} can also search each Flex module's complete \code{module_src}.
+Invalid candidates remain auditable but cannot replace the active program.
 
 Version 1 sources contain \code{schema_version}, an ordered \code{steps} array, and an
 \code{outputs} object. Each step has a safe, unique \code{name}, a \code{primitive} of
@@ -69,25 +83,24 @@ Flex v1 supports string, number, integer, boolean, enum, array, and non-empty
 object signature types. Opaque \code{TypeJsonSchema} values and empty objects are
 rejected because their interfaces cannot be checked safely by this compiler.
 
-Executable sources use a deliberately small guest DSL: \code{Predict},
+Executable sources receive a small guest DSL: \code{Predict},
 \code{ChainOfThought}, \code{ReAct}, \code{ReActV2}, \code{RLM}, \code{CodeAct},
 \code{ProgramOfThought}, \code{Prediction}, \code{Tool}, and explicitly supplied named
 tools. Predictor and tool calls cross a versioned JSON boundary and run on
 the host; optimizer-authored source is never evaluated by the host R session.
 Guest bindings have a separate lexical environment from bridge state.
-Executable mode requires an explicit zero-argument interpreter factory and,
-by default, a runner that advertises an enforced sandbox.
+Supplied tools are privileged host capabilities even though generated source
+runs in a sandbox.
+
+After each bridged request, executable source runs again from the beginning
+with recorded host responses replayed. Keep guest-side computation pure and
+loops bounded because guest side effects can repeat.
 
 When \code{module_src} is \code{NULL}, the baseline is one \code{Predict} call (or one
 \code{RLM} call when executable mode has tools). \verb{$bind()} and
 \verb{$apply_optimization_params()} validate new source transactionally, so an
 invalid candidate cannot replace the active implementation. The source is
 available through the read-only \verb{$module_src} active binding.
-
-GEPA treats each Flex source as one component. Candidate programs are
-explored from the union of validation-example winners, while component
-selection and lineage-aware merges decide what to mutate. Invalid source
-candidates are auditable but cannot replace the active implementation.
 
 Token streaming remains unsupported because Flex creates predictors at run
 time. Dataset concurrency is currently available for declarative zero- and

--- a/man/mcp_repl_runner.Rd
+++ b/man/mcp_repl_runner.Rd
@@ -32,9 +32,10 @@ currently propagate the required Codex sandbox metadata.}
 \item{max_output_chars}{Maximum number of output characters returned to the
 optimizer.}
 
-\item{oversized_output}{mcp-repl oversized-output mode. During authenticated
-RLM traffic, a detected oversized-output preview fails the iteration;
-dsprrr attempts to reset active pager state before returning the failure.}
+\item{oversized_output}{mcp-repl oversized-output mode. RLM previews fail
+closed. Executable Flex accepts only one bounded current-step frame in a
+plain file preview. dsprrr attempts to reset active pager state before
+returning a failure.}
 
 \item{extra_args}{Reserved for future vetted mcp-repl options. It must be
 empty because arbitrary server flags can weaken the managed sandbox policy.}
@@ -57,6 +58,13 @@ iteration instead of accepting an unverifiable partial control frame. These
 markers are plain text in the upstream protocol, so detection is necessarily
 conservative and can only fail closed; dsprrr never follows a disclosed
 sandbox file path from the host process.
+
+Executable Flex may recover a plain file preview only when its raw response
+contains exactly one bounded control frame for the current replay step. The
+frame remains untrusted and is still subject to Flex's host-side request,
+budget, and output validation. Ambiguous previews, pagers, bundles, and MCP
+errors fail closed. Large host-generated requests are compressed before
+transport and rejected before sending if they still exceed the safe bound.
 }
 \details{
 By default, \code{mcp_repl_runner()} starts \code{mcp-repl} through

--- a/man/mcp_repl_runner.Rd
+++ b/man/mcp_repl_runner.Rd
@@ -59,12 +59,13 @@ markers are plain text in the upstream protocol, so detection is necessarily
 conservative and can only fail closed; dsprrr never follows a disclosed
 sandbox file path from the host process.
 
-Executable Flex may recover a plain file preview only when its raw response
-contains exactly one bounded control frame for the current replay step. The
-frame remains untrusted and is still subject to Flex's host-side request,
+Executable Flex decodes one bounded current-step frame from raw output before
+display truncation. It may also recover that frame from a plain file preview.
+The frame remains untrusted and is still subject to Flex's host-side request,
 budget, and output validation. Ambiguous previews, pagers, bundles, and MCP
-errors fail closed. Large host-generated requests are compressed before
-transport and rejected before sending if they still exceed the safe bound.
+errors fail closed. Host-generated requests that exceed the wire bound are
+compressed before transport and rejected before sending if they still do not
+fit.
 }
 \details{
 By default, \code{mcp_repl_runner()} starts \code{mcp-repl} through

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -2,7 +2,10 @@
 
 ## Programming—not prompting—LLMs in R
 
-dsprrr brings the power of [DSPy](https://dspy.ai) to R. Instead of wrestling with prompt strings, **declare** what you want, **compose** modules into pipelines, and let **optimization** find the best prompts automatically.
+dsprrr brings the power of [DSPy](https://dspy.ai) to R. Instead of wrestling
+with prompt strings, **declare** what you want, **compose** modules into
+pipelines, and use **optimization** to improve prompts, examples, or the program
+that executes them.
 
 ```r
 # Install
@@ -105,51 +108,21 @@ pin_module_config(board, "ticket-router-v2", optimized)
 </div>
 </div>
 
-## Experimental structural optimization
+## Optimize the program, not only the prompt
 
-`flex()` makes a complete implementation an optimization parameter. Its safe
-default is a canonical, versioned JSON graph with allowlisted Predict and
-Chain-of-Thought steps, typed references, and explicit output wiring. Opt-in
-executable mode runs a complete R `forward()` program only in a fresh runner
-from an explicit factory, with a versioned bridge for dynamic predictors and
-named host tools. Guest bindings are isolated from bridge state, and
-`max_tool_calls` bounds privileged host-tool requests. Invalid candidates are
-rejected before they can replace the active source.
+Most optimizers improve instructions inside a workflow you designed. `flex()`
+lets GEPA change the workflow itself: which predictors run, where deterministic
+R is enough, and when to call a tool you supplied.
 
-```r
-program <- flex("question -> answer")
-program$module_src
+The worked example starts with a support router that asks a model about every
+ticket. In a deterministic GEPA replay, the selected program checks known
+incident codes directly and reserves the model for ambiguous prose. It keeps
+all six held-out routes correct while cutting predictor calls from six to three.
 
-optimized <- compile(
-  GEPA(metric = metric_exact_match(field = "answer"), seed = 42L),
-  program,
-  trainset = question_answer_data,
-  .llm = llm
-)
-```
+> Flex did not find a better prompt. It found that half the tickets did not
+> need one.
 
-DSPy uses Python module classes and a default Deno/Pyodide interpreter; dsprrr
-uses R `forward()` source and requires an explicit factory, so source is not
-portable between them. GEPA searches complete instruction and `module_src`
-components for ordinary and Flex programs. When a `valset` is supplied,
-training rows drive discovery and reflection while validation rows drive
-selection. Its parent pool unites validation-example winners with the
-multi-metric objective Pareto front; metadata records component selection,
-immediate lineage and ancestry, attempted merge counts, and optional best
-outputs.
-[Read the Flex languages and safety contract &rarr;](articles/flex-optimization.html)
-
-Code-executing modules now make ownership explicit. Pass `runner` for a
-caller-owned backend object that dsprrr reuses and never closes. State
-persistence and reset support are backend-specific. Alternatively, pass a
-mutually exclusive zero-argument `interpreter_factory` for a fresh
-invocation-owned runner that dsprrr closes exactly once. The factory contract
-applies to ProgramOfThought, CodeAct, RLM, and executable Flex; Flex accepts
-only the fresh-factory form. Factory-backed ProgramOfThought, CodeAct, and RLM
-also support isolated async and mirai batch workflows. Caller-owned runners,
-specialized streaming, and executable Flex concurrency remain rejected before
-unsafe sharing or provider work. `run_stream()` without a matching token
-listener preserves the ordinary synchronous `forward()` path.
+[See the complete router demo and decide when Flex fits &rarr;](articles/flex-optimization.html)
 
 ## Getting Started: Configure Your LLM
 

--- a/tests/testthat/test-flex-code-bridge.R
+++ b/tests/testthat/test-flex-code-bridge.R
@@ -228,6 +228,101 @@ test_that("text-only Flex runners fail explicitly before frame truncation", {
   expect_identical(error$frame_limit, 1000L)
 })
 
+test_that("executable Flex binds control metadata to each replay step", {
+  calls <- 0L
+  observed <- list()
+  runner_factory <- function() {
+    list(
+      execute = function(
+        code,
+        context = list(),
+        .control_nonce = NULL,
+        .control_protocol = NULL,
+        .control_max_bytes = NULL
+      ) {
+        calls <<- calls + 1L
+        observed[[calls]] <<- list(
+          context_nonce = context$nonce,
+          control_nonce = .control_nonce,
+          protocol = .control_protocol,
+          max_bytes = .control_max_bytes
+        )
+        if (calls == 1L) {
+          request <- list(
+            index = 1L,
+            kind = "tool",
+            descriptor = list(name = "echo"),
+            arguments = list(value = "ok")
+          )
+          payload <- list(
+            request = request,
+            request_key = dsprrr:::flex_code_request_key(request)
+          )
+          kind <- "request"
+        } else {
+          payload <- list(
+            output = list(result = context$responses[[1L]]$value)
+          )
+          kind <- "final"
+        }
+        list(
+          success = TRUE,
+          result = list(
+            .dsprrr_flex_control = TRUE,
+            version = 1L,
+            nonce = context$nonce,
+            kind = kind,
+            payload = payload
+          )
+        )
+      },
+      policy = function() {
+        list(
+          backend = "control-test",
+          trust = "test-only",
+          sandboxed = TRUE,
+          flex_control_frame_limit = 2048L
+        )
+      },
+      close = function() invisible(NULL)
+    )
+  }
+
+  result <- dsprrr:::flex_code_execute(
+    module_src = "forward <- function(value) list(result = value)",
+    inputs = list(value = "ignored"),
+    outer_signature = signature("value -> result"),
+    tools = list(echo = function(value) value),
+    interpreter_factory = runner_factory,
+    max_predictor_calls = 0L,
+    max_tool_calls = 1L,
+    require_sandbox = TRUE,
+    config = list(),
+    llm = NULL,
+    cache = NULL,
+    rollout_id = NULL
+  )
+
+  expect_identical(result$output, list(result = "ok"))
+  expect_identical(calls, 2L)
+  expect_identical(observed[[1L]]$protocol, "flex")
+  expect_identical(observed[[2L]]$protocol, "flex")
+  expect_identical(observed[[1L]]$max_bytes, 2048L)
+  expect_identical(observed[[2L]]$max_bytes, 2048L)
+  expect_identical(
+    observed[[1L]]$context_nonce,
+    observed[[1L]]$control_nonce
+  )
+  expect_identical(
+    observed[[2L]]$context_nonce,
+    observed[[2L]]$control_nonce
+  )
+  expect_false(identical(
+    observed[[1L]]$control_nonce,
+    observed[[2L]]$control_nonce
+  ))
+})
+
 test_that("executable Flex rejects control values from failed execution", {
   runner_factory <- function() {
     list(

--- a/tests/testthat/test-flex-issue-router-demo.R
+++ b/tests/testthat/test-flex-issue-router-demo.R
@@ -1,0 +1,462 @@
+test_that("executable Flex issue router preserves quality with fewer predictors", {
+  skip_if_not_installed("callr")
+
+  route_signature <- signature(
+    "ticket -> queue: enum('database', 'security', 'payments', 'identity')",
+    instructions = "Route each support ticket to its owning queue."
+  )
+  holdout <- data.frame(
+    ticket = c(
+      "[INC-PAY-4] capture queue is growing",
+      "[INC-DB-17] replicas unavailable",
+      "[INC-SEC-9] login spray detected",
+      "Reset email arrives after its token expires",
+      "Renewal created two invoices",
+      "Read traffic fails after failover"
+    ),
+    queue = c(
+      "payments",
+      "database",
+      "security",
+      "identity",
+      "payments",
+      "database"
+    )
+  )
+
+  lookup_incident <- local({
+    catalog <- c(
+      "INC-DB-17" = "database",
+      "INC-SEC-9" = "security",
+      "INC-PAY-4" = "payments"
+    )
+
+    function(ticket) {
+      hit <- names(catalog)[vapply(
+        names(catalog),
+        grepl,
+        logical(1),
+        x = ticket,
+        fixed = TRUE
+      )]
+      if (!length(hit)) {
+        return(list(found = FALSE))
+      }
+      list(found = TRUE, queue = unname(catalog[[hit[[1L]]]]))
+    }
+  })
+
+  route_chat <- function() {
+    turns <- list()
+    calls <- 0L
+
+    last_turn <- function(role = c("assistant", "user"), ...) {
+      role <- match.arg(role)
+      matching <- Filter(function(turn) identical(turn@role, role), turns)
+      if (!length(matching)) {
+        return(NULL)
+      }
+      matching[[length(matching)]]
+    }
+
+    structure(
+      list(
+        calls = function() calls,
+        get_model = function() "issue-router-test",
+        get_turns = function(...) turns,
+        last_turn = last_turn,
+        chat_structured = function(prompt, type, ...) {
+          prompt <- paste(as.character(prompt), collapse = "\n")
+          queue <- if (grepl("INC-PAY-4", prompt, fixed = TRUE)) {
+            "payments"
+          } else if (grepl("INC-DB-17", prompt, fixed = TRUE)) {
+            "database"
+          } else if (grepl("INC-SEC-9", prompt, fixed = TRUE)) {
+            "security"
+          } else if (
+            grepl(
+              "Reset email arrives after its token expires",
+              prompt,
+              fixed = TRUE
+            )
+          ) {
+            "identity"
+          } else if (
+            grepl("Renewal created two invoices", prompt, fixed = TRUE)
+          ) {
+            "payments"
+          } else if (
+            grepl("Read traffic fails after failover", prompt, fixed = TRUE)
+          ) {
+            "database"
+          } else {
+            stop("unexpected issue-router prompt")
+          }
+
+          calls <<- calls + 1L
+          turns <<- c(
+            turns,
+            list(
+              ellmer::UserTurn(
+                contents = list(ellmer::ContentText(prompt))
+              ),
+              ellmer::AssistantTurn(
+                contents = list(ellmer::ContentText(queue)),
+                tokens = c(2L, 1L, 0L),
+                cost = 0,
+                duration = 0.001
+              )
+            )
+          )
+          list(queue = queue)
+        }
+      ),
+      class = "Chat"
+    )
+  }
+
+  # Fixed reviewed fixtures are the only source run without a sandbox here.
+  baseline_source <- paste(
+    "router <- Predict(\"$outer\", instructions = \"Choose the owning queue.\")",
+    "forward <- function(ticket) router(ticket = ticket)",
+    sep = "\n"
+  )
+  winner_source <- paste(
+    "fallback <- Predict(\"$outer\", instructions = \"Route tickets without a known incident code.\")",
+    "forward <- function(ticket) {",
+    "  if (grepl(\"INC-\", ticket, fixed = TRUE)) {",
+    "    hit <- lookup_incident(ticket = ticket)",
+    "    if (isTRUE(hit$found)) return(Prediction(queue = hit$queue))",
+    "  }",
+    "  fallback(ticket = ticket)",
+    "}",
+    sep = "\n"
+  )
+  make_program <- function(module_src) {
+    suppressWarnings(flex(
+      route_signature,
+      module_src = module_src,
+      tools = list(lookup_incident = lookup_incident),
+      interpreter_factory = r_code_runner,
+      source_format = "r",
+      require_sandbox = FALSE,
+      max_predictor_calls = 1L,
+      max_tool_calls = 1L
+    ))
+  }
+  run_ticket <- function(program, ticket, chat) {
+    run(
+      program,
+      ticket = ticket,
+      .llm = chat,
+      .return_format = "structured",
+      .cache = FALSE
+    )
+  }
+
+  winner <- make_program(winner_source)
+  known_chat <- route_chat()
+  known <- run_ticket(winner, holdout$ticket[[1L]], known_chat)
+
+  expect_identical(known$output, list(queue = "payments"))
+  expect_identical(known$metadata$predictor_calls, 0L)
+  expect_identical(known$metadata$tool_calls, 1L)
+  expect_identical(known$metadata$total_tokens, 0L)
+  expect_identical(known_chat$calls(), 0L)
+
+  ambiguous_chat <- route_chat()
+  ambiguous <- run_ticket(winner, holdout$ticket[[4L]], ambiguous_chat)
+
+  expect_identical(ambiguous$output, list(queue = "identity"))
+  expect_identical(ambiguous$metadata$predictor_calls, 1L)
+  expect_identical(ambiguous$metadata$tool_calls, 0L)
+  expect_identical(ambiguous_chat$calls(), 1L)
+
+  run_holdout <- function(program) {
+    chat <- route_chat()
+    results <- lapply(holdout$ticket, function(ticket) {
+      run_ticket(program, ticket, chat)
+    })
+    list(results = results, chat = chat)
+  }
+  summarize_holdout <- function(execution) {
+    outputs <- vapply(
+      execution$results,
+      function(result) result$output$queue,
+      character(1)
+    )
+    metadata <- lapply(execution$results, `[[`, "metadata")
+    list(
+      accuracy = mean(outputs == holdout$queue),
+      predictor_calls = sum(vapply(
+        metadata,
+        `[[`,
+        integer(1),
+        "predictor_calls"
+      )),
+      tool_calls = sum(vapply(metadata, `[[`, integer(1), "tool_calls")),
+      chat_calls = execution$chat$calls()
+    )
+  }
+
+  after <- summarize_holdout(run_holdout(winner))
+  before <- summarize_holdout(run_holdout(make_program(baseline_source)))
+
+  expect_identical(after$accuracy, 1)
+  expect_identical(after$predictor_calls, 3L)
+  expect_identical(after$tool_calls, 3L)
+  expect_identical(after$chat_calls, 3L)
+  expect_identical(before$accuracy, 1)
+  expect_identical(before$predictor_calls, 6L)
+  expect_identical(before$tool_calls, 0L)
+  expect_identical(before$chat_calls, 6L)
+})
+
+test_that("GEPA selects the executable Flex issue-router hybrid", {
+  skip_if_not_installed("callr")
+
+  route_signature <- signature(
+    "ticket -> queue: enum('database', 'security', 'payments', 'identity')",
+    instructions = "Route each support ticket to its owning queue."
+  )
+  trainset <- data.frame(
+    ticket = c(
+      "[INC-SEC-9] login spray detected",
+      "Reset email arrives after its token expires"
+    ),
+    queue = c("security", "identity")
+  )
+  valset <- data.frame(
+    ticket = c(
+      "[INC-PAY-4] capture queue is growing",
+      "Renewal created two invoices"
+    ),
+    queue = c("payments", "payments")
+  )
+  expect_length(intersect(trainset$ticket, valset$ticket), 0L)
+
+  lookup_incident <- local({
+    catalog <- c(
+      "INC-SEC-9" = "security",
+      "INC-PAY-4" = "payments"
+    )
+
+    function(ticket) {
+      hit <- names(catalog)[vapply(
+        names(catalog),
+        grepl,
+        logical(1),
+        x = ticket,
+        fixed = TRUE
+      )]
+      if (!length(hit)) {
+        return(list(found = FALSE))
+      }
+      list(found = TRUE, queue = unname(catalog[[hit[[1L]]]]))
+    }
+  })
+
+  baseline_source <- paste(
+    "router <- Predict(\"$outer\", instructions = \"Choose the owning queue.\")",
+    "forward <- function(ticket) router(ticket = ticket)",
+    sep = "\n"
+  )
+  winner_source <- paste(
+    "fallback <- Predict(\"$outer\", instructions = \"Route tickets without a known incident code.\")",
+    "forward <- function(ticket) {",
+    "  if (grepl(\"INC-\", ticket, fixed = TRUE)) {",
+    "    hit <- lookup_incident(ticket = ticket)",
+    "    if (isTRUE(hit$found)) return(Prediction(queue = hit$queue))",
+    "  }",
+    "  fallback(ticket = ticket)",
+    "}",
+    sep = "\n"
+  )
+
+  issue_router_chat <- function(winner_source) {
+    force(winner_source)
+    turns <- list()
+    proposal_calls <- 0L
+
+    last_turn <- function(role = c("assistant", "user"), ...) {
+      role <- match.arg(role)
+      matching <- Filter(function(turn) identical(turn@role, role), turns)
+      if (!length(matching)) {
+        return(NULL)
+      }
+      matching[[length(matching)]]
+    }
+
+    structure(
+      list(
+        proposal_calls = function() proposal_calls,
+        get_model = function() "issue-router-gepa-test",
+        get_turns = function(...) turns,
+        last_turn = last_turn,
+        chat_structured = function(prompt, type, ...) {
+          fields <- names(type@properties)
+          if (identical(fields, "module_src")) {
+            proposal_calls <<- proposal_calls + 1L
+            return(list(module_src = winner_source))
+          }
+          if (!identical(fields, "queue")) {
+            stop("unexpected issue-router structured output")
+          }
+
+          prompt <- paste(as.character(prompt), collapse = "\n")
+          queue <- if (grepl("INC-SEC-9", prompt, fixed = TRUE)) {
+            "security"
+          } else if (grepl("INC-PAY-4", prompt, fixed = TRUE)) {
+            "payments"
+          } else if (
+            grepl(
+              "Reset email arrives after its token expires",
+              prompt,
+              fixed = TRUE
+            )
+          ) {
+            "identity"
+          } else if (
+            grepl("Renewal created two invoices", prompt, fixed = TRUE)
+          ) {
+            "payments"
+          } else {
+            stop("unexpected issue-router prompt")
+          }
+
+          turns <<- c(
+            turns,
+            list(
+              ellmer::UserTurn(
+                contents = list(ellmer::ContentText(prompt))
+              ),
+              ellmer::AssistantTurn(
+                contents = list(ellmer::ContentText(queue)),
+                tokens = c(2L, 1L, 0L),
+                cost = 0,
+                duration = 0.001
+              )
+            )
+          )
+          list(queue = queue)
+        }
+      ),
+      class = "Chat"
+    )
+  }
+
+  make_program <- function(module_src) {
+    # Both candidate sources are fixed, reviewed test fixtures.
+    suppressWarnings(flex(
+      route_signature,
+      module_src = module_src,
+      tools = list(lookup_incident = lookup_incident),
+      interpreter_factory = r_code_runner,
+      source_format = "r",
+      require_sandbox = FALSE,
+      max_predictor_calls = 1L,
+      max_tool_calls = 1L
+    ))
+  }
+  route_metric <- metric_with_trace(
+    function(prediction, expected, program_trace) {
+      correct <- identical(prediction$queue, expected$queue[[1L]])
+      predictor_calls <- program_trace$metadata$predictor_calls
+      if (is.null(predictor_calls)) {
+        predictor_calls <- 0L
+      }
+      list(
+        score = if (!correct) {
+          0
+        } else if (identical(as.integer(predictor_calls), 0L)) {
+          1
+        } else {
+          0.5
+        },
+        feedback = if (correct) {
+          "Correct route; prefer deterministic routing when available."
+        } else {
+          "Route does not match the owning queue."
+        }
+      )
+    },
+    field = "queue"
+  )
+
+  optimizer_chat <- issue_router_chat(winner_source)
+  optimized <- compile(
+    GEPA(
+      metric = route_metric,
+      population_size = 2L,
+      generations = 1L,
+      selection = "current_best",
+      track_best_outputs = TRUE,
+      verbose = FALSE
+    ),
+    make_program(baseline_source),
+    trainset,
+    valset = valset,
+    .llm = optimizer_chat,
+    control = dsprrr:::optimizer_control(num_threads = 1L)
+  )
+  optimizer_metadata <- optimized$config$optimizer
+
+  validate <- function(program) {
+    result <- evaluate(
+      program,
+      valset,
+      route_metric,
+      .llm = issue_router_chat(winner_source),
+      .progress = FALSE
+    )
+    predicted <- vapply(result$predictions, `[[`, character(1), "queue")
+    list(
+      accuracy = mean(predicted == valset$queue),
+      score = result$mean_score,
+      predictor_calls = sum(vapply(
+        result$metadata,
+        `[[`,
+        integer(1),
+        "predictor_calls"
+      )),
+      tool_calls = sum(vapply(
+        result$metadata,
+        `[[`,
+        integer(1),
+        "tool_calls"
+      ))
+    )
+  }
+  before <- validate(make_program(baseline_source))
+  after <- validate(optimized)
+
+  expect_identical(optimizer_chat$proposal_calls(), 1L)
+  expect_identical(optimized$module_src, winner_source)
+  expect_identical(optimizer_metadata$best_scores, c(quality = 0.75))
+  expect_setequal(
+    unname(optimizer_metadata$val_aggregate_scores),
+    c(0.5, 0.75)
+  )
+  expect_identical(
+    unname(optimizer_metadata$discovery_eval_counts),
+    c(2L, 2L)
+  )
+  expect_identical(optimizer_metadata$track_best_outputs, TRUE)
+  expect_length(optimizer_metadata$best_outputs_valset, nrow(valset))
+  expect_identical(
+    optimizer_metadata$per_val_instance_best_candidates[["1"]],
+    optimizer_metadata$best_candidate_id
+  )
+  expect_identical(
+    optimizer_metadata$best_outputs_valset[["1"]][[1L]]$output,
+    list(queue = "payments")
+  )
+  expect_identical(before$accuracy, 1)
+  expect_identical(after$accuracy, 1)
+  expect_identical(before$score, 0.5)
+  expect_identical(after$score, 0.75)
+  expect_identical(before$predictor_calls, 2L)
+  expect_identical(after$predictor_calls, 1L)
+  expect_identical(before$tool_calls, 0L)
+  expect_identical(after$tool_calls, 1L)
+})

--- a/tests/testthat/test-mcp-repl-runner.R
+++ b/tests/testthat/test-mcp-repl-runner.R
@@ -113,6 +113,32 @@ test_that("mcp_repl_input compresses large requests without changing them", {
   expect_false(exists(".context", envir = .GlobalEnv, inherits = FALSE))
 })
 
+test_that("mcp_repl_input preserves fitting high-entropy requests", {
+  withr::local_seed(125L)
+  alphabet <- strsplit(
+    paste0(
+      "!#$%&()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+      "[]^_abcdefghijklmnopqrstuvwxyz{|}~"
+    ),
+    "",
+    fixed = TRUE
+  )[[1L]]
+  payload <- paste(sample(alphabet, 6040L, replace = TRUE), collapse = "")
+  code <- paste0("#", payload, "\n1 + 1")
+  expected <- paste0(
+    '.context <- jsonlite::fromJSON("[]", simplifyVector = FALSE)\n',
+    code,
+    "\n"
+  )
+
+  expect_gt(nchar(expected, type = "bytes"), 6000L)
+  expect_lte(
+    dsprrr:::mcp_repl_request_bytes(expected),
+    dsprrr:::.mcp_repl_request_limit_bytes
+  )
+  expect_identical(dsprrr:::mcp_repl_input(code, list()), expected)
+})
+
 test_that("mcp_repl_input rejects oversized encoded requests before transport", {
   calls <- 0L
   repl <- function(input, timeout_ms) {
@@ -690,6 +716,100 @@ test_that("authenticated RLM traffic fails closed on file previews", {
 
   expect_identical(ordinary$success, TRUE)
   expect_identical(ordinary$result, preview)
+})
+
+test_that("Flex normal inline control is decoded before display truncation", {
+  encode_frame <- function(
+    nonce,
+    kind = "final",
+    payload = list(output = list(answer = "ok"))
+  ) {
+    envelope <- list(
+      .dsprrr_flex_control = TRUE,
+      version = 1L,
+      nonce = nonce,
+      kind = kind,
+      payload = payload
+    )
+    json <- jsonlite::toJSON(
+      envelope,
+      auto_unbox = TRUE,
+      null = "null",
+      na = "null",
+      dataframe = "rows",
+      digits = NA
+    )
+    paste0(
+      dsprrr:::.flex_code_control_prefix,
+      gsub(
+        "[[:space:]]",
+        "",
+        jsonlite::base64_enc(charToRaw(as.character(json)))
+      )
+    )
+  }
+
+  nonce <- "current-step"
+  frame <- encode_frame(nonce)
+  raw_text <- paste(strrep("noise", 20L), frame, sep = "\n")
+  repl <- function(input, timeout_ms) {
+    list(result = list(content = list(list(type = "text", text = raw_text))))
+  }
+  runner <- mcp_repl_runner(repl = repl, max_output_chars = 20L)
+
+  result <- runner$execute(
+    "invisible(NULL)",
+    .control_nonce = nonce,
+    .control_protocol = "flex",
+    .control_max_bytes = runner$control_frame_limit
+  )
+
+  expect_true(result$success)
+  expect_identical(result$result$.dsprrr_flex_control, TRUE)
+  expect_identical(result$result$nonce, nonce)
+  expect_identical(result$result$payload$output$answer, "ok")
+  expect_match(result$stdout, "output truncated by dsprrr", fixed = TRUE)
+  expect_identical(
+    dsprrr:::flex_code_decode_control(list(result$result), nonce),
+    result$result
+  )
+
+  invalid <- list(
+    missing = "ordinary output",
+    stale = encode_frame("previous-step"),
+    truncated = substr(frame, 1L, nchar(frame) - 8L),
+    malformed = paste0(dsprrr:::.flex_code_control_prefix, "not-base64!"),
+    duplicate = paste(frame, frame, sep = "\n"),
+    unknown_kind = encode_frame(nonce, kind = "unknown"),
+    non_list_payload = encode_frame(nonce, payload = "invalid"),
+    oversized = encode_frame(
+      nonce,
+      payload = list(output = list(answer = strrep("x", 2000L)))
+    )
+  )
+  for (name in names(invalid)) {
+    raw_text <- invalid[[name]]
+    repl <- function(input, timeout_ms) {
+      list(result = list(content = list(list(type = "text", text = raw_text))))
+    }
+    runner <- mcp_repl_runner(repl = repl, max_output_chars = 100000L)
+    max_bytes <- if (identical(name, "oversized")) {
+      200L
+    } else {
+      runner$control_frame_limit
+    }
+
+    result <- runner$execute(
+      "invisible(NULL)",
+      .control_nonce = nonce,
+      .control_protocol = "flex",
+      .control_max_bytes = max_bytes
+    )
+
+    expect_s3_class(result, "dsprrr_mcp_repl_transport_error")
+    expect_false(result$success, info = name)
+    expect_null(result$result, info = name)
+  }
 })
 
 test_that("Flex recovers one bounded current-step frame from file previews", {

--- a/tests/testthat/test-mcp-repl-runner.R
+++ b/tests/testthat/test-mcp-repl-runner.R
@@ -41,6 +41,34 @@ test_that("injected mcp_repl_runner is persistent but unverified", {
   ))
 })
 
+test_that("mcp_repl_runner realizes arguments for mcptools wrappers", {
+  requests <- list()
+  call_tool <- function(input, timeout_ms) {
+    requests[[length(requests) + 1L]] <<- list(
+      input = input,
+      timeout_ms = timeout_ms
+    )
+    list(result = list(content = list(list(type = "text", text = "ok"))))
+  }
+  repl <- function(input, timeout_ms) {
+    call_info <- match.call()
+    tool_args <- lapply(call_info[-1L], eval)
+    do.call(call_tool, tool_args)
+  }
+
+  runner <- mcp_repl_runner(repl = repl, timeout = 2)
+  result <- runner$execute("1 + 1")
+
+  expect_true(result$success)
+  expect_identical(result$result, "ok")
+  expect_identical(requests[[1L]]$timeout_ms, 2000L)
+
+  runner$reset()
+
+  expect_identical(requests[[2L]]$input, "\u0004")
+  expect_identical(requests[[2L]]$timeout_ms, 2000L)
+})
+
 test_that("mcp_repl_runner overwrites persistent context even when empty", {
   inputs <- character()
   repl <- function(input, timeout_ms) {
@@ -57,6 +85,62 @@ test_that("mcp_repl_runner overwrites persistent context even when empty", {
   expect_match(inputs[[2L]], "\\.context <-")
   expect_match(inputs[[2L]], 'fromJSON("[]",', fixed = TRUE)
   expect_false(grepl("sensitive", inputs[[2L]], fixed = TRUE))
+})
+
+test_that("mcp_repl_input compresses large requests without changing them", {
+  context <- list(
+    payload = strrep("replay payload ", 700L),
+    label = "na\u00efve caf\u00e9"
+  )
+  code <- paste(
+    "local({",
+    "  value <- .context",
+    "  base::rm(.context, envir = base::globalenv())",
+    "  value",
+    "})",
+    sep = "\n"
+  )
+
+  input <- dsprrr:::mcp_repl_input(code, context)
+
+  expect_match(input, "base::memDecompress", fixed = TRUE)
+  expect_lte(
+    dsprrr:::mcp_repl_request_bytes(input),
+    dsprrr:::.mcp_repl_request_limit_bytes
+  )
+  value <- eval(parse(text = input), envir = .GlobalEnv)
+  expect_identical(value, context)
+  expect_false(exists(".context", envir = .GlobalEnv, inherits = FALSE))
+})
+
+test_that("mcp_repl_input rejects oversized encoded requests before transport", {
+  calls <- 0L
+  repl <- function(input, timeout_ms) {
+    calls <<- calls + 1L
+    "ok"
+  }
+  runner <- mcp_repl_runner(repl = repl)
+  result <- local({
+    testthat::local_mocked_bindings(
+      mcp_repl_request_bytes = function(input) {
+        dsprrr:::.mcp_repl_request_limit_bytes + 1L
+      },
+      .package = "dsprrr"
+    )
+    dsprrr:::execute_code_runner(runner, "1 + 1")
+  })
+
+  expect_s3_class(result, "dsprrr_mcp_repl_input_size_error")
+  expect_false(result$success)
+  expect_identical(result$error_type, "execution")
+  expect_true(result$retryable)
+  expect_identical(calls, 0L)
+  expect_false(runner$terminal)
+
+  recovered <- runner$execute("1 + 1")
+  expect_true(recovered$success)
+  expect_identical(recovered$result, "ok")
+  expect_identical(calls, 1L)
 })
 
 test_that("dsprrr-managed mcp_repl_runner advertises its derived policy", {
@@ -606,6 +690,250 @@ test_that("authenticated RLM traffic fails closed on file previews", {
 
   expect_identical(ordinary$success, TRUE)
   expect_identical(ordinary$result, preview)
+})
+
+test_that("Flex recovers one bounded current-step frame from file previews", {
+  encode_frame <- function(nonce, value = "ok", kind = "final") {
+    payload <- if (identical(kind, "overflow")) {
+      list(stage = "final output", encoded_bytes = 4001L, frame_limit = 3000L)
+    } else {
+      list(output = list(answer = value))
+    }
+    envelope <- list(
+      .dsprrr_flex_control = TRUE,
+      version = 1L,
+      nonce = nonce,
+      kind = kind,
+      payload = payload
+    )
+    json <- jsonlite::toJSON(
+      envelope,
+      auto_unbox = TRUE,
+      null = "null",
+      na = "null",
+      dataframe = "rows",
+      digits = NA
+    )
+    paste0(
+      dsprrr:::.flex_code_control_prefix,
+      gsub(
+        "[[:space:]]",
+        "",
+        jsonlite::base64_enc(charToRaw(as.character(json)))
+      )
+    )
+  }
+  preview <- function(frame) {
+    paste(
+      "stderr: compiler warning",
+      "...[full output: /sandbox/output-0001/transcript.txt]...",
+      paste0(frame, " > "),
+      "...[full output: /sandbox/output-0002/transcript.txt]...",
+      sep = "\n"
+    )
+  }
+  nonce <- "current-step"
+  raw_text <- preview(encode_frame(nonce))
+  repl <- function(input, timeout_ms) {
+    list(result = list(content = list(list(type = "text", text = raw_text))))
+  }
+  runner <- mcp_repl_runner(
+    repl = repl,
+    max_output_chars = 20L,
+    oversized_output = "files"
+  )
+
+  result <- runner$execute(
+    "invisible(NULL)",
+    .control_nonce = nonce,
+    .control_protocol = "flex",
+    .control_max_bytes = runner$control_frame_limit
+  )
+
+  expect_identical(result$success, TRUE)
+  expect_identical(result$result$.dsprrr_flex_control, TRUE)
+  expect_identical(result$result$nonce, nonce)
+  expect_identical(result$result$payload$output$answer, "ok")
+  expect_match(result$stdout, "output truncated by dsprrr", fixed = TRUE)
+
+  rlm_result <- runner$execute(
+    "invisible(NULL)",
+    .control_nonce = nonce
+  )
+  expect_s3_class(rlm_result, "dsprrr_mcp_repl_transport_error")
+  expect_identical(rlm_result$success, FALSE)
+
+  raw_text <- preview(encode_frame(nonce, kind = "overflow"))
+  overflow_result <- runner$execute(
+    "invisible(NULL)",
+    .control_nonce = nonce,
+    .control_protocol = "flex",
+    .control_max_bytes = runner$control_frame_limit
+  )
+  expect_identical(overflow_result$success, TRUE)
+  expect_identical(overflow_result$result$kind, "overflow")
+  expect_error(
+    dsprrr:::flex_code_decode_control(list(overflow_result$result), nonce),
+    class = "dsprrr_flex_bridge_frame_size_error"
+  )
+})
+
+test_that("Flex file-preview recovery rejects ambiguous control output", {
+  encode_frame <- function(nonce, value = "ok") {
+    envelope <- list(
+      .dsprrr_flex_control = TRUE,
+      version = 1L,
+      nonce = nonce,
+      kind = "final",
+      payload = list(output = list(answer = value))
+    )
+    json <- jsonlite::toJSON(
+      envelope,
+      auto_unbox = TRUE,
+      null = "null",
+      na = "null",
+      dataframe = "rows",
+      digits = NA
+    )
+    paste0(
+      dsprrr:::.flex_code_control_prefix,
+      gsub(
+        "[[:space:]]",
+        "",
+        jsonlite::base64_enc(charToRaw(as.character(json)))
+      )
+    )
+  }
+  preview <- function(body) {
+    paste(
+      "...[full output: /sandbox/output-0001/transcript.txt]...",
+      body,
+      "...[full output: /sandbox/output-0002/transcript.txt]...",
+      sep = "\n"
+    )
+  }
+  nonce <- "current-step"
+  current <- encode_frame(nonce)
+  cases <- list(
+    stale = encode_frame("previous-step"),
+    missing = "ordinary output",
+    truncated = substr(current, 1L, nchar(current) - 8L),
+    invalid = paste0(dsprrr:::.flex_code_control_prefix, "not-base64!"),
+    duplicate = paste(current, current, sep = "\n"),
+    oversized = encode_frame(nonce, strrep("x", 4000L))
+  )
+
+  for (name in names(cases)) {
+    raw_text <- preview(cases[[name]])
+    repl <- function(input, timeout_ms) {
+      list(result = list(content = list(list(type = "text", text = raw_text))))
+    }
+    runner <- mcp_repl_runner(repl = repl, oversized_output = "files")
+
+    result <- runner$execute(
+      "invisible(NULL)",
+      .control_nonce = nonce,
+      .control_protocol = "flex",
+      .control_max_bytes = runner$control_frame_limit
+    )
+
+    expect_s3_class(result, "dsprrr_mcp_repl_transport_error")
+    expect_identical(result$success, FALSE)
+  }
+
+  bundle_markers <- c(
+    "...[middle truncated; ordered output bundle index: /sandbox/index.md]...",
+    "...[middle truncated; output bundle images: /sandbox/images]...",
+    "...[middle truncated; output bundle unavailable]..."
+  )
+  for (marker in bundle_markers) {
+    raw_text <- paste(marker, current, sep = "\n")
+    repl <- function(input, timeout_ms) {
+      list(result = list(content = list(list(type = "text", text = raw_text))))
+    }
+    runner <- mcp_repl_runner(repl = repl, oversized_output = "files")
+
+    result <- runner$execute(
+      "invisible(NULL)",
+      .control_nonce = nonce,
+      .control_protocol = "flex"
+    )
+
+    expect_s3_class(result, "dsprrr_mcp_repl_transport_error")
+    expect_identical(result$success, FALSE)
+  }
+})
+
+test_that("Flex preview recovery does not bypass MCP errors or pagers", {
+  nonce <- "current-step"
+  envelope <- list(
+    .dsprrr_flex_control = TRUE,
+    version = 1L,
+    nonce = nonce,
+    kind = "final",
+    payload = list(output = list(answer = "ok"))
+  )
+  json <- jsonlite::toJSON(envelope, auto_unbox = TRUE)
+  frame <- paste0(
+    dsprrr:::.flex_code_control_prefix,
+    gsub(
+      "[[:space:]]",
+      "",
+      jsonlite::base64_enc(charToRaw(as.character(json)))
+    )
+  )
+  file_text <- paste(
+    "...[full output: /sandbox/output.txt]...",
+    frame,
+    sep = "\n"
+  )
+  error_repl <- function(input, timeout_ms) {
+    list(
+      result = list(
+        isError = TRUE,
+        content = list(list(type = "text", text = file_text))
+      )
+    )
+  }
+  error_runner <- mcp_repl_runner(
+    repl = error_repl,
+    oversized_output = "files"
+  )
+
+  error_result <- error_runner$execute(
+    "invisible(NULL)",
+    .control_nonce = nonce,
+    .control_protocol = "flex"
+  )
+
+  expect_identical(error_result$success, FALSE)
+  expect_identical(error_result$error_type, "execution")
+  expect_match(error_result$error, "execution error", fixed = TRUE)
+  expect_null(error_result$result)
+
+  inputs <- character()
+  pager_repl <- function(input, timeout_ms) {
+    inputs <<- c(inputs, input)
+    if (identical(input, "\u0004")) {
+      return(list(result = list(content = list())))
+    }
+    text <- paste(frame, "--More-- (2p)", sep = "\n")
+    list(result = list(content = list(list(type = "text", text = text))))
+  }
+  pager_runner <- mcp_repl_runner(
+    repl = pager_repl,
+    oversized_output = "pager"
+  )
+
+  pager_result <- pager_runner$execute(
+    "invisible(NULL)",
+    .control_nonce = nonce,
+    .control_protocol = "flex"
+  )
+
+  expect_s3_class(pager_result, "dsprrr_mcp_repl_transport_error")
+  expect_identical(pager_result$success, FALSE)
+  expect_identical(utils::tail(inputs, 1L), "\u0004")
 })
 
 test_that("authenticated RLM traffic resets an active mcp-repl pager", {

--- a/tests/testthat/test-r-code-runner.R
+++ b/tests/testthat/test-r-code-runner.R
@@ -53,6 +53,42 @@ test_that("code runner protocol supports external sandbox backends", {
   )
 })
 
+test_that("execute_code_runner forwards supported control metadata", {
+  observed <- NULL
+  runner <- list(
+    execute = function(
+      code,
+      context = list(),
+      .control_nonce = NULL,
+      .control_protocol = NULL,
+      .control_max_bytes = NULL
+    ) {
+      observed <<- list(
+        nonce = .control_nonce,
+        protocol = .control_protocol,
+        max_bytes = .control_max_bytes
+      )
+      list(success = TRUE, result = code)
+    },
+    policy = function() {
+      list(backend = "test", trust = "test", sandboxed = TRUE)
+    }
+  )
+
+  result <- dsprrr:::execute_code_runner(
+    runner,
+    "1 + 1",
+    .control_nonce = "step-1",
+    .control_protocol = "flex",
+    .control_max_bytes = 2048L
+  )
+
+  expect_identical(result$result, "1 + 1")
+  expect_identical(observed$nonce, "step-1")
+  expect_identical(observed$protocol, "flex")
+  expect_identical(observed$max_bytes, 2048L)
+})
+
 test_that("code runner protocol validates policy metadata", {
   incomplete <- list(
     execute = function(code, context = list()) NULL,

--- a/tests/testthat/test-teleprompter-gepa-flex.R
+++ b/tests/testthat/test-teleprompter-gepa-flex.R
@@ -426,6 +426,94 @@ test_that("Flex proposer describes the executable R DSL and host tools", {
   )
 })
 
+test_that("GEPA Flex tool contracts distinguish ToolDefs from functions", {
+  ordinary <- dsprrr:::gepa_flex_tool_contract(
+    function(query, limit = 5L) query,
+    "ordinary"
+  )
+  tool <- ellmer::tool(
+    function(query, limit = 5L) query,
+    name = "lookup",
+    description = "Look up records.",
+    arguments = list(
+      query = ellmer::type_string(description = "Search terms."),
+      limit = ellmer::type_integer(
+        description = "Maximum records.",
+        required = FALSE
+      )
+    )
+  )
+  contract <- dsprrr:::gepa_flex_tool_contract(tool, "lookup")
+
+  expect_identical(ordinary$kind, "function")
+  expect_identical(ordinary$arguments, c("query", "limit"))
+  expect_identical(ordinary$required, "query")
+  expect_identical(ordinary$defaults, list(limit = "5L"))
+  expect_identical(contract$name, "lookup")
+  expect_identical(contract$kind, "tool_def")
+  expect_identical(contract$description, "Look up records.")
+  expect_identical(contract$arguments_schema$type, "object")
+  expect_identical(
+    contract$arguments_schema$properties$query,
+    list(type = "string", description = "Search terms.")
+  )
+  expect_identical(
+    contract$arguments_schema$properties$limit,
+    list(type = "integer", description = "Maximum records.")
+  )
+  expect_identical(contract$arguments_schema$required, "query")
+  expect_identical(contract$arguments_schema$additionalProperties, FALSE)
+})
+
+test_that("Flex proposer includes ToolDef metadata in its prompt", {
+  source <- paste(
+    "forward <- function(question) {",
+    "  Prediction(answer = lookup(query = question))",
+    "}",
+    sep = "\n"
+  )
+  tool <- ellmer::tool(
+    function(query) query,
+    name = "lookup",
+    description = "Look up records by query.",
+    arguments = list(
+      query = ellmer::type_string(description = "Search terms to look up.")
+    )
+  )
+  program <- suppressWarnings(flex(
+    "question -> answer",
+    module_src = source,
+    tools = list(lookup = tool),
+    interpreter_factory = r_code_runner,
+    source_format = "r",
+    require_sandbox = FALSE
+  ))
+  chat <- gepa_flex_test_chat(list(module_src = source))
+
+  result <- dsprrr:::gepa_propose_flex_source(
+    program,
+    list(),
+    .llm = chat
+  )
+
+  expect_identical(result$status, "proposed")
+  prompt <- chat$prompts()[[1L]]
+  expect_match(prompt, '"kind":"tool_def"', fixed = TRUE)
+  expect_match(
+    prompt,
+    '"description":"Look up records by query."',
+    fixed = TRUE
+  )
+  expect_match(prompt, '"arguments_schema":{"type":"object"', fixed = TRUE)
+  expect_match(
+    prompt,
+    '"description":"Search terms to look up."',
+    fixed = TRUE
+  )
+  expect_match(prompt, '"required":"query"', fixed = TRUE)
+  expect_match(prompt, '"additionalProperties":false', fixed = TRUE)
+})
+
 test_that("nested Flex proposals label component and root-program evidence", {
   program <- gepa_flex_test_program()
   target <- named_modules(program)[["$/steps/flexible"]]

--- a/vignettes/advanced-modules.Rmd
+++ b/vignettes/advanced-modules.Rmd
@@ -494,12 +494,11 @@ The factory form is the safer default when state must not cross invocation
 boundaries. The direct-runner form is useful for object reuse or intentional
 REPL persistence; never share a stateful runner across concurrent calls.
 Supplying both forms is an error.
-Use synchronous `run()` for these code-executing modules. The generic async and
-module `$stream()` entry points reject a program graph containing
-ProgramOfThought, CodeAct, or RLM before any provider call because those paths
-cannot preserve the specialized runner lifecycle yet. `run_stream()` without a
-matching token listener preserves the ordinary synchronous `forward()` path; a
-matching token-stream request is rejected before provider or factory work.
+Factory-backed ProgramOfThought, CodeAct, and RLM support `run_async()` and
+isolated mirai batch execution because every invocation owns a fresh runner.
+Caller-owned runners remain sequential. Specialized token streaming is still
+rejected before provider or factory work; `run_stream()` without a matching
+token listener preserves the ordinary synchronous `forward()` path.
 
 ### Basic Usage
 
@@ -663,23 +662,19 @@ agent <- code_act(
 
 ## Flex (experimental)
 
-`flex()` makes a complete implementation part of a module's optimization
-state. Its safe default is canonical, versioned JSON with Predict and
-Chain-of-Thought steps. Opt-in executable mode accepts complete R `forward()`
-source, dynamic predictors, deterministic control flow, and named host tools,
-evaluated only through a fresh configured interpreter.
+Use `flex()` when the implementation strategy is the search problem. GEPA can
+change which predictors run, add deterministic R logic, or call a selected
+tool—not only rewrite instructions inside a fixed module.
 
 ```{r flex-basic, eval=FALSE}
 program <- flex("question -> answer")
 program$module_src
 ```
 
-Use `program$bind(candidate)` to validate and replace the source
-transactionally. Direct assignment to `module_src` is rejected. DSPy uses
-Python module classes and a default Deno/Pyodide interpreter; dsprrr uses R
-`forward()` source and an explicit factory, so source is not portable. See
-[Structural Optimization with Flex](flex-optimization.html) for both source
-languages, references, and the safety boundary.
+Use a regular module when its shape is known, or an explicit pipeline when
+people should own the workflow. See [Flex: Optimize the Whole
+Program](flex-optimization.html) for a deterministic GEPA replay that preserves
+router accuracy while removing unnecessary model calls.
 
 ## Combining Modules
 
@@ -763,14 +758,14 @@ dsprrr's advanced modules bring battle-tested patterns from DSPy to R:
 | `multi_chain_comparison()` | Complex analysis, multiple valid approaches | (M+1)× cost |
 | `program_of_thought()` | Exact computation, data analysis | Code execution overhead |
 | `code_act()` | Tasks needing both tools AND computation | Agent loop overhead |
-| `flex()` | Testing bounded or executable structures | Experimental dual-source API |
+| `flex()` | Optimizing the choice among predictors, R logic, and tools | Experimental; executable source requires a sandbox |
 
 **Getting started:**
 - Start with **ChainOfThought** for complex reasoning tasks
 - Add **BestOfN** when you need reliability
 - Use **ProgramOfThought** for exact computation (math, statistics)
 - Use **CodeAct** when you need tools AND code execution together
-- Use **Flex** when predictor structure itself is the experiment
+- Use **Flex** when the implementation strategy itself is the experiment
 
 ## Further Reading
 

--- a/vignettes/advanced-optimization.Rmd
+++ b/vignettes/advanced-optimization.Rmd
@@ -369,46 +369,16 @@ print(compiled$demos)
 3. Re-evaluates and repeats
 4. Builds a demo set that covers edge cases
 
-## Structural Candidates with Flex
+## When the implementation is part of the search
 
-`flex()` exposes a module's complete implementation through `module_src`.
-GEPA can propose complete candidates and apply them through the module's
-transactional optimization boundary:
+Most teleprompters keep module structure fixed. GEPA can also optimize a
+`flex()` module's complete `module_src`: the choice and order of predictors, or
+in executable mode, deterministic R branches and selected tool calls. Invalid
+candidates are rejected before selection.
 
-```{r flex-candidate}
-program <- flex("question -> answer")
-optimizer <- GEPA(
-  metric = metric_exact_match(field = "answer"),
-  population_size = 6L,
-  generations = 2L,
-  seed = 42L
-)
-optimized <- compile(
-  optimizer,
-  program,
-  trainset = trainset,
-  .llm = llm
-)
-```
-
-The safe default is a version 1 JSON graph containing allowlisted Predict and
-Chain-of-Thought steps with typed backward references. Opt-in
-`source_format = "r"` accepts complete R source with deterministic logic,
-control flow, the DSPy Flex predictor family, and explicit host tools. That
-source runs only in a fresh configured interpreter, uses a versioned host
-bridge, and requires an advertised sandbox by default. Direct host-tool calls
-have their own `max_tool_calls` budget.
-
-Advertising the graph as a parameter does not make every teleprompter a
-structural optimizer. GEPA represents every mutable program as a complete set
-of instruction and, when present, Flex-source components. It rejects invalid
-source candidates before selection and ranks whole programs. Upstream GEPA's
-frontier is indexed by validation example over complete candidates; component
-selection and lineage-aware merge are separate operations. Other teleprompters
-do not silently rewrite `module_src`. A fully frozen graph short-circuits
-without proposer or evaluation work and records that optimization was skipped.
-See [Structural Optimization with
-Flex](flex-optimization.html) for the full schema and audit contract.
+Use this only when implementation strategy is genuinely unresolved. See
+[Flex: Optimize the Whole Program](flex-optimization.html) for a complete
+before-and-after example and the runtime boundary.
 
 ## GEPA (Reflective Prompt Evolution)
 
@@ -471,7 +441,9 @@ multi-objective Pareto candidates.
 When a program contains Flex leaves, GEPA candidates include complete
 `module_src` values as well as ordinary instructions. Invalid source proposals
 remain auditable but non-selectable. Pareto selection is whole-program, not an
-implementation of DSPy's per-component frontier.
+implementation of DSPy's per-component frontier. The [Flex
+guide](flex-optimization.html) shows how to evaluate those candidates on both
+answer quality and predictor calls.
 
 ## Omni
 

--- a/vignettes/articles/agentic-optimization-harnesses.Rmd
+++ b/vignettes/articles/agentic-optimization-harnesses.Rmd
@@ -29,21 +29,14 @@ optimizable leaf in a module graph. This makes them useful when the search
 problem is not "find one better prompt," but "repair the contract among several
 pipeline stages."
 
-DSPy 3.3.0 introduced experimental `Flex`, which can optimize a program's
-source code and structure inside a sandbox. `AutoResearch()` and
-`MetaHarness()` are **not** Flex optimizers. They accept complete replacements
-only for allowlisted instruction and template fields; they do not execute
-optimizer-authored R module source, add predictors, or change graph topology.
-That narrower edit language is an intentional host-validation boundary.
+`AutoResearch()` and `MetaHarness()` do **not** change module topology or run
+optimizer-authored module source. They edit allowlisted instructions and
+templates while the trusted R evaluator keeps the workflow fixed.
 
-dsprrr's separate experimental `flex()` module exposes both a constrained,
-versioned JSON graph and opt-in complete R source behind a fresh interpreter,
-isolated predictor/tool bridge, separate predictor/tool budgets, and default
-sandbox requirement. GEPA,
-rather than these agentic harnesses, searches complete validated Flex source
-components using validation-example winner frontiers and explicit component
-selection. See [Structural Optimization with Flex](flex-optimization.html)
-and the [DSPy 3.3.0 release notes](https://github.com/stanfordnlp/dspy/releases/tag/3.3.0).
+Use the separate experimental `flex()` module when GEPA should optimize the
+implementation strategy itself: predictor structure, deterministic R, or
+selected tools. See [Flex: Optimize the Whole
+Program](flex-optimization.html) for that workflow and its sandbox boundary.
 
 ## Choose the Search Owner
 

--- a/vignettes/articles/flex-optimization.Rmd
+++ b/vignettes/articles/flex-optimization.Rmd
@@ -1,11 +1,11 @@
 ---
-title: "Structural Optimization with Flex"
+title: "Flex: Optimize the Whole Program"
 description: >
-  Optimize safe declarative graphs or interpreter-backed R programs with
-  dsprrr's experimental Flex module.
+  Use Flex when optimization should decide which model calls, deterministic
+  code, or tools a task needs—not only rewrite a prompt.
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Structural Optimization with Flex}
+  %\VignetteIndexEntry{Flex: Optimize the Whole Program}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
@@ -19,285 +19,417 @@ knitr::opts_chunk$set(
 )
 ```
 
-`flex()` is an experimental module whose complete implementation is one
-optimization parameter. It has two source modes:
+Most dsprrr optimizers improve the instructions or examples inside a program
+whose shape you chose. `flex()` makes the implementation itself optimizable.
+GEPA can change how many predictors run, add a deterministic branch, or call a
+tool you supplied.
 
-- `source_format = "json"` is the safe default: a bounded, versioned graph
-  parsed strictly as data; and
-- `source_format = "r"` is opt-in: complete R source evaluated only inside a
-  fresh runner returned by an explicit `interpreter_factory`.
+That extra freedom is useful when you can score the outcome but do not yet know
+the best decomposition. It is unnecessary when the workflow is already clear.
 
-The second mode brings deterministic computation, control flow, host tools,
-and dynamically selected predictors much closer to DSPy 3.3 Flex. It does not
-turn the host R session into an evaluation environment. Predictor and tool
-requests cross a versioned JSON bridge, generated source receives only a small
-guest DSL in a separate lexical environment, and typed outputs are checked
-again on the host.
+| What should change? | Use |
+|---|---|
+| Instructions or examples inside a known module | A regular module and teleprompter |
+| A workflow whose steps your team should own | An explicit pipeline |
+| The number or order of Predict and Chain-of-Thought steps | JSON Flex |
+| The choice among R logic, predictors, and selected tools | Executable Flex |
 
-## Start with the safe baseline
+## A router that learns when not to call a model
 
-With no `module_src`, `flex()` creates one Predict step over the outer
-signature:
+Suppose a support team routes tickets to four queues. Some tickets contain an
+incident code with a known owner. Others need language-model judgment.
 
-```{r baseline}
+A conventional predictor sends every ticket to the model. The Flex objective
+is more specific: keep routing accuracy, but avoid a predictor call when the
+incident catalog already contains the answer.
+
+### Define the task and its evidence
+
+Use separate training and validation rows during search, then reserve a holdout
+set for the final comparison:
+
+```{r router-data}
 library(dsprrr)
 
-program <- flex("question -> answer")
-program$module_src
-
-result <- run(
-  program,
-  question = "Why does ice float?",
-  .llm = ellmer::chat_openai()
+route_signature <- signature(
+  "ticket -> queue: enum('database', 'security', 'payments', 'identity')",
+  instructions = "Route each support ticket to its owning queue."
 )
-```
 
-The `module_src` active binding is read-only and canonical. Equivalent input
-JSON is normalized to one stable representation, which supports reliable
-fingerprints, comparisons, and optimizer candidates.
-
-## Describe a two-step plan
-
-Version 1 JSON source has exactly three top-level fields:
-
-- `schema_version`, currently the number `1`;
-- `steps`, an ordered array (which may be empty for an input-only program); and
-- `outputs`, a mapping for every output in the outer signature.
-
-Each step declares a unique `name`, an allowlisted `primitive`, a `signature`,
-and an `inputs` mapping. Optional `instructions` refine the step. Input and
-output references may point to an outer input (`$input.<field>`) or an output
-from an earlier step (`$step.<name>.<field>`).
-
-```{r two-step}
-source <- jsonlite::toJSON(
-  list(
-    schema_version = 1,
-    steps = list(
-      list(
-        name = "draft",
-        primitive = "chain_of_thought",
-        signature = "question -> draft",
-        instructions = "Work out the relevant causal mechanism.",
-        inputs = list(question = "$input.question")
-      ),
-      list(
-        name = "final",
-        primitive = "predict",
-        signature = "draft -> answer",
-        instructions = "Give a concise answer for a general reader.",
-        inputs = list(draft = "$step.draft.draft")
-      )
-    ),
-    outputs = list(answer = "$step.final.answer")
+train <- data.frame(
+  ticket = c(
+    "[INC-DB-17] checkout failures in us-east",
+    "Password reset links expire immediately",
+    "Duplicate charge after a plan upgrade",
+    "Queries time out after a schema migration"
   ),
-  auto_unbox = TRUE
+  queue = c(
+    "database", "identity", "payments", "database"
+  )
 )
 
-program <- flex(
-  "question -> answer",
-  module_src = source,
-  max_predictor_calls = 4
+validation <- data.frame(
+  ticket = c(
+    "[INC-SEC-9] unusual-login burst",
+    "Card charged twice for one invoice"
+  ),
+  queue = c("security", "payments")
+)
+
+holdout <- data.frame(
+  ticket = c(
+    "[INC-PAY-4] capture queue is growing",
+    "[INC-DB-17] replicas unavailable",
+    "[INC-SEC-9] login spray detected",
+    "Reset email arrives after its token expires",
+    "Renewal created two invoices",
+    "Read traffic fails after failover"
+  ),
+  queue = c(
+    "payments", "database", "security", "identity", "payments", "database"
+  )
 )
 ```
 
-Version 1 permits only `predict` and `chain_of_thought`. Step names and
-references follow a restricted grammar, references can only point backwards,
-and every step-signature input needs exactly one compatible binding while every
-outer output needs exactly one compatible mapping. A plan may reuse or ignore
-outer inputs, although runtime inputs must still match the outer signature.
-`max_predictor_calls` bounds graph size before execution.
-Version 1 supports ellmer string, number, integer, boolean, enum, array, and
-non-empty object field types. Opaque `TypeJsonSchema` values and empty objects
-are rejected explicitly; the IR does not guess whether an arbitrary JSON
-Schema is assignable.
+The catalog is an ordinary R closure wrapped in an ellmer tool definition. Its
+description tells GEPA what the tool returns; supplying it to Flex gives
+generated code one named capability rather than the rest of the host session.
 
-## Opt in to executable R source
+```{r router-tool}
+lookup_incident_fn <- local({
+  catalog <- c(
+    "INC-DB-17" = "database",
+    "INC-SEC-9" = "security",
+    "INC-PAY-4" = "payments"
+  )
 
-Executable Flex requires a zero-argument factory, not a shared runner. Each
-invocation gets a fresh runner and dsprrr closes it on success, failure, or
-interrupt. The default `require_sandbox = TRUE` also requires that runner's
-validated policy to advertise an enforced sandbox.
+  function(ticket) {
+    hit <- names(catalog)[vapply(
+      names(catalog),
+      grepl,
+      logical(1),
+      x = ticket,
+      fixed = TRUE
+    )]
+    if (!length(hit)) {
+      return(list(found = FALSE))
+    }
+    list(found = TRUE, queue = unname(catalog[[hit[[1L]]]]))
+  }
+})
 
-```{r executable}
-source <- paste(
-  "draft <- ChainOfThought('$outer', instructions = 'Solve carefully.')",
-  "forward <- function(question) {",
-  "  result <- draft(question = question)",
-  "  Prediction(answer = result$answer)",
-  "}",
+lookup_incident <- ellmer::tool(
+  lookup_incident_fn,
+  name = "lookup_incident",
+  description = paste(
+    "Find the owner of an incident code in a support ticket.",
+    "Returns list(found = FALSE) when no known code appears; otherwise",
+    "returns list(found = TRUE, queue = <owning queue>)."
+  ),
+  arguments = list(
+    ticket = ellmer::type_string(
+      description = "Complete support-ticket text."
+    )
+  )
+)
+```
+
+### Start with one predictor
+
+Executable Flex source defines a top-level `forward()` function. This baseline
+always calls one predictor, even for a ticket whose incident code is already in
+the catalog.
+
+```{r router-baseline}
+baseline_source <- paste(
+  "router <- Predict(\"$outer\", instructions = \"Choose the owning queue.\")",
+  "forward <- function(ticket) router(ticket = ticket)",
   sep = "\n"
 )
 
-program <- flex(
-  "question -> answer",
-  module_src = source,
-  interpreter_factory = my_sandboxed_runner,
-  source_format = "r"
+sandbox_factory <- function() mcp_repl_runner(timeout = 45)
+
+baseline <- flex(
+  route_signature,
+  module_src = baseline_source,
+  tools = list(lookup_incident = lookup_incident),
+  interpreter_factory = sandbox_factory,
+  source_format = "r",
+  max_predictor_calls = 1L,
+  max_tool_calls = 1L
 )
 ```
 
-The guest DSL exposes `Predict`, `ChainOfThought`, `ReAct`, `ReActV2`, `RLM`,
-`CodeAct`, `ProgramOfThought`, `Prediction`, and `Tool`. Constructors return
-callable functions. Signatures use `"$outer"` or ordinary string notation.
-No adapter, optimizer, package-loading, provider-configuration, nested Flex,
-or unrestricted host namespace is exposed.
-Plain functions are available as direct host calls and to `RLM`; `ReAct` and
-`CodeAct` receive only supplied ellmer ToolDef objects because provider-facing
-tools require an explicit description and argument schema.
+Install `mcptools` and [Posit
+mcp-repl](https://github.com/posit-dev/mcp-repl) before running this example:
 
-Named host tools retain their original closure environments and run on the
-host, outside the sandbox:
+```r
+install.packages("mcptools")
+# In a shell:
+# uv tool install posit-mcp-repl
+```
 
-```{r executable-tool}
-offset <- 5L
+mcp-repl's OS sandbox is the execution boundary for optimizer-authored R
+source.
 
-tool_program <- flex(
-  "value: integer -> result: integer",
-  module_src = paste(
-    "forward <- function(value) {",
-    "  Prediction(result = add_offset(value = value))",
-    "}",
-    sep = "\n"
-  ),
-  tools = list(add_offset = function(value) value + offset),
-  interpreter_factory = my_sandboxed_runner,
-  source_format = "r"
+### Score the answer and the work
+
+An exact-match metric alone cannot distinguish two correct programs. A
+trace-aware metric can. Here, a correct route scores `1`; a correct route that
+needed a predictor scores `0.9`; a wrong route scores `0`.
+
+```{r router-metric}
+route_metric <- metric_with_trace(
+  function(prediction, expected, program_trace) {
+    observed <- as.character(prediction$queue)
+    wanted <- as.character(expected$queue)
+    correct <- identical(observed, wanted)
+
+    calls <- program_trace$metadata$predictor_calls
+    if (is.null(calls)) {
+      calls <- 0L
+    }
+
+    list(
+      score = if (!correct) 0 else if (calls == 0L) 1 else 0.9,
+      feedback = if (!correct) {
+        sprintf("Expected '%s'; got '%s'.", wanted, observed)
+      } else if (calls > 0L) {
+        paste(
+          "Correct, but a predictor ran.",
+          "Prefer the incident catalog when it covers the ticket."
+        )
+      } else {
+        "Correct and deterministic."
+      }
+    )
+  },
+  field = "queue"
 )
 ```
 
-Treat host tools as privileged capabilities: the sandbox restricts generated
-source, not what an explicitly supplied host function can do. Bridge values
-must be JSON-compatible. `max_predictor_calls` limits bridged predictor calls;
-`max_tool_calls` independently bounds direct host-tool calls and defaults to
-100. Neither limits deterministic R statements. The current portable bridge
-replays guest source with immutable prior responses until it reaches a new
-request or final output; host predictor and tool side effects occur once, but
-deterministic guest statements before a request may run again. Keep those
-statements pure and loops explicitly bounded. Structured runner results carry
-large control values without stdout truncation. Text-only runners advertise a
-finite frame limit and fail with a typed size error before accepting a partial
-frame.
+### Optional: run a live search
 
-## Replace a plan transactionally
+The deterministic package test below is the reproducible proof. A live search
+also lets GEPA propose complete `module_src` candidates, but remote model output
+and runtime vary. Training rows generate feedback; validation rows decide which
+candidate survives. Keep the first run deliberately small and bounded:
 
-Use `bind()` to replace the active source:
-
-```{r bind}
-program$bind(source)
-program$module_src # The validated, canonical source is now active
-```
-
-dsprrr parses, validates, type-checks, and compiles the complete candidate
-before changing the module. If validation fails, the previous source and plan
-remain active. Direct assignment is rejected:
-
-```{r read-only}
-program$module_src <- source
-# Error: module_src is read-only; use bind()
-```
-
-Optimizer infrastructure can use
-`program$apply_optimization_params(list(module_src = candidate))` as the same
-transactional boundary. The module advertises its graph as an optimization
-parameter, but an optimizer only changes `module_src` if that optimizer
-explicitly supports structural candidates. Ordinary prompt optimization does
-not silently rewrite the plan.
-
-## Search complete programs with GEPA
-
-`GEPA()` explicitly supports both Flex source modes. For a program that
-contains Flex leaves, each Flex source is one complete component alongside
-ordinary predictor-instruction components. Source text is never spliced:
-dsprrr copies the program, validates and binds each complete source
-transactionally, then evaluates it through the selected Flex runtime.
-
-```{r gepa-flex}
-metric <- metric_exact_match(field = "answer")
-optimizer <- GEPA(
-  metric = metric,
-  population_size = 6L,
-  generations = 2L,
-  seed = 42L
-)
+```{r router-compile}
+llm <- ellmer::chat_openai(model = "gpt-5-mini")
 
 optimized <- compile(
-  optimizer,
-  program,
-  trainset = question_answer_data,
-  .llm = llm
+  GEPA(
+    metric = route_metric,
+    metric_threshold = 0.95,
+    population_size = 2L,
+    generations = 1L,
+    selection = "current_best",
+    seed = 20260810L,
+    track_best_outputs = TRUE,
+    verbose = FALSE
+  ),
+  baseline,
+  trainset = train,
+  valset = validation,
+  .llm = llm,
+  control = optimizer_control(
+    max_metric_calls = 30L,
+    max_provider_calls = 30L,
+    max_elapsed_seconds = 300,
+    num_threads = 1L,
+    progress = FALSE
+  )
 )
-
-optimized$module_src
-optimized$config$optimizer$component_semantics
 ```
 
-The dedicated source proposer sees the task objective, root and component
-signatures, field descriptions and schemas, source language, allowed
-primitives and tools, current complete source, row-aligned failures, metric
-feedback, and the predictor and host-tool call limits. Provider failures
-propagate instead of being
-disguised as unchanged candidates. Invalid source proposals receive aligned
-failure records for audit and budget accounting but are never selectable.
+Remote model output is stochastic, so a seed does not guarantee identical
+source. Judge the result on held-out behavior, not whether it reproduces one
+particular program string. The limits stop the search and return its best
+partial result after 30 metric calls, 30 provider calls, or five active minutes.
 
-DSPy/GEPA's validation frontier is the union of complete candidate programs
-that win on at least one validation example. dsprrr combines those winners with
-the multi-metric objective Pareto front when choosing parents. Components are
-selected for mutation with round-robin, budget-atomic all-component, or custom
-selection; they do not have separate Pareto frontiers. With a separate
-`valset`, training rows drive discovery/reflection and validation rows drive
-selection, winners, and retained outputs. dsprrr records stable candidate IDs,
-immediate parents and ancestry, aggregate and per-example scores, discovery
-evaluation counts, per-example winners, optional best outputs, attempted merge
-counts, and common-ancestor three-way merges. Fine-grained checkpoint resume
-and GEPA's cached subsample pre-acceptance gate for merges remain explicit
-differences.
+### Compare quality and calls
 
-Freezing a module removes its components from this search. If the complete
-graph has no mutable components, GEPA returns a fresh unchanged program without
-calling the proposer or evaluator and records
-`skip_reason = "no_mutable_components"` in optimizer metadata.
+Report ordinary accuracy separately from the efficiency objective:
 
-## Understand the safety boundary
+```{r router-evaluate}
+accuracy <- metric_exact_match(field = "queue")
 
-JSON Flex controls what predictors run and how typed values flow between them.
-It cannot:
+before <- evaluate(
+  baseline,
+  holdout,
+  metric = accuracy,
+  .llm = llm,
+  .parallel = FALSE,
+  .progress = FALSE
+)
+after <- evaluate(
+  optimized,
+  holdout,
+  metric = accuracy,
+  .llm = llm,
+  .parallel = FALSE,
+  .progress = FALSE
+)
 
-- evaluate R or Python expressions;
-- call arbitrary functions, tools, files, or network services;
-- construct module classes outside the allowlist;
-- reference a later step or create a cycle; or
-- exceed its source-size and predictor-call bounds.
+count_calls <- function(result, field) {
+  sum(vapply(result$metadata, function(metadata) {
+    value <- metadata[[field]]
+    if (is.null(value)) 0L else as.integer(value)
+  }, integer(1)))
+}
 
-Executable Flex deliberately can express control flow and call allowlisted
-capabilities, so its safety depends on the selected runner policy. `r_code_runner()`
-is a trusted-input subprocess runner and does not satisfy the default sandbox
-requirement. Set `require_sandbox = FALSE` only for source you trust.
+comparison <- data.frame(
+  program = c("baseline", "optimized"),
+  accuracy = c(before$mean_score, after$mean_score),
+  predictor_calls = c(
+    count_calls(before, "predictor_calls"),
+    count_calls(after, "predictor_calls")
+  ),
+  tool_calls = c(
+    count_calls(before, "tool_calls"),
+    count_calls(after, "tool_calls")
+  )
+)
+comparison
+```
 
-Flex runs synchronously. Native dataset concurrency is implemented for JSON
-sources with zero or one predictor step. Concurrent executable Flex and
-multi-step JSON requests fail before provider work; their per-row asynchronous
-execution engine is not implemented yet. Matching token-stream requests are
-also rejected because runtime-created predictors are not statically
-discoverable. One-shot `run_stream()` fallback still uses the ordinary
-`forward()` contract.
+The package's deterministic regressions fix the GEPA proposal and model
+responses. One compiles the baseline and selects the hybrid on disjoint
+training and validation rows; the other runs both reviewed programs on six
+held-out tickets:
 
-Program artifacts persist the source language and sandbox policy. Executable
-artifacts also store tools and the factory as registry-backed runtime values,
-so restoring them requires the same registry (or explicit trusted embedding)
-and never invokes a factory during serialization or restoration.
+| Reviewed program | Holdout accuracy | Predictor calls | Tool calls |
+|---|---:|---:|---:|
+| Baseline | 1.00 | 6 | 0 |
+| Hybrid | 1.00 | 3 | 3 |
 
-## Choose Flex deliberately
+That replay verifies proposal, selection, runtime, and call accounting; it is
+not a promise that every stochastic GEPA run will discover the same source. For
+a live run, accept the candidate only when held-out quality is at least as good
+and predictor calls fall:
 
-Use JSON Flex when the search question is a bounded topology choice, such as
-whether a task benefits from an intermediate draft. Use executable Flex when
-optimization genuinely needs coupled source edits across deterministic logic,
-control flow, tools, and predictors and you have an appropriate sandbox. Use a
-regular module when one known topology plus optimized instructions is enough;
-use an explicit pipeline when humans should own and review the topology.
+```{r router-acceptance}
+stopifnot(
+  after$mean_score >= before$mean_score,
+  count_calls(after, "predictor_calls") <
+    count_calls(before, "predictor_calls")
+)
+```
 
-DSPy Flex executes a Python module class and ships a default Deno/Pyodide
-interpreter. dsprrr Flex executes a top-level R `forward()` function and
-requires an explicit factory; source is not portable between the two
-languages. Because both APIs are experimental, persist `module_src`, runtime
-bindings, and package versions, then revalidate a candidate after upgrades.
+The reveal is simple: **Flex did not find a better prompt. It found that half
+the tickets did not need one.**
+
+## Read the program GEPA selected
+
+Always inspect executable source before promoting it. A useful candidate for
+this task has a deterministic catalog path and a predictor fallback:
+
+```{r router-winner}
+optimized$module_src
+```
+
+The deterministic replay selects this shape:
+
+```r
+fallback <- Predict(
+  "$outer",
+  instructions = "Route tickets without a known incident code."
+)
+forward <- function(ticket) {
+  if (grepl("INC-", ticket, fixed = TRUE)) {
+    hit <- lookup_incident(ticket = ticket)
+    if (isTRUE(hit$found)) {
+      return(Prediction(queue = hit$queue))
+    }
+  }
+  fallback(ticket = ticket)
+}
+```
+
+`module_src` is the program Flex optimized—not an explanation of what happened.
+The runtime trace supplies the evidence: predictor calls, tool calls, tokens,
+and the exact source used for each row. GEPA also records the winning candidate
+ID and validation score:
+
+```{r router-audit}
+optimized$config$optimizer$best_candidate_id
+optimized$config$optimizer$best_scores
+optimized$config$optimizer$per_val_instance_best_candidates
+```
+
+Persist callable tools and factories by registry name rather than embedding
+them in the artifact:
+
+```{r router-persist}
+board <- pins::board_folder("pins")
+router_registry <- list(
+  lookup_incident = lookup_incident,
+  sandbox_factory = sandbox_factory
+)
+
+pin_module_config(
+  board,
+  "issue-router-flex",
+  optimized,
+  registry = router_registry
+)
+
+restored <- pins::pin_read(board, "issue-router-flex") |>
+  restore_module_config(registry = router_registry)
+```
+
+Use the same registry names when restoring. Saving and restoring the artifact
+does not invoke the factory. The registry supplies executable authority, so
+version and review its definitions as code. Record the model, package versions,
+data split, metric, and seed beside the pin; pass the model again when running
+the restored fallback path.
+
+## Choose the smaller source language that fits
+
+Flex has two source modes because not every structural question needs code.
+
+| Mode | Use it when | Execution boundary |
+|---|---|---|
+| JSON (default) | GEPA may vary a bounded graph of Predict and Chain-of-Thought steps | Parsed and type-checked as data; no code interpreter |
+| R (opt-in) | Candidates need branches, deterministic computation, dynamic predictors, or named tools | Fresh runner from `interpreter_factory`; enforced sandbox required by default |
+
+JSON sources use backward references between ordered steps and map their final
+values to the outer signature. See [`flex()`](../reference/flex.html) for the
+schema and limits. Start there unless the optimization question truly needs R
+control flow or tools.
+
+Executable Flex exposes a small set of predictor constructors plus the named
+tools you supply. Those tools execute on the host and keep their closure
+environments, so treat each one as a privileged capability.
+
+`max_predictor_calls` limits predictor invocations across the bridge, and
+`max_tool_calls` limits direct host-tool requests. A single agentic predictor
+such as ReAct, CodeAct, or RLM can perform additional work internally; configure
+that primitive's own limits as well.
+
+The guest source runs again from the beginning after each bridged request while
+recorded host responses are replayed. Keep guest-side computation pure, avoid
+external side effects, and bound loops explicitly.
+
+Generated R must run in an enforced sandbox. `r_code_runner()` isolates a
+subprocess but is for source you already trust; do not disable
+`require_sandbox` for optimizer-authored code. Executable Flex is synchronous,
+so evaluate it with `.parallel = FALSE`; specialized token streaming is not
+available.
+
+## When Flex is the wrong tool
+
+Do not use Flex merely because a task contains more than one step. Prefer a
+regular module when prompt or demonstration optimization is enough. Prefer an
+explicit pipeline when people should design and review the workflow. If a
+decision is entirely deterministic and already known, write an R function.
+
+Use Flex for the unresolved middle: the outcome is measurable, several
+implementation strategies are plausible, and the choice of model calls, code,
+or tools is itself what you want to optimize.
+
+For algorithm details, see [Advanced
+Optimization](../articles/advanced-optimization.html). For intentional API
+differences and remaining gaps, see [dsprrr vs.
+DSPy](../articles/dspy-comparison.html).

--- a/vignettes/cheatsheet.Rmd
+++ b/vignettes/cheatsheet.Rmd
@@ -306,7 +306,7 @@ flowchart TB
   Start -->|Exact computation| POT["type = program_of_thought"]
   Start -->|Tools plus R code| CodeAct["type = codeact"]
   Start -->|Explore large context| RLM["type = rlm"]
-  Start -->|Vary predictor structure| Flex["type = flex (experimental)"]
+  Start -->|Optimize how the task executes| Flex["type = flex (experimental)"]
 ```
 
 | Type | Class | Use Case |
@@ -318,7 +318,7 @@ flowchart TB
 | `"program_of_thought"` | `ProgramOfThoughtModule` | Generate and execute R code |
 | `"codeact"` | `CodeActModule` | Combine tools and R code |
 | `"rlm"` | `RLMModule` | Explore large context through a REPL |
-| `"flex"` | `FlexModule` | Validated JSON graph or interpreter-backed R source (experimental) |
+| `"flex"` | `FlexModule` | Optimize predictor, R-logic, and tool strategy (experimental) |
 
 ### Code Runner Ownership
 
@@ -344,31 +344,21 @@ backend-specific.
 ```{r flex-cheatsheet}
 #| eval: false
 program <- flex("question -> answer")
-program$module_src       # Canonical, read-only JSON
+program$module_src       # Validated, read-only JSON
 program$bind(candidate)  # Validate and replace transactionally
 
 code_program <- flex(
   "question -> answer",
   module_src = "forward <- function(question) Prediction(answer = question)",
-  interpreter_factory = my_sandboxed_runner,
+  interpreter_factory = function() mcp_repl_runner(timeout = 30),
   source_format = "r"
-)
-
-optimized <- compile(
-  GEPA(metric = metric_exact_match(field = "answer"), seed = 42L),
-  program,
-  trainset = question_answer_data,
-  .llm = llm
 )
 ```
 
-JSON Flex version 1 permits Predict and Chain-of-Thought graphs. Executable
-Flex adds complete R `forward()` source, deterministic control flow, the DSPy
-Flex primitive family, and named host tools behind a fresh interpreter and a
-versioned bridge. `max_tool_calls` separately bounds privileged host calls.
-GEPA validates complete candidate sources and selects
-parents from validation-example winners with component selection and lineage
-metadata kept separately.
+Use JSON Flex for a bounded Predict/Chain-of-Thought graph. Use executable Flex
+when GEPA may need R control flow, dynamic predictors, or named tools; generated
+source requires a fresh sandboxed interpreter. See [Flex: Optimize the Whole
+Program](flex-optimization.html).
 
 ---
 

--- a/vignettes/concepts-optimization-theory.Rmd
+++ b/vignettes/concepts-optimization-theory.Rmd
@@ -37,7 +37,8 @@ When you build an LLM application, you're implicitly defining an optimization pr
 
 Traditional prompt engineering solves this by hand: you write prompts, test
 them, and tweak them. Most dsprrr optimizers automate that prompt search;
-experimental Flex also exposes a constrained predictor structure to GEPA.
+experimental Flex lets GEPA optimize how the module executes, including
+predictor structure and, in executable mode, R logic and selected tools.
 
 ## What Gets Optimized
 
@@ -364,13 +365,13 @@ compiled <- compile(tp, mod, trainset)
 ```
 
 GEPA reflects on failed examples, proposes revised instructions, evaluates
-them, and keeps a Pareto frontier across metrics. This is reflective prompt
-evolution, not general genetic programming over executable programs. For
-ordinary modules, optional crossover combines instruction text. When a program
-contains Flex leaves, crossover instead selects complete parent component
-values atomically, including full `module_src` strings; it never splices JSON
-source text. GEPA is useful when feedback is informative and you can afford
-repeated evaluation.
+them, and keeps a Pareto frontier across metrics. For ordinary modules this is
+reflective prompt evolution: optional crossover combines instruction text.
+When a program contains Flex leaves, GEPA can instead select complete
+`module_src` values atomically; it never splices source text. GEPA is useful
+when feedback is informative and you can afford repeated evaluation. See
+[Flex: Optimize the Whole Program](flex-optimization.html) when the
+implementation itself should be part of the search.
 
 ### AutoResearch and Meta-Harness: Agentic Program Search
 

--- a/vignettes/dspy-comparison.Rmd
+++ b/vignettes/dspy-comparison.Rmd
@@ -51,26 +51,18 @@ provider communication.
 | `dspy.Refine` | `refine()` | Retries with LLM-generated feedback |
 | `dspy.MultiChainComparison` | `multi_chain_comparison()` | |
 | `dspy.RLM` | `rlm_module()` | Recursive language models over an R REPL; accepts the 3.3 `max_iters` spelling and either runner lifecycle. Tool names, inputs, sub-LM responses, and authenticated control frames are validated strictly; compacted mcp-repl control responses fail closed |
-| Experimental `dspy.Flex` | `flex()` | Dual-mode analogue: a safe versioned JSON graph by default, plus opt-in complete R source in a fresh interpreter with a versioned host bridge and separate predictor/tool budgets. R source defines `forward()` rather than a Python module class, and no default sandbox is silently selected |
+| Experimental `dspy.Flex` | `flex()` | GEPA can optimize a bounded predictor graph or an R `forward()` program. dsprrr requires an explicit fresh interpreter for executable source rather than choosing a default sandbox |
 | `dspy.Parallel` / `Module.batch` | `run_dataset()`, `run(..., .parallel = TRUE)` | Batch over a data frame; heterogeneous (module, example) fan-out is not yet a dedicated module |
 | `dspy.majority` | `ensemble()` with `reduce_majority()` | Plus `reduce_weighted_vote()`, `reduce_best_by_metric()` |
 | `dspy.KNN` | `KNNFewShot` teleprompter / KNN module | Bring-your-own vectorizer (e.g., `ragnar::embed_openai()`) |
 | Retrieval (custom functions) | `rag_module()` + ragnar | First-class ragnar retriever integration |
 
-For ProgramOfThought, CodeAct, and RLM, `runner` and
-`interpreter_factory` are mutually exclusive and one is required. A direct
-`runner` is caller-owned: dsprrr reuses the object across invocations and never
-closes it, while the backend determines whether execution state persists and
-whether reset is available. An `interpreter_factory` is a zero-argument
-function called once per invocation; its fresh runner is owned by dsprrr and
-closed exactly once when that invocation ends, including on failure. This
-mirrors DSPy 3.3's lifecycle while retaining an explicit caller-owned option
-for R workflows.
-
-Executable Flex accepts only `interpreter_factory`, never a caller-owned
-runner, so each call has isolated bridge state. Its default
-`require_sandbox = TRUE` rejects trusted-input-only runners. The declarative
-JSON mode remains the resource-free default and needs no interpreter.
+For ProgramOfThought, CodeAct, and RLM, choose either a caller-owned `runner`
+or a zero-argument `interpreter_factory` that creates a fresh runner per
+invocation. Executable Flex accepts only the factory form and requires an
+enforced sandbox by default; JSON Flex needs no interpreter. See [Flex:
+Optimize the Whole Program](flex-optimization.html) for the practical choice
+between those modes.
 
 One notable difference: DSPy 3.0 *removed* `dspy.Assert`/`dspy.Suggest`
 in favor of `BestOfN`/`Refine`. dsprrr keeps both styles: declarative
@@ -89,7 +81,7 @@ feedback injection.
 | `BootstrapFewShotWithRandomSearch` | `BootstrapFewShotWithRandomSearch` | Equivalent |
 | `MIPROv2` | `MIPROv2` | Discrete Bayesian optimization with UCB over instruction + demo candidates |
 | `SIMBA` | `SIMBA` | Adapted: hard-example mining + LLM-generated rules; simplified vs. the full introspective algorithm |
-| `GEPA` | `GEPA` | Adapted: reflective mutation and validated complete-program candidates for ordinary and Flex programs. dsprrr separates trainset discovery from valset selection, combines validation-example winners with the multi-metric Pareto front, supports round-robin/budget-atomic-all/custom component selection, and records immediate lineage, attempted merges, per-example scores/winners, and optional retained outputs. Cached subsample merge acceptance, fine-grained resume, and built-in experiment trackers remain different |
+| `GEPA` | `GEPA` | Adapted reflective optimization for instructions and complete Flex sources, with separate train/validation roles, multi-objective selection, lineage, and optional retained outputs. Cached subsample merge acceptance, fine-grained resume, and built-in experiment trackers remain different |
 | `COPRO` | `COPRO` | Equivalent (coordinate ascent over instructions) |
 | `KNNFewShot` | `KNNFewShot` | Equivalent |
 | `Ensemble` | `Ensemble` | Equivalent |
@@ -226,15 +218,11 @@ optimizers operate on single modules).
 
 In rough priority order, based on the stable DSPy 3.3 runtime:
 
-1. **Remaining Flex parity**: dsprrr now supports complete interpreter-backed
-   R source, deterministic computation, control flow, explicit host tools, the
-   DSPy Flex primitive family, separate runtime predictor/tool-call limits, and
-   GEPA source search. It intentionally requires an explicit interpreter
-   factory rather than selecting a default sandbox, uses a top-level R
-   `forward()` function rather than a Python module class, and cannot port
-   source between the two.
-   Concurrent executable evaluation, fine-grained checkpoint resume, and
-   GEPA's cached subsample merge-acceptance gate remain unimplemented.
+1. **Remaining Flex gaps**: concurrent executable evaluation, fine-grained
+   checkpoint resume, and GEPA's cached subsample merge-acceptance gate remain
+   unimplemented. The top-level R `forward()` function, explicit interpreter
+   factory, and non-portable R/Python source are intentional API differences,
+   not missing parity.
 2. **One package-wide invocation/result contract** carrying native turns,
    usage, cost, cache state, timing, and normalized errors across every module.
 3. **Package-level OpenTelemetry spans** for module, optimizer, evaluation,


### PR DESCRIPTION
## Summary

- Reframe Flex around optimizing how a module executes—control flow, predictor selection, and tools—not only prompt text.
- Replace the previous API tour with a reproducible issue-router demo that preserves 6/6 held-out accuracy while reducing predictor calls from 6 to 3.
- Harden executable Flex over mcp-repl with realized wrapper arguments, bounded compressed replays, fresh per-step protocol nonces, and fail-closed preview recovery.
- Preserve ellmer ToolDef descriptions and argument schemas in GEPA proposer contracts.
- Align the README, references, pkgdown site, advanced guides, comparison docs, persistence, and sandbox guidance.

## Demonstration

| Program | Correct | Predictor calls | Tool calls |
| --- | ---: | ---: | ---: |
| Baseline | 6/6 | 6 | 0 |
| Hybrid | 6/6 | 3 | 3 |

Known incident codes take the deterministic host-tool path; ambiguous tickets fall back to one predictor call.

## Verification

- R CMD check: 0 errors, 0 warnings, 0 notes.
- Full test suite: 6,494 passed; 10 expected skips.
- Focused Flex and runtime tests: 836 passed.
- Real managed mcp-repl smoke tests passed for deterministic and predictor-fallback paths.
- Pkgdown check and full site build passed; desktop and mobile browser review found no overflow or console errors.
- Air formatting and git diff checks passed.
- Jarl reports only 33 pre-existing baseline findings; no finding originates in this commit.