### PR TITLE
Harden RLM execution and document DSPy 3.3 parity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,25 +36,55 @@ First development changelog. dsprrr is experimental; the API may change.
   invocation-owned code runner, which dsprrr closes exactly once when the
   invocation ends. A directly supplied `runner` remains caller-owned and is
   reused; whether state persists or can be reset is backend-specific. Supply
-  exactly one of `runner` and `interpreter_factory`.
+  exactly one of `runner` and `interpreter_factory`. RLM now requires the
+  selected runner to advertise `persistent = TRUE`; existing
+  `rlm_module(..., runner = r_code_runner())` calls must opt into
+  `r_code_runner(persistent = TRUE)` or use a persistent factory.
+
+* `r_code_runner(persistent = TRUE)` now keeps one callr process and execution
+  environment alive across `execute()` calls. A factory-backed RLM can stage a
+  large or rich R context once, preserve derived values between iterations, and
+  shut the process down with its invocation-owned lifecycle. The backend
+  remains trusted-input-only and retains the host user's permissions.
+
+* `rlm_module()` now exposes graph-visible `generate_action` and `extract`
+  predictors. GEPA and the agentic harnesses can tune both; nested MIPROv2 can
+  tune their instructions with `max_bootstrapped_demos = 0L`, while unsupported
+  child-demo bootstrapping and BootstrapFewShot or LabeledFewShot on programs
+  containing RLM fail explicitly. BootstrapFewShotWithRandomSearch rejects the
+  same ineligible graphs instead of returning an unchanged baseline marked as
+  compiled. `sub_lm = NULL` inherits the outer LM; recursive single and batch queries return
+  host-produced values through one nonce-bound, schema-checked ordered replay
+  ledger; incompatible typed `SUBMIT()` payloads become repairable
+  observations; and the default 10,000-character module excerpt preserves both
+  head and tail after any stricter runner limit. Structured results report
+  submission versus fallback source, bounded trajectory, requested recursive
+  calls, known provider-call attempts, complete usage when every contributing call
+  reports it, and runner policy. The one-call `rlm()` helper now creates a fresh
+  managed `mcp-repl` sandbox factory by default, while still accepting an
+  explicit runner or interpreter factory.
 
 * The code-runner protocol now has explicit `start()`/`shutdown()` lifecycle
   hooks, typed repairable execution versus terminal interpreter failures, and
   terminal-session invalidation. Code modules do not retry or reuse a runner
   after process/protocol failure and preserve the primary failure when teardown
-  also fails. RLM host tools now cross an authenticated replay bridge, so the
+  also fails. RLM host tools now cross a nonce-bound, schema-checked replay bridge, so the
   original live closure executes once on the host without being deparsed or
-  serialized into guest code. Factory-backed Program of Thought, CodeAct, and RLM modules support
-  isolated async and mirai batch workflows; caller-owned runners remain
-  sequential-only.
+  serialized into guest code. Factory-backed Program of Thought, CodeAct, and
+  RLM modules support isolated async and mirai `run_dataset()` workflows;
+  caller-owned runners remain sequential-only. Direct `run()` calls stage each
+  RLM input as one REPL variable regardless of its R length; explicit batches
+  use `run_dataset()`, with list-columns for rich per-row objects.
 
-* Program artifacts now write format version 4, persist either a runner or an
-  interpreter factory for code-executing modules, and preserve Flex source,
-  source language, predictor- and host-tool-call limits, sandbox requirement,
-  factory, and tools. Valid version 3 runner-only artifacts and the earlier
-  two- and six-field v4 Flex shapes remain readable:
-  dsprrr verifies their closed schema and integrity before upgrading them in
-  memory. Artifact construction and restoration never invoke a stored factory.
+* Program artifacts now write format version 5, including graph-visible RLM
+  action and extraction predictors with their tuned instructions, demos, and
+  optimizer state. Version 4 continues to preserve runtime factories and Flex
+  configuration; valid version 3 runner-only artifacts and earlier v4 Flex/RLM
+  shapes remain readable. dsprrr verifies their original closed schema and
+  integrity before restoration. Non-RLM manifests upgrade in memory; a legacy
+  childless RLM receives fresh default predictors and is written as a complete
+  version 5 graph the next time it is saved. Artifact construction and
+  restoration never invoke a stored factory.
 
 * DSPy 3.3 alignment adds immutable `with_instructions()` and
   `append_instructions()` transforms, plus `metric_with_trace()` for objectives
@@ -95,19 +125,19 @@ First development changelog. dsprrr is experimental; the API may change.
 * DSPy 3.3 execution contracts are enforced in the R runtime: `rlm_module()`
   accepts the `max_iters` alias, rejects duplicate, reserved, missing, and
   ellipsis-style tool names, rejects unexpected invocation inputs, and no
-  longer stringifies arbitrary sub-LM responses. RLM submit/query control frames
-  now survive text-only runners through versioned, per-invocation authenticated
-  envelopes; malformed and duplicate frames fail closed, and one-query batches
-  retain their array shape. `code_act()` now limits tool calls executed inside
-  ellmer's internal tool loop and protects its built-in runner-tool namespace.
-  Authenticated decoding ignores valid stale frames while requiring exactly one
-  frame for the current invocation, and `SUBMIT()` rejects duplicate output
-  names. The generic `module()` factory now routes RLM's `max_iters` alias
-  instead of silently using its `max_iterations` default, and rejects supplying
-  both spellings. CodeAct list aliases are validated against ellmer's
-  provider-neutral tool-name grammar before registration. The RLM alias is
-  appended after the pre-existing positional arguments so older positional
-  calls retain their meaning.
+  longer stringifies arbitrary sub-LM responses. RLM submit/query control
+  frames now survive text-only runners through versioned, per-invocation
+  nonce-bound envelopes; malformed and duplicate frames fail closed, and
+  one-query batches retain their array shape. `code_act()` now limits tool
+  calls executed inside ellmer's internal tool loop and protects its built-in
+  runner-tool namespace. Invocation-bound decoding ignores valid stale frames
+  while requiring exactly one frame for the current invocation, and `SUBMIT()`
+  rejects duplicate output names. The generic `module()` factory now routes
+  RLM's `max_iters` alias instead of silently using its `max_iterations`
+  default, and rejects supplying both spellings. CodeAct list aliases are
+  validated against ellmer's provider-neutral tool-name grammar before
+  registration. The RLM alias is appended after the pre-existing positional
+  arguments so older positional calls retain their meaning.
 
 * Code-executing modules validate runner results consistently and preserve the
   primary execution error if teardown also fails. ProgramOfThought validates
@@ -261,9 +291,11 @@ First development changelog. dsprrr is experimental; the API may change.
   for every module type, instead of triggering a spurious "unknown input"
   warning and being dropped for non-`PredictModule` modules (#dsprrr-jup).
   `PredictModule` (and the wrapper/few-shot modules that delegate to it) honor
-  it for the structured-output cache; modules that drive the LLM directly
-  (e.g. `RAGModule`, `ReActModule`, `RLMModule`) accept `.cache` but do not yet
-  route their own calls through the cache (#dsprrr-aa2).
+  it for the structured-output cache. RLM forwards it to the graph-visible
+  action and fallback predictors; recursive `llm_query()` calls and runner
+  execution remain uncached. Modules that drive the LLM directly (e.g.
+  `RAGModule` and `ReActModule`) accept `.cache` but do not yet route their own
+  calls through the cache (#dsprrr-aa2).
 
 * `BootstrapFewShot` now harvests demonstrations when the metric targets a
   specific output field (e.g. `metric_exact_match(field = "answer")`).

--- a/R/artifact.R
+++ b/R/artifact.R
@@ -11,11 +11,15 @@
 #' `registry` to store stable IDs, or set `trusted = TRUE` to embed them. Embedded
 #' values are restored only when `trusted = TRUE` is also supplied while loading.
 #' Registry IDs are the recommended contract for tools, custom functions,
-#' retrievers, stores, code runners, and interpreter factories. Format version 4
-#' records exactly one runner or factory for each code-executing module without
-#' invoking a factory during write or restore. Valid version 3 runner-only
-#' manifests are checked against their original schema and integrity digest,
-#' then upgraded in memory; other historical versions are rejected.
+#' retrievers, stores, code runners, and interpreter factories. Format version 5
+#' adds graph-visible RLM action and extraction predictors. Version 4 records
+#' exactly one runner or factory for each code-executing module. Valid version 3
+#' runner-only and version 4 manifests are checked against their original schema
+#' and integrity digest. Non-RLM manifests are upgraded in memory. A legacy
+#' childless RLM is restored under its original schema with fresh default child
+#' predictors and becomes a complete version 5 graph when it is next saved.
+#' Other historical versions are rejected. Factories are never invoked during
+#' write or restore.
 #'
 #' Declarative ellmer text, JSON, inline/remote image, and PDF content is stored
 #' through a closed codec. Remote content URLs must be stable HTTPS URLs without
@@ -61,10 +65,10 @@
 #' @name program-artifact
 NULL
 
-artifact_format_version <- function() 4L
+artifact_format_version <- function() 5L
 
 artifact_supported_format_versions <- function() {
-  c(3L, artifact_format_version())
+  c(3L, 4L, artifact_format_version())
 }
 
 #' @rdname program-artifact
@@ -2368,26 +2372,45 @@ artifact_validate_manifest <- function(artifact) {
 }
 
 artifact_upgrade_manifest <- function(artifact) {
-  if (!identical(as.integer(artifact$format_version), 3L)) {
+  version <- as.integer(artifact$format_version)
+  if (!version %in% c(3L, 4L)) {
+    return(artifact)
+  }
+
+  # Legacy RLM manifests are intentionally restored under their original
+  # schema so the constructor can supply fresh default child predictors. The
+  # next write serializes those children as a complete v5 graph.
+  has_childless_rlm <- any(vapply(
+    artifact$graph$nodes,
+    function(node) {
+      identical(node$class, "RLMModule") &&
+        artifact_is_plain_list(node$children) &&
+        length(node$children) == 0L
+    },
+    logical(1)
+  ))
+  if (has_childless_rlm) {
     return(artifact)
   }
 
   upgraded <- artifact
-  runtime_classes <- c(
-    "ProgramOfThoughtModule",
-    "CodeActModule",
-    "RLMModule"
-  )
-  for (id in names(upgraded$graph$nodes)) {
-    node <- upgraded$graph$nodes[[id]]
-    if (node$class %in% runtime_classes) {
-      runner_position <- match("runner", names(node$fields))
-      node$fields <- append(
-        node$fields,
-        list(interpreter_factory = NULL),
-        after = runner_position
-      )
-      upgraded$graph$nodes[[id]] <- node
+  if (identical(version, 3L)) {
+    runtime_classes <- c(
+      "ProgramOfThoughtModule",
+      "CodeActModule",
+      "RLMModule"
+    )
+    for (id in names(upgraded$graph$nodes)) {
+      node <- upgraded$graph$nodes[[id]]
+      if (node$class %in% runtime_classes) {
+        runner_position <- match("runner", names(node$fields))
+        node$fields <- append(
+          node$fields,
+          list(interpreter_factory = NULL),
+          after = runner_position
+        )
+        upgraded$graph$nodes[[id]] <- node
+      }
     }
   }
   upgraded$format_version <- artifact_format_version()
@@ -2398,6 +2421,29 @@ artifact_upgrade_manifest <- function(artifact) {
 
 artifact_validate_restored_graph <- function(program, artifact) {
   graph <- module_graph(program, boundaries = "cross", cycles = "record")
+  legacy_rlm_paths <- names(Filter(
+    function(node) {
+      identical(node$class, "RLMModule") &&
+        artifact_is_plain_list(node$children) &&
+        length(node$children) == 0L
+    },
+    artifact$graph$nodes
+  ))
+  if (length(legacy_rlm_paths) > 0L) {
+    implicit_child_paths <- unlist(
+      lapply(
+        legacy_rlm_paths,
+        function(path) {
+          paste0(path, "/", c("generate_action", "extract"))
+        }
+      ),
+      use.names = FALSE
+    )
+    # Older RLM artifacts predate graph-visible predictors. Their restored
+    # modules receive fresh default predictors, which are intentionally absent
+    # from the legacy manifest comparison.
+    graph <- graph[!graph$path %in% implicit_child_paths, , drop = FALSE]
+  }
   expected_paths <- c(
     artifact$root,
     vapply(artifact$graph$edges, `[[`, character(1), "path")
@@ -2538,7 +2584,7 @@ artifact_validate_node_payload <- function(node, malformed, version) {
   artifact_validate_state_and_optimization(node, malformed)
   artifact_validate_provider_model(node$provider_model, node$id, malformed)
   artifact_validate_fields(node, malformed, version = version)
-  artifact_validate_children_schema(node, malformed)
+  artifact_validate_children_schema(node, malformed, version = version)
   invisible(node)
 }
 
@@ -3316,7 +3362,7 @@ artifact_validate_knn_fields <- function(node, malformed) {
   TRUE
 }
 
-artifact_validate_children_schema <- function(node, malformed) {
+artifact_validate_children_schema <- function(node, malformed, version) {
   children <- node$children
   invalid <- function() {
     malformed(paste0("Node ", node$id, " has invalid class-specific children."))
@@ -3327,7 +3373,6 @@ artifact_validate_children_schema <- function(node, malformed) {
     "FnModule",
     "ProgramOfThoughtModule",
     "CodeActModule",
-    "RLMModule",
     "RAGModule",
     "FlexModule"
   )
@@ -3342,6 +3387,23 @@ artifact_validate_children_schema <- function(node, malformed) {
     artifact_is_plain_list(value) &&
       (!nonempty || length(value) > 0L) &&
       all(vapply(value, artifact_is_node_ref, logical(1)))
+  }
+  if (identical(node$class, "RLMModule")) {
+    legacy_childless <- version < 5L &&
+      artifact_is_plain_list(children) &&
+      length(children) == 0L
+    current_children <- version >= 5L &&
+      artifact_is_plain_list(children) &&
+      artifact_names_match(
+        names(children),
+        c("generate_action", "extract")
+      ) &&
+      artifact_is_node_ref(children$generate_action) &&
+      artifact_is_node_ref(children$extract)
+    if (!legacy_childless && !current_children) {
+      invalid()
+    }
+    return(invisible(children))
   }
   valid <- switch(
     node$class,
@@ -3965,7 +4027,9 @@ artifact_construct_module <- function(node, children, registry, trusted) {
       verbose = fields$verbose,
       tools = runtime_list(fields$tools),
       config = config,
-      chat = NULL
+      chat = NULL,
+      generate_action = children$generate_action,
+      extract = children$extract
     ),
     RAGModule = RAGModule$new(
       signature = signature,

--- a/R/evaluate.R
+++ b/R/evaluate.R
@@ -90,15 +90,54 @@ evaluate <- function(module, ...) {
   UseMethod("evaluate")
 }
 
+# Capture a trace boundary that also works for modules with bounded retention.
+evaluation_trace_cursor <- function(module) {
+  traces <- module$state$traces %||% list()
+  sequence <- module$state$trace_sequence %||% NULL
+  if (
+    is.numeric(sequence) &&
+      length(sequence) == 1L &&
+      !is.na(sequence) &&
+      is.finite(sequence) &&
+      sequence >= 0
+  ) {
+    return(list(length = length(traces), sequence = as.numeric(sequence)))
+  }
+  length(traces)
+}
+
+
+# Return trace indices added after a cursor, including when old retained traces
+# were evicted and list length therefore stayed constant.
+evaluation_trace_indices <- function(module, cursor) {
+  traces <- module$state$traces %||% list()
+  if (is.list(cursor) && !is.null(cursor$sequence)) {
+    sequence <- module$state$trace_sequence %||% cursor$sequence
+    added <- as.numeric(sequence) - as.numeric(cursor$sequence)
+    if (!is.finite(added) || added <= 0 || length(traces) == 0L) {
+      return(integer())
+    }
+    retained <- min(length(traces), floor(added))
+    return(seq.int(length(traces) - retained + 1L, length(traces)))
+  }
+  trace_count_before <- as.integer(cursor)
+  if (length(traces) <= trace_count_before) {
+    return(integer())
+  }
+  seq.int(trace_count_before + 1L, length(traces))
+}
+
+
 # Return only traces recorded during one evaluation epoch. The boundary is
 # important for reused modules and cache hits: no earlier trace can leak into a
 # later metric invocation.
 new_evaluation_trace_events <- function(module, trace_count_before) {
   traces <- module$state$traces %||% list()
-  if (length(traces) <= trace_count_before) {
+  indices <- evaluation_trace_indices(module, trace_count_before)
+  if (length(indices) == 0L) {
     return(list())
   }
-  traces[seq.int(trace_count_before + 1L, length(traces))]
+  traces[indices]
 }
 
 # Project the most recent module event onto the row-level metadata surface used
@@ -403,7 +442,7 @@ evaluate.Module <- function(
     } else {
       list(.parallel = parallel_allowed)
     }
-    trace_count_before <- length(module$state$traces %||% list())
+    trace_count_before <- evaluation_trace_cursor(module)
     evaluated <- tryCatch(
       {
         evaluated <- do.call(
@@ -456,10 +495,19 @@ evaluate.Module <- function(
     } else {
       replicate(nrow(evaluated), list(), simplify = FALSE)
     }
-    row_trace_events <- align_evaluation_trace_events(
-      new_evaluation_trace_events(module, trace_count_before),
-      nrow(evaluated)
+    row_trace_events <- attr(
+      evaluated,
+      "dsprrr_row_trace_events",
+      exact = TRUE
     )
+    if (
+      !is.list(row_trace_events) || length(row_trace_events) != nrow(evaluated)
+    ) {
+      row_trace_events <- align_evaluation_trace_events(
+        new_evaluation_trace_events(module, trace_count_before),
+        nrow(evaluated)
+      )
+    }
 
     scores <- numeric(nrow(evaluated))
     run_errors <- vapply(
@@ -488,7 +536,7 @@ evaluate.Module <- function(
       expected_row <- data[i, , drop = FALSE]
       prediction <- predictions[[i]]
       program_trace <- new_program_trace(
-        events = row_trace_events[[i]],
+        events = row_trace_events[[i]] %||% list(),
         metadata = metadata[[i]],
         row_id = .trace_row_ids[[i]],
         epoch = epoch

--- a/R/mcp-repl-runner.R
+++ b/R/mcp-repl-runner.R
@@ -7,7 +7,7 @@
 #' operating-system primitives. This makes it suitable for code proposed by an
 #' optimizer or language model.
 #'
-#' For authenticated RLM submit/query traffic, dsprrr caps each encoded control
+#' For nonce-bound RLM submit/query traffic, dsprrr caps each encoded control
 #' frame at 3,000 bytes so it stays below mcp-repl's inline-output threshold.
 #' If mcp-repl nevertheless returns a file-preview or active-pager marker (for
 #' example because user code printed a large value first), the runner fails the
@@ -33,10 +33,11 @@
 #' - network access disabled by the sandbox; and
 #' - oversized output written to sandbox-visible files.
 #'
-#' The sandbox is deliberately on by default. Setting `sandbox = "off"` is
-#' rejected because this runner advertises itself as safe for untrusted code.
-#' Use [r_code_runner()] explicitly for trusted-input-only subprocess
-#' isolation.
+#' The sandbox is deliberately on by default. It disables network access but
+#' the `workspace-write` policy still permits mutation inside allowed workspace
+#' paths. Setting `sandbox = "off"` is rejected because this runner advertises
+#' an enforced sandbox. Use [r_code_runner()] explicitly for trusted-input-only
+#' subprocess isolation.
 #'
 #' Supplying `repl` is useful for an externally managed MCP connection and for
 #' deterministic tests. It must be a function with the mcp-repl tool contract:
@@ -75,6 +76,7 @@
 #' runner <- mcp_repl_runner()
 #' runner$execute("mean(1:10)")
 #' runner$reset()
+#' runner$close()
 #' }
 mcp_repl_runner <- function(
   repl = NULL,
@@ -751,7 +753,10 @@ McpReplRunner <- R6::R6Class(
       control_value <- if (identical(control_protocol, "flex")) {
         flex_control
       } else if (identical(control_protocol, "rlm")) {
-        decode_rlm_control(raw_text, .control_nonce)
+        # The module decodes this value again after the runner boundary. Mark
+        # it with a process-local identity so arbitrary classed R
+        # objects returned by generated code cannot impersonate control frames.
+        decode_rlm_control(raw_text, .control_nonce, .attest = TRUE)
       } else {
         NULL
       }
@@ -943,19 +948,16 @@ mcp_repl_timeout_ms <- function(timeout) {
 .mcp_repl_request_limit_bytes <- 7000L
 
 mcp_repl_input <- function(code, context) {
-  context_json <- jsonlite::toJSON(
-    context,
-    auto_unbox = TRUE,
-    null = "null",
-    na = "null",
-    dataframe = "rows",
-    digits = NA
-  )
+  # `serializeJSON()` preserves the distinction between data frames, atomic
+  # vectors, and nested replay records. `fromJSON(..., simplifyVector = TRUE)`
+  # cannot preserve all three at once: it repairs data frames by also
+  # simplifying bridge replay ledgers into data frames.
+  context_json <- jsonlite::serializeJSON(context, digits = NA)
   context_literal <- encodeString(as.character(context_json), quote = "\"")
   input <- paste0(
-    ".context <- jsonlite::fromJSON(",
+    ".context <- jsonlite::unserializeJSON(",
     context_literal,
-    ", simplifyVector = FALSE)\n",
+    ")\n",
     code,
     "\n"
   )
@@ -1220,12 +1222,25 @@ mcp_repl_normalize_response <- function(response) {
 
 mcp_repl_truncate <- function(text, max_chars) {
   text <- paste(text %||% "", collapse = "\n")
-  if (nchar(text, type = "chars") <= max_chars) {
+  total <- nchar(text, type = "chars")
+  if (total <= max_chars) {
     return(text)
   }
+  marker <- paste0(
+    "\n... [mcp-repl output truncated by dsprrr; ",
+    total,
+    " total characters] ...\n"
+  )
+  if (nchar(marker, type = "chars") + 2L > max_chars) {
+    return(substr(text, 1L, max_chars))
+  }
+  visible <- max_chars - nchar(marker, type = "chars")
+  head_chars <- ceiling(visible / 2)
+  tail_chars <- floor(visible / 2)
   paste0(
-    substr(text, 1L, max_chars),
-    "\n... [mcp-repl output truncated by dsprrr]"
+    substr(text, 1L, head_chars),
+    marker,
+    substr(text, total - tail_chars + 1L, total)
   )
 }
 
@@ -1237,7 +1252,7 @@ mcp_repl_rlm_transport_issue <- function(text, oversized_output) {
 
   if (
     grepl(
-      "Authenticated RLM control frame exceeds the runner transport limit",
+      "RLM control frame exceeds the runner transport limit",
       text,
       fixed = TRUE
     )
@@ -1283,26 +1298,26 @@ mcp_repl_transport_error_result <- function(
   detail <- switch(
     issue,
     files = paste(
-      "mcp-repl compacted authenticated RLM output into a file preview;",
+      "mcp-repl compacted nonce-bound RLM output into a file preview;",
       "the control frame could not be verified"
     ),
     pager = paste(
-      "mcp-repl entered its pager while returning authenticated RLM output;",
+      "mcp-repl entered its pager while returning nonce-bound RLM output;",
       "the session was reset because the control frame could not be verified"
     ),
     `pager-reset-failed` = paste(
-      "mcp-repl entered its pager while returning authenticated RLM output;",
+      "mcp-repl entered its pager while returning nonce-bound RLM output;",
       "the control frame could not be verified and the session could not be reset"
     ),
     `control-frame-limit` = paste(
-      "the authenticated RLM control frame exceeded mcp-repl's safe inline",
+      "the RLM control frame exceeded mcp-repl's safe inline",
       "transport limit"
     ),
     `flex-control` = paste(
       "mcp-repl returned executable Flex output whose control frame",
       "could not be verified"
     ),
-    "authenticated RLM output could not be verified"
+    "nonce-bound RLM output could not be verified"
   )
   result <- mcp_repl_error_result(
     detail,

--- a/R/module-base.R
+++ b/R/module-base.R
@@ -178,8 +178,9 @@ Module <- R6::R6Class(
           }
           inputs <- lapply(
             inputs,
-            batch_recycle_input,
-            size = input_contract$size
+            function(value) {
+              module_batch_recycle_input(self, value, input_contract$size)
+            }
           )
           return(run_factory_interpreter_batch(
             module = self,
@@ -188,7 +189,8 @@ Module <- R6::R6Class(
             .llm = .llm,
             .progress = .progress,
             .return_format = .return_format,
-            .concurrency = runtime
+            .concurrency = runtime,
+            .cache = .cache
           ))
         }
         if (
@@ -1220,6 +1222,74 @@ factory_interpreter_history_field <- function(module) {
 }
 
 
+# Append one RLM observability record while preserving the module's bounded
+# retention contract when records are merged back from isolated workers.
+append_factory_interpreter_rlm_record <- function(records, record) {
+  limit <- getOption("dsprrr.rlm_trace_limit", 100L)
+  if (
+    !is.numeric(limit) ||
+      length(limit) != 1L ||
+      is.na(limit) ||
+      !is.finite(limit) ||
+      limit < 1L
+  ) {
+    limit <- 100L
+  }
+  records <- append(records %||% list(), list(record))
+  if (length(records) > floor(limit)) {
+    records <- utils::tail(records, floor(limit))
+  }
+  records
+}
+
+
+# Commit a canonical RLM trace produced by an isolated interpreter worker.
+# Worker-local state and prompt history disappear with the mirai process, so
+# both stores must be reconstructed in the parent in input-row order.
+commit_factory_interpreter_trace <- function(module, trace, index, runtime) {
+  if (!inherits(module, "RLMModule") || is.null(trace)) {
+    return(invisible(module))
+  }
+  if (!is.list(trace)) {
+    cli::cli_abort(
+      "Interpreter worker returned an invalid canonical trace",
+      class = "dsprrr_trace_contract_error"
+    )
+  }
+
+  trace_cursor <- evaluation_trace_cursor(module)
+  history_generation_before <- prompt_history_generation()
+  sequence <- module$state$trace_sequence %||% 0
+  valid_sequence <- is.numeric(sequence) &&
+    length(sequence) == 1L &&
+    !is.na(sequence) &&
+    is.finite(sequence) &&
+    sequence >= 0
+  if (!valid_sequence) {
+    cli::cli_abort(
+      "RLM trace sequence is invalid",
+      class = "dsprrr_trace_contract_error"
+    )
+  }
+
+  module$state$trace_sequence <- as.numeric(sequence) + 1
+  module$state$traces <- append_factory_interpreter_rlm_record(
+    module$state$traces,
+    trace
+  )
+
+  add_to_global_history(trace, source = "RLMModule")
+  reconcile_dataset_row_observability(
+    module = module,
+    trace_count_before = trace_cursor,
+    history_generation_before = history_generation_before,
+    row_index = index,
+    runtime = runtime
+  )
+  invisible(module)
+}
+
+
 format_factory_interpreter_batch_row <- function(
   result,
   index,
@@ -1268,24 +1338,30 @@ run_factory_interpreter_batch <- function(
   .llm,
   .progress,
   .return_format,
-  .concurrency
+  .concurrency,
+  .cache = NULL
 ) {
+  validate_cache_arg(.cache)
   input_sets <- lapply(seq_len(n), function(i) lapply(inputs, `[[`, i))
   history_field <- factory_interpreter_history_field(module)
+  row_trace_events <- vector("list", n)
   llm <- .llm %||% module$chat %||% get_default_chat()
   if (is.null(llm)) {
     cli::cli_abort("No LLM provided. Pass .llm or set a default chat.")
   }
 
   if (identical(.concurrency$effective_backend, "sequential")) {
-    rows <- lapply(seq_len(n), function(index) {
+    rows <- vector("list", n)
+    for (index in seq_len(n)) {
+      trace_count_before <- evaluation_trace_cursor(module)
+      history_generation_before <- prompt_history_generation()
       result <- tryCatch(
         {
           forwarded <- module$forward(
             input_sets[[index]],
             .llm = llm,
             trace = TRUE,
-            .cache = FALSE
+            .cache = .cache
           )
           list(
             output = forwarded$output[[1L]],
@@ -1296,14 +1372,25 @@ run_factory_interpreter_batch <- function(
         interrupt = function(condition) stop(condition),
         error = function(condition) condition
       )
-      format_factory_interpreter_batch_row(
+      reconcile_dataset_row_observability(
+        module = module,
+        trace_count_before = trace_count_before,
+        history_generation_before = history_generation_before,
+        row_index = index,
+        runtime = .concurrency
+      )
+      row_trace_events[[index]] <- new_evaluation_trace_events(
+        module,
+        trace_count_before
+      )
+      rows[[index]] <- format_factory_interpreter_batch_row(
         result,
         index,
         .return_format,
         .concurrency,
         chat = llm
       )
-    })
+    }
   } else {
     profile <- new_dsprrr_mirai_profile()
     mapped <- NULL
@@ -1333,7 +1420,8 @@ run_factory_interpreter_batch <- function(
       module,
       llm,
       history_field,
-      namespace_path
+      namespace_path,
+      cache
     ) {
       if (
         file.exists(file.path(namespace_path, "R", "module-base.R")) &&
@@ -1345,16 +1433,40 @@ run_factory_interpreter_batch <- function(
       }
       tryCatch(
         {
+          trace_cursor <- if (inherits(module, "RLMModule")) {
+            get(
+              "evaluation_trace_cursor",
+              envir = asNamespace("dsprrr")
+            )(module)
+          } else {
+            NULL
+          }
           forwarded <- module$forward(
             input_set,
             .llm = llm,
             trace = TRUE,
-            .cache = FALSE
+            .cache = cache
           )
           history <- if (is.null(history_field)) {
             list()
           } else {
             module$state[[history_field]]
+          }
+          trace <- if (is.null(trace_cursor)) {
+            NULL
+          } else {
+            trace_indices <- get(
+              "evaluation_trace_indices",
+              envir = asNamespace("dsprrr")
+            )(module, trace_cursor)
+            if (length(trace_indices) == 0L) {
+              cli::cli_abort(
+                "RLM worker completed without a canonical trace",
+                class = "dsprrr_trace_contract_error"
+              )
+            } else {
+              module$state$traces[[trace_indices[[length(trace_indices)]]]]
+            }
           }
           list(
             ok = TRUE,
@@ -1364,7 +1476,8 @@ run_factory_interpreter_batch <- function(
               history[[length(history)]]
             } else {
               NULL
-            }
+            },
+            trace = trace
           )
         },
         interrupt = function(condition) stop(condition),
@@ -1384,7 +1497,8 @@ run_factory_interpreter_batch <- function(
         module = module,
         llm = llm,
         history_field = history_field,
-        namespace_path = namespace_path
+        namespace_path = namespace_path,
+        cache = .cache
       ),
       .compute = profile
     )
@@ -1398,7 +1512,8 @@ run_factory_interpreter_batch <- function(
       profile_owned <- FALSE
     }
 
-    rows <- lapply(seq_len(n), function(index) {
+    rows <- vector("list", n)
+    for (index in seq_len(n)) {
       record <- records[[index]]
       if (mirai::is_mirai_error(record)) {
         condition <- simpleError(record$message %||% as.character(record))
@@ -1418,20 +1533,37 @@ run_factory_interpreter_batch <- function(
           metadata = record$metadata
         )
         if (!is.null(history_field) && !is.null(record$history)) {
-          module$state[[history_field]] <- append(
-            module$state[[history_field]],
-            list(record$history)
-          )
+          module$state[[history_field]] <- if (inherits(module, "RLMModule")) {
+            append_factory_interpreter_rlm_record(
+              module$state[[history_field]],
+              record$history
+            )
+          } else {
+            append(module$state[[history_field]], list(record$history))
+          }
         }
+        trace_count_before <- evaluation_trace_cursor(module)
+        commit_factory_interpreter_trace(
+          module = module,
+          trace = record$trace,
+          index = index,
+          runtime = .concurrency
+        )
+        row_trace_events[[index]] <- new_evaluation_trace_events(
+          module,
+          trace_count_before
+        )
       }
-      format_factory_interpreter_batch_row(
+      rows[[index]] <- format_factory_interpreter_batch_row(
         result,
         index,
         .return_format,
         .concurrency
       )
-    })
+    }
   }
+
+  attr(rows, "dsprrr_row_trace_events") <- row_trace_events
 
   if (identical(.return_format, "structured")) {
     structure(rows, class = c("dsprrr_batch_result", "list"))

--- a/R/module-predict.R
+++ b/R/module-predict.R
@@ -75,10 +75,17 @@ PredictModule <- R6::R6Class(
       request <- build_module_request(self, inputs)
       prompt <- request$prompt
       llm <- resolve_module_llm(self, .llm = .llm)
+      turns_before <- batch_chat_turns(llm)
       start_turn_count <- tryCatch(
         length(llm$get_turns()),
         error = function(e) 0L
       )
+      cache_state <- new.env(parent = emptyenv())
+      cache_state$status <- "unknown"
+      cache_observer <- function(status, ...) {
+        cache_state$status <- status
+        invisible(NULL)
+      }
 
       # Record start time
       start_time <- Sys.time()
@@ -91,7 +98,8 @@ PredictModule <- R6::R6Class(
             request = request,
             output_type = self$signature@output_type,
             .cache = .cache,
-            rollout_id = rollout_id
+            rollout_id = rollout_id,
+            .observer = cache_observer
           )
         },
         error = function(e) {
@@ -132,16 +140,27 @@ PredictModule <- R6::R6Class(
         error = function(e) list(user_turn, assistant_turn)
       )
 
-      # Extract token info from ellmer's AssistantTurn (has @tokens vector)
-      token_info <- if (
-        !is.null(assistant_turn) && !is.null(assistant_turn@tokens)
-      ) {
+      verified_usage <- chat_usage_metadata(llm, turns_before)
+      token_info <- if (!is.na(verified_usage$provider_calls)) {
+        verified_usage[c(
+          "input_tokens",
+          "output_tokens",
+          "cached_input_tokens",
+          "total_tokens"
+        )]
+      } else if (!is.null(assistant_turn) && !is.null(assistant_turn@tokens)) {
         tokens <- assistant_turn@tokens
+        input_tokens <- tokens[1]
+        output_tokens <- tokens[2]
         list(
-          input_tokens = tokens[1],
-          output_tokens = tokens[2],
+          input_tokens = input_tokens,
+          output_tokens = output_tokens,
           cached_input_tokens = tokens[3],
-          total_tokens = sum(tokens[1:2], na.rm = TRUE)
+          total_tokens = if (anyNA(c(input_tokens, output_tokens))) {
+            NA_integer_
+          } else {
+            as.integer(input_tokens + output_tokens)
+          }
         )
       } else {
         list(
@@ -152,12 +171,30 @@ PredictModule <- R6::R6Class(
         )
       }
 
-      # Get cost and duration from AssistantTurn
-      cost <- if (!is.null(assistant_turn)) assistant_turn@cost else NA_real_
-      duration_s <- if (!is.null(assistant_turn)) {
+      # Get cost and duration from every verified current-call assistant turn.
+      cost <- if (!is.na(verified_usage$provider_calls)) {
+        verified_usage$cost
+      } else if (!is.null(assistant_turn)) {
+        assistant_turn@cost
+      } else {
+        NA_real_
+      }
+      duration_s <- if (!is.na(verified_usage$provider_calls)) {
+        verified_usage$duration_s
+      } else if (!is.null(assistant_turn)) {
         assistant_turn@duration
       } else {
         NA_real_
+      }
+
+      provider_calls <- if (identical(cache_state$status, "hit")) {
+        0L
+      } else if (!is.na(verified_usage$provider_calls)) {
+        verified_usage$provider_calls
+      } else if (cache_state$status %in% c("miss", "bypass")) {
+        1L
+      } else {
+        NA_integer_
       }
 
       model <- tryCatch(llm$get_model(), error = function(e) NA_character_)
@@ -175,7 +212,9 @@ PredictModule <- R6::R6Class(
         total_tokens = token_info$total_tokens,
         cost = cost,
         duration_s = duration_s,
-        latency_ms = latency_ms # Our measured latency (includes R overhead)
+        latency_ms = latency_ms, # Our measured latency (includes R overhead)
+        cache = cache_state$status,
+        provider_calls = provider_calls
       )
 
       # Record trace if requested - store ellmer turns directly
@@ -192,7 +231,9 @@ PredictModule <- R6::R6Class(
           latency_ms = latency_ms,
           tokens = token_info,
           cost = cost,
-          model = model
+          model = model,
+          cache = cache_state$status,
+          provider_calls = provider_calls
         )
 
         # Optionally include full chat object for advanced replay
@@ -466,14 +507,16 @@ PredictModule <- R6::R6Class(
       request,
       output_type,
       .cache = NULL,
-      rollout_id = NULL
+      rollout_id = NULL,
+      .observer = NULL
     ) {
       call_llm_request(
         llm = llm,
         request = request,
         output_type = output_type,
         .cache = .cache,
-        rollout_id = rollout_id
+        rollout_id = rollout_id,
+        .observer = .observer
       )
     }
   ),

--- a/R/module-rlm.R
+++ b/R/module-rlm.R
@@ -1,75 +1,69 @@
 #' Recursive Language Model (RLM) Module
 #'
 #' @description
-#' A module that transforms context from "input" to "environment", enabling LLMs
-#' to programmatically explore large contexts through a REPL interface rather
-#' than embedding them in prompts.
+#' An experimental inference-time analyst for inputs whose useful evidence is
+#' too large, irregular, or unpredictable to place in one prompt. RLM keeps the
+#' inputs in an R environment and lets the model iteratively inspect summaries,
+#' run computations, and decide what to examine next.
 #'
 #' @details
-#' Instead of `llm(prompt, context=huge_document)`, RLM stores context as R
-#' variables that the LLM can peek, slice, search, and recursively query.
+#' Each input is available under `.context`. Generated R code can use ordinary R
+#' plus `peek()`, `search()`, value-returning `llm_query()` calls, declared host
+#' tools, and `SUBMIT(...)`. RLM requires a runner whose `policy()` advertises
+#' `persistent = TRUE`; variables therefore remain available across turns within
+#' one invocation. Invalid submitted fields or types become iteration errors
+#' that the model can repair. If no valid submission is produced, the separate
+#' `extract` predictor performs one typed fallback.
+#' RLM validates explicit ellmer string, number, integer, boolean, enum, array,
+#' and object outputs. Opaque `TypeJsonSchema` nodes are rejected at
+#' construction because they cannot participate in this strict repair loop.
 #'
-#' The execution flow is:
-#' 1. Context is made available as variables in an R execution environment
-#' 2. LLM generates R code to explore and analyze the context
-#' 3. Code is executed by the configured code runner
-#' 4. Results are fed back to the LLM for the next iteration
-#' 5. Process continues until SUBMIT() is called or max_iterations reached
-#' 6. If max_iterations reached without SUBMIT(), fallback extraction is used
+#' The `generate_action` and `extract` predictors are graph-visible through
+#' [named_modules()]. GEPA can tune them; nested MIPROv2 is instruction-only
+#' with bootstrapped demos disabled. BootstrapFewShot and LabeledFewShot reject
+#' programs containing an RLM until predictor-local demonstrations are
+#' available.
+#' Model-visible execution evidence defaults to a 10,000-character head-and-tail view
+#' after any runner-level transport limit; that formatted evidence is retained
+#' in the returned trajectory. Trace state retains hashes and sizes for input
+#' objects, not their full values.
+#' Structured metadata separates logical action, recursive, and extraction
+#' counts from verified provider calls. A child-predictor cache hit contributes
+#' zero provider calls and zero current-run usage; totals remain `NA` whenever
+#' every contributing provider turn cannot be verified.
 #'
-#' Available REPL tools:
-#' - `SUBMIT(...)`: Terminate and return final output values
-#' - `peek(var, start, end)`: View a slice of a variable (default: first 1000 chars)
-#' - `search(var, pattern)`: Regex search in variable
-#' - `llm_query(query, context_slice)`: Recursive LLM call (requires sub_lm)
-#' - `llm_query_batched(queries, slices)`: Batched recursive calls
+#' For generated code, prefer a fresh sandboxed [mcp_repl_runner()] factory.
+#' Its managed transport is intentionally bounded and is best for compact,
+#' JSON-compatible context. Its default policy disables network access but
+#' allows writes within the configured workspace. Declared host tools execute
+#' in the dsprrr host process, outside that guest sandbox. This backend requires
+#' the suggested `mcptools` package and Posit's external `mcp-repl` executable.
+#' For large data frames or richer local R objects,
+#' `r_code_runner(persistent = TRUE)` can stage context once, but it is
+#' trusted-input-only: the child process retains the host user's file, network,
+#' and environment permissions.
 #'
-#' Security: Code execution requires explicit opt-in via `runner` or
-#' `interpreter_factory`.
-#' The built-in runner uses a separate process but is NOT a security sandbox.
-#' Inspect `runner$policy()` before execution. For untrusted inputs, provide a
-#' runner backed by OS-level sandboxing, such as [mcp_repl_runner()].
-#' Authenticated RLM control frames sent through mcp-repl are limited to 3,000
-#' encoded bytes. If aggregate output is compacted into a file preview or pager,
-#' the iteration fails closed because mcp-repl does not expose structured
-#' compaction metadata; dsprrr does not read a sandbox-disclosed path from the
-#' host process.
-#'
-#' Runner lifecycle: supply exactly one runtime source. `runner` is
-#' caller-owned, reused across calls, and never closed by dsprrr. The backend determines
-#' whether execution state persists and whether `reset()` is available;
-#' serialize access to stateful backends. `interpreter_factory` is a
-#' zero-argument function that returns a fresh runner implementing `execute()`,
-#' `policy()`, optional `start()`, and terminal `shutdown()` or `close()`. The
-#' module owns that runner for one invocation and shuts it down exactly once on
-#' success, error, or interrupt.
-#'
-#' [run_async()] supports factory-backed RLM in an isolated mirai process and
-#' rejects caller-owned runners. [stream_async()] and a module's `$stream()`
-#' method remain unavailable because streaming would bypass execution. The
-#' [run_stream()] one-shot `forward()` fallback remains available.
+#' Supply exactly one runtime source. A caller-owned `runner` is reused and
+#' never closed by dsprrr. An `interpreter_factory` creates one invocation-owned
+#' runner which dsprrr shuts down on success, error, or interrupt. Factory-backed
+#' RLM supports [run_async()] and isolated [run_dataset()] execution; token
+#' streaming is unavailable. A direct [run()] call always stages each supplied
+#' value as one REPL variable, regardless of its R length. Use [run_dataset()]
+#' for multiple invocations, with list-columns for data frames, vectors, lists,
+#' matrices, or other rich per-row values.
 #'
 #' @examples
 #' \dontrun{
-#' # Create a runner (required for code execution)
-#' runner <- r_code_runner(timeout = 30)
-#'
-#' # Create an RLM module for exploring large documents
-#' rlm <- rlm_module(
+#' analyst <- rlm_module(
 #'   signature = "document, question -> answer",
-#'   runner = runner
+#'   interpreter_factory = function() mcp_repl_runner(timeout = 30)
 #' )
-#'
-#' # Use it for context exploration
-#' long_doc <- paste(readLines("large_file.txt"), collapse = "\n")
-#' result <- run(rlm, document = long_doc, question = "What are the main themes?", .llm = llm)
-#'
-#' # Enable recursive LLM calls for complex reasoning
-#' rlm_recursive <- rlm_module(
-#'   signature = "document -> summary",
-#'   runner = runner,
-#'   sub_lm = ellmer::chat_openai(model = "gpt-4o-mini"),
-#'   max_llm_calls = 10
+#' compact_doc <- "Section 1: ...\nSection 2: ..."
+#' result <- run(
+#'   analyst,
+#'   document = compact_doc,
+#'   question = "What evidence supports the conclusion?",
+#'   .llm = ellmer::chat_openai()
 #' )
 #' }
 #'
@@ -80,32 +74,43 @@ NULL
 #' Create a Recursive Language Model (RLM) Module
 #'
 #' @description
-#' Factory function to create an RLMModule that enables LLMs to programmatically
-#' explore large contexts through a REPL interface.
-#' Use [run()] to execute it. [run_async()] supports factory-backed modules;
-#' async streaming and module `$stream()` reject RLM. [run_stream()] preserves
-#' the synchronous `forward()` fallback unless a matching token-stream request
-#' is active; that request is rejected first.
+#' Create an RLM whose implementation can adaptively explore R objects at
+#' inference time. Use RLM when the inspection path is not known in advance;
+#' use ordinary R when that path becomes stable, or Flex when labeled examples
+#' should discover a reusable implementation.
 #'
 #' @param signature A Signature object or string notation defining inputs/outputs
+#'   with explicit ellmer string, number, integer, boolean, enum, array, or
+#'   object output types. Opaque `TypeJsonSchema` outputs are unsupported.
 #' @param runner Optional caller-owned code runner implementing `execute()` and
-#'   `policy()`. It is retained, never automatically closed, and must not be
-#'   shared concurrently when persistent.
+#'   `policy()`. Its policy must declare `persistent = TRUE`. It is retained,
+#'   never automatically closed, and must not be shared concurrently. For the
+#'   trusted callr backend, use `r_code_runner(persistent = TRUE)`.
 #' @param max_iterations Maximum REPL iterations before fallback (default 20)
 #' @param max_iters DSPy 3.3-compatible alias for `max_iterations`. Supply only
 #'   one of these arguments.
 #' @param interpreter_factory Optional zero-argument function returning a fresh
 #'   runner with `execute()`, `policy()`, optional `start()`, and idempotent
-#'   terminal `shutdown()` or `close()`.
+#'   terminal `shutdown()` or `close()`. Its policy must advertise
+#'   `persistent = TRUE` for RLM.
 #'   Supply exactly one of `runner` and `interpreter_factory`.
 #' @param max_llm_calls Maximum recursive LLM calls allowed (default 50)
-#' @param max_output_chars Maximum characters per execution output (default 100000)
-#' @param sub_lm Optional ellmer Chat for recursive queries. NULL = disabled.
+#' @param max_output_chars Maximum model-visible characters per execution output.
+#'   Longer output is shown as a head-and-tail excerpt. Default 10000.
+#' @param sub_lm Optional ellmer Chat for recursive queries. `NULL` inherits the
+#'   invocation's outer Chat. Set `max_llm_calls = 0` to disable recursion.
 #' @param verbose Logical. Print execution progress (default FALSE)
-#' @param tools Named list of user-defined host functions. Guest code emits an
-#'   authenticated request, dsprrr invokes the original function in the host,
+#' @param tools Named list of user-defined host functions or ellmer ToolDef
+#'   objects. Guest code emits an
+#'   invocation-bound request, dsprrr validates it and invokes the original
+#'   function in the host,
 #'   and the guest is replayed with the response. Closures are never deparsed or
-#'   serialized into generated code.
+#'   serialized into generated code. These tools execute in the host process,
+#'   outside the guest runner sandbox, with the host's permissions. ToolDef
+#'   schemas guide generation; the callable must still enforce semantic
+#'   constraints beyond the bridge's lossless JSON-compatible value checks.
+#'   A protocol safety ceiling permits at most 1,000 host-tool calls in one
+#'   generated R step.
 #' @param ... Additional arguments passed to the module
 #'
 #' @return An RLMModule object
@@ -113,16 +118,23 @@ NULL
 #' @export
 #' @examples
 #' \dontrun{
-#' runner <- r_code_runner(timeout = 30)
-#' rlm <- rlm_module("question -> answer", runner = runner)
-#' result <- run(rlm, question = "What is the 10th Fibonacci number?", .llm = llm)
+#' analyst <- rlm_module(
+#'   "document, question -> answer",
+#'   interpreter_factory = function() mcp_repl_runner(timeout = 30)
+#' )
+#' result <- run(
+#'   analyst,
+#'   document = "Owner: team-a\nObligation: rotate keys quarterly",
+#'   question = "Which obligations have no owner?",
+#'   .llm = ellmer::chat_openai()
+#' )
 #' }
 rlm_module <- function(
   signature,
   runner = NULL,
   max_iterations = 20L,
   max_llm_calls = 50L,
-  max_output_chars = 100000L,
+  max_output_chars = 10000L,
   sub_lm = NULL,
   verbose = FALSE,
   tools = list(),
@@ -176,6 +188,15 @@ rlm_module <- function(
     minimum = 1L
   )
 
+  if (!is.logical(verbose) || length(verbose) != 1L || is.na(verbose)) {
+    cli::cli_abort(
+      "{.arg verbose} must be TRUE or FALSE",
+      class = "dsprrr_rlm_argument_error"
+    )
+  }
+
+  validate_rlm_sub_lm(sub_lm)
+
   validate_rlm_tools(tools)
 
   RLMModule$new(
@@ -191,6 +212,306 @@ rlm_module <- function(
     ...
   )
 }
+
+
+validate_rlm_sub_lm <- function(sub_lm) {
+  if (is.null(sub_lm)) {
+    return(invisible(sub_lm))
+  }
+  chat <- tryCatch(sub_lm[["chat"]], error = function(e) NULL)
+  if (!is.function(chat)) {
+    cli::cli_abort(
+      c(
+        "{.arg sub_lm} must be an ellmer Chat or compatible object",
+        "i" = "It must provide a {.code chat(prompt)} method."
+      ),
+      class = "dsprrr_rlm_sub_lm_error"
+    )
+  }
+  invisible(sub_lm)
+}
+
+
+rlm_type_contains_json_schema <- function(type) {
+  if (inherits(type, "ellmer::TypeJsonSchema")) {
+    return(TRUE)
+  }
+  if (inherits(type, "ellmer::TypeArray")) {
+    return(rlm_type_contains_json_schema(type@items))
+  }
+  if (inherits(type, "ellmer::TypeObject")) {
+    return(any(vapply(
+      type@properties,
+      rlm_type_contains_json_schema,
+      logical(1)
+    )))
+  }
+  FALSE
+}
+
+
+validate_rlm_output_type <- function(type) {
+  if (rlm_type_contains_json_schema(type)) {
+    cli::cli_abort(
+      c(
+        "RLM cannot strictly validate opaque TypeJsonSchema outputs",
+        "i" = paste(
+          "Use ellmer type_string(), type_number(), type_integer(),",
+          "type_boolean(), type_enum(), type_array(), or type_object()."
+        )
+      ),
+      class = c(
+        "dsprrr_rlm_json_schema_unsupported",
+        "dsprrr_rlm_signature_error"
+      )
+    )
+  }
+  invisible(type)
+}
+
+
+clone_rlm_chat <- function(chat) {
+  clone <- tryCatch(chat[["clone"]], error = function(e) NULL)
+  if (is.function(clone)) {
+    cloned <- tryCatch(
+      clone(deep = TRUE),
+      error = function(e) clone()
+    )
+    set_turns <- tryCatch(cloned[["set_turns"]], error = function(e) NULL)
+    if (is.function(set_turns)) {
+      set_turns(list())
+    }
+    return(cloned)
+  }
+  chat
+}
+
+
+new_rlm_action_module <- function() {
+  PredictModule$new(
+    signature = signature(
+      inputs = list(input(
+        "state",
+        type = ellmer::type_string(),
+        description = "RLM task, available variables, and prior REPL trajectory"
+      )),
+      output_type = ellmer::type_object(
+        reasoning = ellmer::type_string(
+          description = "Brief rationale for the next operation"
+        ),
+        code = ellmer::type_string(
+          description = "One non-empty R expression or block to execute"
+        )
+      ),
+      instructions = paste(
+        "Choose the next useful R operation for an iterative investigation.",
+        "Use the supplied state as the complete source of task and trajectory context."
+      )
+    )
+  )
+}
+
+
+new_rlm_extract_module <- function(output_type) {
+  PredictModule$new(
+    signature = signature(
+      inputs = list(input(
+        "state",
+        type = ellmer::type_string(),
+        description = "Original task and bounded RLM trajectory"
+      )),
+      output_type = output_type,
+      instructions = paste(
+        "Return the best supported typed answer from the trajectory.",
+        "Do not invent evidence that the RLM did not observe."
+      )
+    )
+  )
+}
+
+
+rlm_predictor_abort <- function(predictor, message, class) {
+  cli::cli_abort(
+    c(
+      "RLM {.field {predictor}} predictor has an incompatible signature",
+      "x" = message
+    ),
+    class = c(
+      class,
+      "dsprrr_rlm_predictor_contract_error",
+      "dsprrr_rlm_predictor_error"
+    ),
+    predictor = predictor
+  )
+}
+
+
+rlm_predictor_type_contract <- function(type) {
+  required <- tryCatch(isTRUE(type@required), error = function(error) NULL)
+  if (is.null(required)) {
+    return(NULL)
+  }
+
+  if (inherits(type, "ellmer::TypeIgnore")) {
+    return(list(kind = "ignore", required = required))
+  }
+  if (inherits(type, "ellmer::TypeJsonSchema")) {
+    return(list(
+      kind = "json_schema",
+      json = type@json,
+      required = required
+    ))
+  }
+  if (inherits(type, "ellmer::TypeBasic")) {
+    return(list(
+      kind = "basic",
+      type = type@type,
+      required = required
+    ))
+  }
+  if (inherits(type, "ellmer::TypeEnum")) {
+    return(list(
+      kind = "enum",
+      values = type@values,
+      required = required
+    ))
+  }
+  if (inherits(type, "ellmer::TypeArray")) {
+    items <- rlm_predictor_type_contract(type@items)
+    if (is.null(items)) {
+      return(NULL)
+    }
+    return(list(
+      kind = "array",
+      items = items,
+      required = required
+    ))
+  }
+  if (inherits(type, "ellmer::TypeObject")) {
+    properties <- lapply(type@properties, rlm_predictor_type_contract)
+    if (any(vapply(properties, is.null, logical(1)))) {
+      return(NULL)
+    }
+    return(list(
+      kind = "object",
+      properties = properties,
+      required = required,
+      additional_properties = isTRUE(type@additional_properties)
+    ))
+  }
+  NULL
+}
+
+
+rlm_predictor_required_string <- function(type) {
+  inherits(type, "ellmer::TypeBasic") &&
+    identical(type@type, "string") &&
+    isTRUE(type@required)
+}
+
+
+validate_rlm_predictor_state_input <- function(signature, predictor, class) {
+  input_names <- vapply(signature@inputs, `[[`, character(1), "name")
+  valid <- length(signature@inputs) == 1L &&
+    identical(input_names, "state") &&
+    rlm_predictor_required_string(signature@inputs[[1L]]$type)
+  if (!valid) {
+    rlm_predictor_abort(
+      predictor,
+      "It must accept exactly one required string input named {.field state}.",
+      class
+    )
+  }
+  invisible(signature)
+}
+
+
+validate_rlm_action_predictor <- function(module) {
+  predictor <- "generate_action"
+  class <- "dsprrr_rlm_generate_action_contract_error"
+  signature <- tryCatch(module$signature, error = function(error) NULL)
+  if (!S7::S7_inherits(signature, Signature)) {
+    rlm_predictor_abort(
+      predictor,
+      "It must expose a dsprrr Signature.",
+      class
+    )
+  }
+  validate_rlm_predictor_state_input(signature, predictor, class)
+
+  output_type <- signature@output_type
+  valid <- inherits(output_type, "ellmer::TypeObject") &&
+    isTRUE(output_type@required) &&
+    !isTRUE(output_type@additional_properties) &&
+    identical(names(output_type@properties), c("reasoning", "code")) &&
+    all(vapply(
+      output_type@properties,
+      rlm_predictor_required_string,
+      logical(1)
+    ))
+  if (!valid) {
+    rlm_predictor_abort(
+      predictor,
+      paste(
+        "It must return exactly the required string fields",
+        "{.field reasoning} and {.field code}."
+      ),
+      class
+    )
+  }
+  invisible(module)
+}
+
+
+validate_rlm_extract_predictor <- function(module, output_type) {
+  predictor <- "extract"
+  class <- "dsprrr_rlm_extract_contract_error"
+  signature <- tryCatch(module$signature, error = function(error) NULL)
+  if (!S7::S7_inherits(signature, Signature)) {
+    rlm_predictor_abort(
+      predictor,
+      "It must expose a dsprrr Signature.",
+      class
+    )
+  }
+  validate_rlm_predictor_state_input(signature, predictor, class)
+
+  actual <- rlm_predictor_type_contract(signature@output_type)
+  expected <- rlm_predictor_type_contract(output_type)
+  if (is.null(actual) || is.null(expected) || !identical(actual, expected)) {
+    rlm_predictor_abort(
+      predictor,
+      paste(
+        "Its output type must equal the RLM output type, including field",
+        "structure and required flags. Descriptions may differ."
+      ),
+      class
+    )
+  }
+  invisible(module)
+}
+
+
+validate_rlm_predictor_children <- function(children, output_type) {
+  if (
+    !is.list(children) ||
+      !identical(names(children), c("generate_action", "extract")) ||
+      !inherits(children$generate_action, "Module") ||
+      !inherits(children$extract, "Module")
+  ) {
+    cli::cli_abort(
+      "RLM graph children must be named generate_action and extract modules",
+      class = c(
+        "dsprrr_rlm_predictor_structure_error",
+        "dsprrr_rlm_predictor_error"
+      )
+    )
+  }
+  validate_rlm_action_predictor(children$generate_action)
+  validate_rlm_extract_predictor(children$extract, output_type)
+  invisible(children)
+}
+
 
 rlm_reserved_tool_names <- function() {
   c(
@@ -253,7 +574,7 @@ validate_rlm_tools <- function(tools) {
   }
   if (
     anyNA(tool_names) ||
-      any(!nzchar(tool_names))
+      !all(nzchar(tool_names))
   ) {
     cli::cli_abort(
       c(
@@ -339,6 +660,64 @@ validate_rlm_tools <- function(tools) {
   invisible(tools)
 }
 
+
+format_rlm_tool_contract <- function(tool, name) {
+  description <- NULL
+  argument_text <- NULL
+
+  if (inherits(tool, "ellmer::ToolDef")) {
+    description <- tool@description
+    properties <- tool@arguments@properties
+    if (length(properties) > 0L) {
+      argument_text <- vapply(
+        names(properties),
+        function(argument) {
+          spec <- properties[[argument]]
+          required <- if (isTRUE(spec@required)) "" else " = NULL"
+          paste0(argument, ": ", format_ellmer_type(spec), required)
+        },
+        character(1)
+      )
+    }
+  }
+
+  if (is.null(argument_text)) {
+    fmls <- formals(tool)
+    if (!is.null(fmls)) {
+      missing_defaults <- vapply(fmls, rlang::is_missing, logical(1))
+      argument_text <- vapply(
+        names(fmls),
+        function(argument) {
+          if (isTRUE(missing_defaults[[argument]])) {
+            argument
+          } else {
+            paste0(argument, " = <default>")
+          }
+        },
+        character(1)
+      )
+    }
+    description <- attr(tool, "description", exact = TRUE) %||% description
+  }
+
+  signature_text <- paste0(
+    name,
+    "(",
+    paste(argument_text %||% character(), collapse = ", "),
+    ")"
+  )
+  if (
+    is.character(description) &&
+      length(description) == 1L &&
+      !is.na(description) &&
+      nzchar(description)
+  ) {
+    paste0("- `", signature_text, "`: ", description)
+  } else {
+    paste0("- `", signature_text, "`: User-defined host tool")
+  }
+}
+
 normalize_rlm_sub_lm_text <- function(response) {
   text <- if (is.character(response)) {
     response
@@ -364,6 +743,20 @@ normalize_rlm_sub_lm_text <- function(response) {
     )
   }
   text
+}
+
+
+is_rlm_provider_error <- function(error) {
+  inherits(
+    error,
+    c(
+      "httr2_error",
+      "httr2_failure",
+      "ellmer_error",
+      "ellmer::LMError",
+      "dsprrr_rlm_provider_error"
+    )
+  )
 }
 
 
@@ -403,6 +796,12 @@ RLMModule <- R6::R6Class(
     #' @field tools User-defined REPL tools
     tools = NULL,
 
+    #' @field generate_action Optimizable predictor for the next R operation
+    generate_action = NULL,
+
+    #' @field extract Optimizable predictor for typed fallback extraction
+    extract = NULL,
+
     #' @description
     #' Initialize an RLMModule
     #'
@@ -423,13 +822,15 @@ RLMModule <- R6::R6Class(
       runner = NULL,
       max_iterations = 20L,
       max_llm_calls = 50L,
-      max_output_chars = 100000L,
+      max_output_chars = 10000L,
       sub_lm = NULL,
       verbose = FALSE,
       tools = list(),
       config = list(),
       chat = NULL,
-      interpreter_factory = NULL
+      interpreter_factory = NULL,
+      generate_action = NULL,
+      extract = NULL
     ) {
       binding <- normalize_code_runner_binding(
         runner = runner,
@@ -442,6 +843,7 @@ RLMModule <- R6::R6Class(
           class = "dsprrr_rlm_signature_error"
         )
       }
+      validate_rlm_output_type(signature@output_type)
       signature_inputs <- vapply(
         signature@inputs,
         function(input) input$name,
@@ -457,9 +859,15 @@ RLMModule <- R6::R6Class(
           class = "dsprrr_rlm_signature_error"
         )
       }
-      if (rlm_host_tool_replay_field() %in% signature_inputs) {
+      reserved_replay_fields <- c(
+        rlm_control_replay_field(),
+        rlm_host_tool_replay_field(),
+        rlm_query_replay_field()
+      )
+      if (any(reserved_replay_fields %in% signature_inputs)) {
+        reserved <- intersect(reserved_replay_fields, signature_inputs)
         cli::cli_abort(
-          "RLM signature input {.field {rlm_host_tool_replay_field()}} is reserved for the authenticated host-tool bridge",
+          "RLM signature input {.field {reserved}} is reserved for bridge replay",
           class = "dsprrr_rlm_signature_error"
         )
       }
@@ -479,6 +887,19 @@ RLMModule <- R6::R6Class(
         "max_output_chars",
         minimum = 1L
       )
+      if (!is.logical(verbose) || length(verbose) != 1L || is.na(verbose)) {
+        cli::cli_abort(
+          "{.arg verbose} must be TRUE or FALSE",
+          class = "dsprrr_rlm_argument_error"
+        )
+      }
+      validate_rlm_sub_lm(sub_lm)
+      generate_action <- generate_action %||% new_rlm_action_module()
+      extract <- extract %||% new_rlm_extract_module(signature@output_type)
+      validate_rlm_predictor_children(
+        list(generate_action = generate_action, extract = extract),
+        signature@output_type
+      )
       super$initialize(
         signature = signature,
         config = config,
@@ -493,9 +914,12 @@ RLMModule <- R6::R6Class(
       self$sub_lm <- sub_lm
       self$verbose <- verbose
       self$tools <- tools
+      self$generate_action <- generate_action
+      self$extract <- extract
 
       # Store REPL history per execution
       self$state$repl_history <- list()
+      self$state$trace_sequence <- 0
     },
 
     #' @description
@@ -504,11 +928,29 @@ RLMModule <- R6::R6Class(
     #' @param batch Named list or data frame of inputs
     #' @param .llm Optional ellmer chat object
     #' @param trace Logical whether to record trace information
+    #' @param .cache Logical or `NULL`. Per-call structured-response cache control
     #' @param ... Additional arguments
     #' @return Tibble with output, chat, metadata columns
-    forward = function(batch, .llm = NULL, trace = TRUE, ...) {
+    forward = function(
+      batch,
+      .llm = NULL,
+      trace = TRUE,
+      .cache = NULL,
+      ...
+    ) {
+      validate_cache_arg(.cache)
       # Handle inputs
       if (is.data.frame(batch)) {
+        if (nrow(batch) != 1L) {
+          cli::cli_abort(
+            c(
+              "RLM forward() accepts exactly one data-frame row",
+              "x" = "Received {nrow(batch)} rows.",
+              "i" = "Use {.fn run} with an interpreter factory for isolated batch execution."
+            ),
+            class = "dsprrr_rlm_batch_error"
+          )
+        }
         inputs <- as.list(batch[1, , drop = FALSE])
       } else {
         inputs <- batch
@@ -525,7 +967,7 @@ RLMModule <- R6::R6Class(
         !is.list(inputs) ||
           (!valid_empty_inputs && is.null(names(inputs))) ||
           anyNA(names(inputs)) ||
-          any(!nzchar(names(inputs))) ||
+          !all(nzchar(names(inputs))) ||
           anyDuplicated(names(inputs))
       ) {
         cli::cli_abort(
@@ -533,12 +975,22 @@ RLMModule <- R6::R6Class(
           class = "dsprrr_rlm_input_error"
         )
       }
-      missing_inputs <- setdiff(expected_inputs, names(inputs))
+      required_inputs <- vapply(
+        self$signature@inputs,
+        function(input) {
+          tryCatch(isTRUE(input$type@required), error = function(e) TRUE)
+        },
+        logical(1)
+      )
+      missing_inputs <- setdiff(
+        expected_inputs[required_inputs],
+        names(inputs)
+      )
       unexpected_inputs <- setdiff(names(inputs), expected_inputs)
       if (length(missing_inputs) > 0L || length(unexpected_inputs) > 0L) {
         cli::cli_abort(
           c(
-            "RLM inputs must exactly match the signature",
+            "RLM inputs must match declared signature fields",
             if (length(missing_inputs) > 0L) {
               c("x" = "Missing: {.field {missing_inputs}}")
             },
@@ -556,7 +1008,8 @@ RLMModule <- R6::R6Class(
         cli::cli_abort("No LLM provided. Pass .llm or set a default chat.")
       }
 
-      llm <- base_llm$clone()
+      llm <- clone_rlm_chat(base_llm)
+      sub_lm <- self$sub_lm %||% base_llm
 
       with_code_runner_lease(
         self$runner,
@@ -565,19 +1018,55 @@ RLMModule <- R6::R6Class(
         function(runner, lease) {
           start_time <- Sys.time()
 
+          if (!isTRUE(lease$policy$persistent)) {
+            cli::cli_abort(
+              c(
+                "RLM requires a persistent interpreter",
+                "x" = "The selected runner starts a fresh execution state for each turn.",
+                "i" = "Use {.code r_code_runner(persistent = TRUE)} for trusted inputs or {.fn mcp_repl_runner} for managed execution."
+              ),
+              class = "dsprrr_rlm_persistent_runner_error"
+            )
+          }
+
           # Initialize call counter (shared across recursions)
           call_counter <- new.env()
           call_counter$count <- 0L
+          call_counter$provider_calls <- 0L
+          call_counter$provider_calls_known <- TRUE
+          call_counter$usage <- list()
+
+          prepare_context <- tryCatch(
+            runner[["prepare_context"]],
+            error = function(e) NULL
+          )
+          context_prepared <- FALSE
+          if (isTRUE(lease$policy$persistent) && is.function(prepare_context)) {
+            prepare_context(inputs)
+            context_prepared <- TRUE
+          }
+          session_state_id <- paste0(".dsprrr_rlm_state_", rlm_control_nonce())
+          if (!isTRUE(lease$owned)) {
+            on.exit(
+              private$cleanup_invocation_state(runner, session_state_id),
+              add = TRUE
+            )
+          }
 
           # Build context description for system prompt
           context_desc <- private$describe_context(inputs)
 
           # Build system prompt
-          system_prompt <- private$build_system_prompt(context_desc)
+          system_prompt <- private$build_system_prompt(
+            context_desc,
+            has_sub_lm = self$max_llm_calls > 0L
+          )
 
           # REPL iteration loop
           history <- list()
           final_answer <- NULL
+          fallback_metadata <- NULL
+          result_chat <- llm
 
           for (iter in seq_len(self$max_iterations)) {
             if (self$verbose) {
@@ -592,7 +1081,13 @@ RLMModule <- R6::R6Class(
             )
 
             # Get LLM response (code generation)
-            response <- private$get_code_response(llm, prompt)
+            response <- private$get_code_response(
+              base_llm,
+              prompt,
+              trace = trace,
+              .cache = .cache
+            )
+            result_chat <- response$chat
 
             if (self$verbose) {
               cli::cli_alert(
@@ -606,7 +1101,10 @@ RLMModule <- R6::R6Class(
               inputs,
               call_counter,
               runner,
-              lease$policy
+              lease$policy,
+              sub_lm = sub_lm,
+              context_prepared = context_prepared,
+              session_state_id = session_state_id
             )
 
             # Record in history
@@ -616,7 +1114,14 @@ RLMModule <- R6::R6Class(
               code = response$code,
               output = exec_result$formatted_output,
               success = exec_result$success,
-              is_final = exec_result$is_final
+              is_final = exec_result$is_final,
+              action_metadata = private$compact_action_metadata(
+                response$metadata
+              ),
+              execution_metadata = list(
+                duration_ms = exec_result$raw_result$duration_ms %||% NA_real_,
+                error_type = exec_result$raw_result$error_type %||% NULL
+              )
             )
 
             # Check for SUBMIT() termination
@@ -656,29 +1161,95 @@ RLMModule <- R6::R6Class(
               "i" = "Using fallback extraction from trajectory",
               "i" = "Consider increasing max_iterations or simplifying the query"
             ))
-            final_answer <- private$extract_fallback(inputs, history, llm)
+            fallback_result <- private$extract_fallback(
+              inputs,
+              history,
+              base_llm,
+              trace = trace,
+              .cache = .cache
+            )
+            final_answer <- fallback_result$value
+            fallback_metadata <- fallback_result$metadata
+            result_chat <- fallback_result$chat
           }
+
+          output <- private$build_output(final_answer, source = final_source)
+          usage <- private$summarize_action_usage(
+            history,
+            fallback_metadata = fallback_metadata,
+            recursive_metadata = call_counter$usage
+          )
+          action_calls <- length(history)
+          extraction_calls <- as.integer(identical(final_source, "fallback"))
+          action_provider_calls <- private$summarize_provider_calls(
+            lapply(history, function(entry) entry$action_metadata %||% list())
+          )
+          extraction_provider_calls <- if (extraction_calls == 1L) {
+            private$metadata_provider_calls(fallback_metadata)
+          } else {
+            0L
+          }
+          recursive_provider_calls <- if (
+            isTRUE(call_counter$provider_calls_known)
+          ) {
+            as.integer(call_counter$provider_calls)
+          } else {
+            NA_integer_
+          }
+          provider_calls <- private$sum_provider_call_counts(c(
+            action_provider_calls,
+            recursive_provider_calls,
+            extraction_provider_calls
+          ))
 
           # Store REPL history
           if (trace) {
-            self$state$repl_history <- c(
+            self$state$trace_sequence <- self$state$trace_sequence + 1
+            input_summary <- private$summarize_trace_inputs(inputs)
+            self$state$repl_history <- private$append_bounded_trace(
               self$state$repl_history,
-              list(list(
+              list(
                 timestamp = start_time,
-                inputs = inputs,
+                inputs = input_summary,
                 history = history,
-                final_answer = private$build_output(
-                  final_answer,
-                  source = final_source
-                ),
+                final_answer = output,
                 iterations_used = length(history),
                 llm_calls_used = call_counter$count
-              ))
+              )
             )
+            trace_entry <- list(
+              timestamp = start_time,
+              inputs = input_summary,
+              output = output,
+              history = history,
+              latency_ms = as.numeric(difftime(
+                Sys.time(),
+                start_time,
+                units = "secs"
+              )) *
+                1000,
+              tokens = usage,
+              input_tokens = usage$input_tokens,
+              cached_input_tokens = usage$cached_input_tokens,
+              output_tokens = usage$output_tokens,
+              total_tokens = usage$total_tokens,
+              cost = usage$cost,
+              provider_calls = provider_calls,
+              action_calls = action_calls,
+              action_provider_calls = action_provider_calls,
+              recursive_calls = call_counter$count,
+              recursive_provider_calls = recursive_provider_calls,
+              extraction_calls = extraction_calls,
+              extraction_provider_calls = extraction_provider_calls,
+              model = private$rlm_model_name(base_llm),
+              output_source = final_source
+            )
+            self$state$traces <- private$append_bounded_trace(
+              self$state$traces,
+              trace_entry
+            )
+            add_to_global_history(trace_entry, source = "RLMModule")
           }
-
-          # Build output matching signature
-          output <- private$build_output(final_answer, source = final_source)
 
           duration_secs <- as.numeric(difftime(
             Sys.time(),
@@ -694,8 +1265,21 @@ RLMModule <- R6::R6Class(
             max_iterations = self$max_iterations,
             llm_calls = call_counter$count,
             max_llm_calls = self$max_llm_calls,
+            output_source = final_source,
             duration_ms = round(duration_ms, 2),
             repl_history = history,
+            input_tokens = usage$input_tokens,
+            cached_input_tokens = usage$cached_input_tokens,
+            output_tokens = usage$output_tokens,
+            total_tokens = usage$total_tokens,
+            cost = usage$cost,
+            provider_calls = provider_calls,
+            action_calls = action_calls,
+            action_provider_calls = action_provider_calls,
+            recursive_calls = call_counter$count,
+            recursive_provider_calls = recursive_provider_calls,
+            extraction_calls = extraction_calls,
+            extraction_provider_calls = extraction_provider_calls,
             runner_policy = lease$policy_summary,
             runner_lifecycle = if (lease$owned) {
               "invocation-owned"
@@ -706,7 +1290,7 @@ RLMModule <- R6::R6Class(
 
           tibble::tibble(
             output = list(output),
-            chat = list(llm),
+            chat = list(result_chat),
             metadata = list(metadata)
           )
         }
@@ -735,7 +1319,9 @@ RLMModule <- R6::R6Class(
         verbose = self$verbose,
         tools = self$tools,
         config = self$config,
-        chat = self$chat
+        chat = self$chat,
+        generate_action = self$generate_action$reset_copy(),
+        extract = self$extract$reset_copy()
       )
     },
 
@@ -754,10 +1340,41 @@ RLMModule <- R6::R6Class(
         tools = self$tools,
         config = lapply(self$config, identity),
         chat = self$chat,
-        interpreter_factory = self$interpreter_factory
+        interpreter_factory = self$interpreter_factory,
+        generate_action = self$generate_action$deepcopy(),
+        extract = self$extract$deepcopy()
       )
       copied$state <- lapply(self$state, identity)
       copied
+    },
+
+    #' @description
+    #' Expose the action and extraction predictors to graph optimizers
+    #' @return Named list of child modules
+    graph_children = function() {
+      list(
+        generate_action = self$generate_action,
+        extract = self$extract
+      )
+    },
+
+    #' @description
+    #' Replace the action and extraction predictors
+    #' @param children Named child-module list
+    #' @return The module, invisibly
+    set_graph_children = function(children) {
+      self$validate_graph_children(children)
+      self$generate_action <- children$generate_action
+      self$extract <- children$extract
+      invisible(self)
+    },
+
+    #' @description
+    #' Validate replacement RLM predictor children
+    #' @param children Named child-module list
+    #' @return The children, invisibly
+    validate_graph_children = function(children) {
+      validate_rlm_predictor_children(children, self$signature@output_type)
     },
 
     #' @description
@@ -781,7 +1398,7 @@ RLMModule <- R6::R6Class(
         "*" = "Max iterations: {.val {self$max_iterations}}",
         "*" = "Max LLM calls: {.val {self$max_llm_calls}}",
         "*" = "Runner: {code_runner_binding_label(self$runner, self$interpreter_factory)}",
-        "*" = "Recursive queries: {.val {if (is.null(self$sub_lm)) 'disabled' else 'enabled'}}",
+        "*" = "Recursive queries: {.val {if (self$max_llm_calls == 0L) 'disabled' else if (is.null(self$sub_lm)) 'outer LM' else 'separate sub-LM'}}",
         "*" = "Custom tools: {.val {length(self$tools)}}"
       ))
       invisible(self)
@@ -789,6 +1406,54 @@ RLMModule <- R6::R6Class(
   ),
 
   private = list(
+    #' Remove invocation-private state from a reusable caller-owned runner
+    cleanup_invocation_state = function(runner, session_state_id) {
+      state_name <- encodeString(session_state_id, quote = "\"")
+      cleanup_code <- paste0(
+        "base::local({\n",
+        "  .root <- base::parent.env(base::environment())\n",
+        "  if (base::exists(",
+        state_name,
+        ", envir = .root, inherits = FALSE)) {\n",
+        "    base::rm(list = ",
+        state_name,
+        ", envir = .root)\n",
+        "  }\n",
+        "  base::invisible(TRUE)\n",
+        "})"
+      )
+
+      cleanup_error <- tryCatch(
+        {
+          result <- runner$execute(cleanup_code, context = list())
+          if (!isTRUE(result$success)) {
+            stop(result$error %||% "runner rejected invocation cleanup")
+          }
+          release_context <- tryCatch(
+            runner[["release_context"]],
+            error = function(e) NULL
+          )
+          if (is.function(release_context)) {
+            release_context()
+          }
+          NULL
+        },
+        interrupt = function(e) e,
+        error = function(e) e
+      )
+      if (inherits(cleanup_error, "condition")) {
+        cli::cli_warn(
+          c(
+            "RLM could not fully clear its caller-owned interpreter state",
+            "x" = conditionMessage(cleanup_error),
+            "i" = "Reset or close the runner before reusing it."
+          ),
+          class = "dsprrr_rlm_cleanup_warning"
+        )
+      }
+      invisible(NULL)
+    },
+
     #' Get output field names from signature for display
     get_output_names = function() {
       paste(private$get_output_field_names(), collapse = ", ")
@@ -799,16 +1464,97 @@ RLMModule <- R6::R6Class(
       output_type <- self$signature@output_type
       if (methods::.hasSlot(output_type, "properties")) {
         props <- output_type@properties
-        if (length(props) > 0) {
-          return(props)
-        }
+        props <- props[
+          !vapply(
+            props,
+            inherits,
+            logical(1),
+            what = "ellmer::TypeIgnore"
+          )
+        ]
+        return(props)
+      }
+      if (inherits(output_type, "ellmer::TypeIgnore")) {
+        return(list())
       }
       list(answer = output_type)
+    },
+
+    #' Get required output field names from signature
+    get_required_output_field_names = function() {
+      specs <- private$get_output_specs()
+      names(specs)[vapply(
+        specs,
+        function(spec) {
+          tryCatch(isTRUE(spec@required), error = function(e) TRUE)
+        },
+        logical(1)
+      )]
     },
 
     #' Get output field names from signature
     get_output_field_names = function() {
       names(private$get_output_specs())
+    },
+
+    #' Format a true-length head-and-tail excerpt
+    format_excerpt = function(text, max_chars = self$max_output_chars) {
+      if (is.null(text) || length(text) == 0L) {
+        return("")
+      }
+      text <- paste(as.character(text), collapse = "\n")
+      total <- nchar(text, type = "chars")
+      if (total <= max_chars) {
+        return(text)
+      }
+      marker <- paste0("\n... [", total, " total characters] ...\n")
+      if (nchar(marker) + 2L > max_chars) {
+        return(substr(text, 1L, max_chars))
+      }
+      omitted <- total
+      for (iteration in seq_len(10L)) {
+        marker <- paste0(
+          "\n... [",
+          omitted,
+          " characters omitted; total ",
+          total,
+          "] ...\n"
+        )
+        if (nchar(marker) + 2L > max_chars) {
+          return(substr(text, 1L, max_chars))
+        }
+        visible <- max_chars - nchar(marker)
+        head_chars <- ceiling(visible / 2)
+        tail_chars <- floor(visible / 2)
+        next_omitted <- total - head_chars - tail_chars
+        if (identical(next_omitted, omitted)) {
+          break
+        }
+        omitted <- next_omitted
+      }
+      paste0(
+        substr(text, 1L, head_chars),
+        marker,
+        substr(text, total - tail_chars + 1L, total)
+      )
+    },
+
+    #' Preview one context value without embedding the full object
+    preview_context_value = function(value) {
+      text <- if (is.character(value) && length(value) == 1L) {
+        value
+      } else if (is.data.frame(value)) {
+        paste(
+          utils::capture.output(utils::str(value, max.level = 1L)),
+          collapse = " "
+        )
+      } else {
+        paste(
+          utils::capture.output(utils::str(value, max.level = 1L)),
+          collapse = " "
+        )
+      }
+      private$format_excerpt(text, max_chars = 1000L)
     },
 
     #' Describe context variables for the system prompt
@@ -821,6 +1567,15 @@ RLMModule <- R6::R6Class(
         names(inputs),
         function(name) {
           val <- inputs[[name]]
+          input_index <- match(
+            name,
+            vapply(
+              self$signature@inputs,
+              function(spec) spec$name,
+              character(1)
+            )
+          )
+          input_spec <- self$signature@inputs[[input_index]]
           type_str <- class(val)[1]
           size_str <- if (is.character(val)) {
             total_chars <- sum(nchar(val))
@@ -835,15 +1590,9 @@ RLMModule <- R6::R6Class(
             "1 object"
           }
 
-          preview <- if (is.character(val) && length(val) == 1) {
-            if (nchar(val) > 100) {
-              paste0(substr(val, 1, 100), "...")
-            } else {
-              val
-            }
-          } else {
-            deparse(val, width.cutoff = 60)[1]
-          }
+          preview <- private$preview_context_value(val)
+          declared <- format_ellmer_type(input_spec$type, verbose = TRUE)
+          description <- input_spec$description %||% ""
 
           paste0(
             "- `.context$",
@@ -852,7 +1601,11 @@ RLMModule <- R6::R6Class(
             type_str,
             ", ",
             size_str,
-            ")\n",
+            "; declared ",
+            declared,
+            ")",
+            if (nzchar(description)) paste0(" - ", description) else "",
+            "\n",
             "  Preview: ",
             preview
           )
@@ -864,17 +1617,16 @@ RLMModule <- R6::R6Class(
     },
 
     #' Build the system prompt for RLM
-    build_system_prompt = function(context_desc) {
-      has_sub_lm <- !is.null(self$sub_lm)
+    build_system_prompt = function(context_desc, has_sub_lm = TRUE) {
       output_fields <- private$get_output_field_names()
-      submit_usage <- if (length(output_fields) == 1) {
-        paste0("SUBMIT(", output_fields[[1]], ")")
+      output_specs <- private$get_output_specs()
+      required_fields <- private$get_required_output_field_names()
+      submit_usage <- if (length(required_fields) == 0L) {
+        "SUBMIT()"
       } else {
         paste0(
           "SUBMIT(",
-          paste(output_fields, collapse = ", "),
-          ") or SUBMIT(",
-          paste0(output_fields, " = ...", collapse = ", "),
+          paste0(required_fields, " = ...", collapse = ", "),
           ")"
         )
       }
@@ -899,11 +1651,36 @@ RLMModule <- R6::R6Class(
       }
 
       if (length(self$tools) > 0) {
-        custom_tool_names <- names(self$tools)
         tool_desc <- c(
           tool_desc,
-          paste0("- `", custom_tool_names, "()`: User-defined tool")
+          vapply(
+            names(self$tools),
+            function(name) format_rlm_tool_contract(self$tools[[name]], name),
+            character(1)
+          )
         )
+      }
+
+      output_contract <- vapply(
+        names(output_specs),
+        function(name) {
+          spec <- output_specs[[name]]
+          description <- spec@description %||% ""
+          paste0(
+            "- `",
+            name,
+            "`: ",
+            format_ellmer_type(spec, verbose = TRUE),
+            if (!name %in% required_fields) " (optional)" else "",
+            if (nzchar(description)) paste0(" - ", description) else ""
+          )
+        },
+        character(1)
+      )
+
+      task_instructions <- self$signature@instructions %||% ""
+      if (!nzchar(task_instructions)) {
+        task_instructions <- "Answer the declared task using only supported evidence."
       }
 
       glue::glue(
@@ -911,8 +1688,15 @@ RLMModule <- R6::R6Class(
 You are working in an R REPL environment. Your goal is to answer the query by
 writing R code to explore and analyze the provided context.
 
+## Task
+{task_instructions}
+
 ## Available Variables
 {context_desc}
+
+## Declared Output
+{paste(output_contract, collapse = '
+')}
 
 ## Available Functions
 {paste(tool_desc, collapse = '
@@ -922,9 +1706,11 @@ writing R code to explore and analyze the provided context.
 1. Explore the context programmatically - don't ask to see all content at once
 2. Use peek() to examine slices of large text
 3. Use search() to find specific patterns
-4. Break complex queries into smaller sub-questions{if (has_sub_lm) ' using llm_query()' else ''}
+4. Break complex queries into smaller sub-questions{if (has_sub_lm) ' using llm_query(); it returns a value you can assign and combine' else ''}
 5. Call {submit_usage} when you have the final answer
 6. You have {self$max_iterations} iterations{if (has_sub_lm) paste0(' and ', self$max_llm_calls, ' LLM calls') else ''}
+7. Submitted values must satisfy the declared output types; invalid submissions are returned as repairable errors
+8. Keep work before llm_query(), host-tool calls, and SUBMIT() read-only because bridge replay can repeat direct external side effects
 
 ## Response Format
 Return JSON with:
@@ -958,7 +1744,7 @@ Code:
 ```
 
 {if (h$success) 'Output:' else 'Error:'}
-{h$output}
+{private$format_excerpt(h$output)}
 {if (h$is_final) '(SUBMIT was called)' else ''}
 "
           )
@@ -975,36 +1761,56 @@ Code:
     },
 
     #' Get code response from LLM
-    get_code_response = function(llm, prompt) {
-      output_type <- ellmer::type_object(
-        reasoning = ellmer::type_string(
-          description = "Your thought process for this step"
+    get_code_response = function(
+      llm,
+      prompt,
+      trace = TRUE,
+      .cache = NULL
+    ) {
+      action_llm <- clone_rlm_chat(llm)
+      action_result <- tryCatch(
+        self$generate_action$forward(
+          list(state = prompt),
+          .llm = action_llm,
+          trace = FALSE,
+          .cache = .cache
         ),
-        code = ellmer::type_string(
-          description = "R code to execute"
-        )
-      )
-
-      result <- tryCatch(
-        llm$chat_structured(prompt, type = output_type),
         error = function(e) {
-          cli::cli_abort(c(
-            "Failed to get code from LLM",
-            "x" = "Error: {e$message}"
-          ))
+          cli::cli_abort(
+            c(
+              "Failed to get code from LLM",
+              "x" = "Error: {e$message}"
+            ),
+            class = "dsprrr_rlm_action_error",
+            parent = e
+          )
         }
       )
+      result <- action_result$output[[1L]]
 
-      if (is.null(result$code) || !is.character(result$code)) {
-        cli::cli_abort(c(
-          "LLM returned invalid response",
-          "i" = "Missing or invalid 'code' field"
-        ))
+      valid_code <- is.character(result$code) &&
+        length(result$code) == 1L &&
+        !is.na(result$code) &&
+        nzchar(trimws(result$code))
+      if (!valid_code) {
+        cli::cli_abort(
+          c(
+            "LLM returned invalid response",
+            "i" = "{.field code} must be one non-empty R source string."
+          ),
+          class = "dsprrr_rlm_action_error"
+        )
       }
+      metadata <- private$normalize_predictor_metadata(
+        self$generate_action,
+        action_result$metadata[[1L]] %||% list()
+      )
 
       list(
         reasoning = result$reasoning %||% "",
-        code = strip_rlm_code_fences(result$code)
+        code = strip_rlm_code_fences(result$code),
+        metadata = metadata,
+        chat = action_result$chat[[1L]] %||% action_llm
       )
     },
 
@@ -1014,7 +1820,10 @@ Code:
       inputs,
       call_counter,
       runner,
-      runner_policy
+      runner_policy,
+      sub_lm,
+      context_prepared = FALSE,
+      session_state_id
     ) {
       code <- strip_rlm_code_fences(code)
       control_nonce <- rlm_control_nonce()
@@ -1022,26 +1831,71 @@ Code:
       # Build RLM prelude that defines tools
       rlm_prelude <- create_rlm_prelude(
         max_llm_calls = self$max_llm_calls,
-        has_sub_lm = !is.null(self$sub_lm),
+        has_sub_lm = self$max_llm_calls > 0L,
         custom_tools = self$tools,
         output_fields = private$get_output_field_names(),
+        required_output_fields = private$get_required_output_field_names(),
         control_nonce = control_nonce,
         control_frame_limit = runner_policy$rlm_control_frame_limit %||% Inf
       )
 
-      # Build combined code: prelude + user code
+      state_name <- encodeString(session_state_id, quote = "\"")
+      user_code <- encodeString(code, quote = "\"")
+      prelude_code <- encodeString(rlm_prelude, quote = "\"")
+
+      # Each bridge replay starts from the same RLM assignment state. Ordinary
+      # bindings are committed only after the complete block succeeds. Direct
+      # external effects are not transactional and can repeat. A non-local
+      # restart suspends query, tool, and final controls, so guest tryCatch()
+      # cannot continue past a privileged boundary.
       combined_code <- paste0(
-        "# RLM Prelude\n",
-        rlm_prelude,
-        "\n\n# User Code\n",
-        code
+        "base::local({\n",
+        "  # Replay-isolated RLM user-code bindings\n",
+        "  .rlm_root <- base::parent.env(base::environment())\n",
+        "  .rlm_state_name <- ",
+        state_name,
+        "\n",
+        "  if (!base::exists(.rlm_state_name, envir = .rlm_root, inherits = FALSE)) {\n",
+        "    base::assign(.rlm_state_name, base::new.env(parent = .rlm_root), envir = .rlm_root)\n",
+        "  }\n",
+        "  .rlm_state <- base::get(.rlm_state_name, envir = .rlm_root, inherits = FALSE)\n",
+        "  .rlm_tx <- base::new.env(parent = .rlm_state)\n",
+        "  .rlm_tx$.context <- .context\n",
+        "  base::eval(base::parse(text = ",
+        prelude_code,
+        "), envir = .rlm_tx)\n",
+        "  .rlm_injected_names <- base::ls(.rlm_tx, all.names = TRUE)\n",
+        "  .rlm_step <- base::withRestarts(\n",
+        "    {\n",
+        "      .rlm_value <- base::eval(base::parse(text = ",
+        user_code,
+        "), envir = .rlm_tx)\n",
+        "      base::list(control = FALSE, value = .rlm_value)\n",
+        "    },\n",
+        "    .dsprrr_rlm_control = function(frame) {\n",
+        "      base::list(control = TRUE, value = frame)\n",
+        "    }\n",
+        "  )\n",
+        "  if (base::isTRUE(.rlm_step$control)) {\n",
+        "    .rlm_step$value\n",
+        "  } else {\n",
+        "    .rlm_names <- base::setdiff(\n",
+        "      base::ls(.rlm_tx, all.names = TRUE),\n",
+        "      base::c('.context', .rlm_injected_names)\n",
+        "    )\n",
+        "    for (.rlm_name in .rlm_names) {\n",
+        "      base::assign(.rlm_name, base::get(.rlm_name, envir = .rlm_tx, inherits = FALSE), envir = .rlm_state)\n",
+        "    }\n",
+        "    .rlm_step$value\n",
+        "  }\n",
+        "})\n"
       )
 
       # Execute with inputs as context
-      tool_replay <- list()
+      control_replay <- list()
       repeat {
-        execution_context <- inputs
-        execution_context[[rlm_host_tool_replay_field()]] <- tool_replay
+        execution_context <- if (isTRUE(context_prepared)) list() else inputs
+        execution_context[[rlm_control_replay_field()]] <- control_replay
         result <- execute_code_runner(
           runner,
           combined_code,
@@ -1056,28 +1910,71 @@ Code:
           result$stderr,
           result$error
         )) {
+          if (!isTRUE(result$success) && !is.character(candidate)) {
+            next
+          }
           decoded <- decode_rlm_control(candidate, control_nonce)
           if (!is.null(decoded)) {
             control_value <- decoded
             break
           }
         }
-        if (!is_rlm_host_tool_request(control_value)) {
+        if (
+          !is_rlm_host_tool_request(control_value) &&
+            !is_rlm_query_request(control_value)
+        ) {
+          if (is_rlm_final(control_value)) {
+            control_index <- attr(
+              control_value,
+              "rlm_control_index",
+              exact = TRUE
+            )
+            if (!identical(control_index, length(control_replay) + 1L)) {
+              cli::cli_abort(
+                "RLM final control diverged from the recorded replay sequence",
+                class = "dsprrr_rlm_control_error"
+              )
+            }
+          }
           break
         }
-        if (length(tool_replay) >= 1000L) {
+
+        if (!identical(control_value$index, length(control_replay) + 1L)) {
+          cli::cli_abort(
+            "RLM controls were returned out of replay order",
+            class = "dsprrr_rlm_control_error"
+          )
+        }
+
+        if (is_rlm_query_request(control_value)) {
+          request <- control_value
+          query_outcome <- private$process_rlm_query(
+            request,
+            call_counter,
+            sub_lm
+          )
+          control_replay[[length(control_replay) + 1L]] <- list(
+            kind = "query",
+            request = unclass(request),
+            success = query_outcome$success,
+            value = query_outcome$value,
+            error = query_outcome$error
+          )
+          next
+        }
+
+        tool_calls <- sum(vapply(
+          control_replay,
+          function(record) identical(record$kind, "host_tool"),
+          logical(1)
+        ))
+        if (tool_calls >= 1000L) {
           cli::cli_abort(
             "RLM exceeded the per-iteration host-tool bridge limit",
             class = "dsprrr_rlm_host_tool_limit_error"
           )
         }
         request <- control_value
-        if (!identical(request$index, length(tool_replay) + 1L)) {
-          cli::cli_abort(
-            "RLM host-tool requests were returned out of order",
-            class = "dsprrr_rlm_host_tool_protocol_error"
-          )
-        }
         if (!request$name %in% names(self$tools)) {
           cli::cli_abort(
             "RLM requested unknown host tool {.val {request$name}}",
@@ -1099,17 +1996,17 @@ Code:
             )
           }
         )
-        tool_replay[[length(tool_replay) + 1L]] <- c(
-          list(request = unclass(request)),
+        control_replay[[length(control_replay) + 1L]] <- c(
+          list(kind = "host_tool", request = unclass(request)),
           tool_outcome
         )
       }
 
-      if (!isTRUE(result$success)) {
+      if (!isTRUE(result$success) && !is_rlm_final(control_value)) {
         control_value <- NULL
       }
 
-      # Detect SUBMIT termination using the versioned runner-neutral envelope.
+      # Detect and strictly validate SUBMIT before terminating the loop.
       is_final <- is_rlm_final(control_value)
       final_value <- if (is_final) {
         extract_rlm_final(control_value)
@@ -1117,46 +2014,47 @@ Code:
         NULL
       }
 
-      # Handle rlm_query requests (if sub_lm is available)
-      if (is_rlm_query_request(control_value) && !is.null(self$sub_lm)) {
-        # Process the recursive query (single or batch)
-        query_result <- private$process_rlm_query(
-          control_value,
-          call_counter
+      if (is_final) {
+        validated <- tryCatch(
+          list(
+            value = private$normalize_final_answer(
+              final_value,
+              source = "submit"
+            ),
+            error = NULL
+          ),
+          error = function(error) list(value = NULL, error = error)
         )
-
-        # Return the query result as the output
-        return(list(
-          success = query_result$success,
-          is_final = FALSE,
-          final_value = NULL,
-          formatted_output = query_result$formatted_output,
-          error = query_result$error,
-          raw_result = result
-        ))
+        if (inherits(validated$error, "condition")) {
+          message <- conditionMessage(validated$error)
+          return(list(
+            success = FALSE,
+            is_final = FALSE,
+            final_value = NULL,
+            formatted_output = paste0("Error: ", message),
+            error = message,
+            raw_result = result
+          ))
+        }
+        final_value <- validated$value
       }
 
       # Format output for history
-      formatted_output <- if (result$success) {
+      formatted_output <- if (is_final) {
+        "[SUBMIT accepted]"
+      } else if (result$success) {
         private$format_execution_output(result)
       } else {
         paste("Error:", result$error %||% "Unknown error")
       }
-
-      # Truncate if too long
-      if (nchar(formatted_output) > self$max_output_chars) {
-        formatted_output <- paste0(
-          substr(formatted_output, 1, self$max_output_chars),
-          "\n... [TRUNCATED]"
-        )
-      }
+      formatted_output <- private$format_excerpt(formatted_output)
 
       list(
-        success = result$success,
+        success = is_final || isTRUE(result$success),
         is_final = is_final,
         final_value = final_value,
         formatted_output = formatted_output,
-        error = result$error,
+        error = if (is_final) NULL else result$error,
         raw_result = result
       )
     },
@@ -1164,10 +2062,14 @@ Code:
     #' Process an rlm_query request (single or batch)
     #'
     #' @return List with success, formatted_output, error fields
-    process_rlm_query = function(request, call_counter) {
+    process_rlm_query = function(request, call_counter, sub_lm) {
+      call_counter$provider_calls <- call_counter$provider_calls %||% 0L
+      call_counter$provider_calls_known <-
+        call_counter$provider_calls_known %||% TRUE
+
       # Handle batch queries
       if (isTRUE(request$batch)) {
-        return(private$process_rlm_query_batch(request, call_counter))
+        return(private$process_rlm_query_batch(request, call_counter, sub_lm))
       }
 
       # Single query processing
@@ -1181,6 +2083,7 @@ Code:
         cli::cli_warn(error_msg)
         return(list(
           success = FALSE,
+          value = NULL,
           formatted_output = paste0("Error: ", error_msg),
           error = error_msg
         ))
@@ -1197,18 +2100,28 @@ Code:
         query
       }
 
+      query_llm <- clone_rlm_chat(sub_lm)
+      turns_before <- batch_chat_turns(query_llm)
       result <- tryCatch(
         {
-          response <- self$sub_lm$chat(prompt)
+          response <- query_llm$chat(prompt)
           text <- normalize_rlm_sub_lm_text(response)
           list(
             success = TRUE,
-            formatted_output = paste0("Query result: ", text),
-            error = NULL
+            value = text,
+            formatted_output = paste0(
+              "Query result: ",
+              private$format_excerpt(text)
+            ),
+            error = NULL,
+            metadata = chat_usage_metadata(query_llm, turns_before)
           )
         },
         error = function(e) {
           if (inherits(e, "dsprrr_rlm_sub_lm_response_error")) {
+            stop(e)
+          }
+          if (!is_rlm_provider_error(e)) {
             stop(e)
           }
           cli::cli_warn(c(
@@ -1218,10 +2131,20 @@ Code:
           ))
           list(
             success = FALSE,
+            value = NULL,
             formatted_output = paste0("Query error: ", e$message),
-            error = e$message
+            error = e$message,
+            metadata = c(
+              canonical_usage_metadata(),
+              list(provider_calls = NA_integer_)
+            )
           )
         }
+      )
+      private$record_recursive_provider_calls(call_counter, result$metadata)
+      call_counter$usage <- append(
+        call_counter$usage,
+        list(result$metadata %||% canonical_usage_metadata())
       )
 
       result
@@ -1230,7 +2153,11 @@ Code:
     #' Process batch rlm_query requests
     #'
     #' @return List with success, formatted_output, error fields
-    process_rlm_query_batch = function(request, call_counter) {
+    process_rlm_query_batch = function(request, call_counter, sub_lm) {
+      call_counter$provider_calls <- call_counter$provider_calls %||% 0L
+      call_counter$provider_calls_known <-
+        call_counter$provider_calls_known %||% TRUE
+
       queries <- request$queries
       slices <- request$slices
       n_queries <- length(queries)
@@ -1248,6 +2175,7 @@ Code:
         cli::cli_warn(error_msg)
         return(list(
           success = FALSE,
+          value = NULL,
           formatted_output = paste0("Error: ", error_msg),
           error = error_msg
         ))
@@ -1256,6 +2184,7 @@ Code:
       if (n_queries == 0L) {
         return(list(
           success = TRUE,
+          value = character(),
           formatted_output = "",
           error = NULL
         ))
@@ -1278,25 +2207,23 @@ Code:
         character(1)
       )
 
-      batch_result <- private$run_batched_sub_lm_queries(prompts)
+      batch_result <- private$run_batched_sub_lm_queries(prompts, sub_lm)
       results <- batch_result$results
       errors <- batch_result$errors
-
-      # Format output
-      formatted_parts <- vapply(
-        seq_len(n_queries),
-        function(i) {
-          result_i <- results[[i]]
-          result_text <- if (is.null(result_i)) {
-            ""
-          } else {
-            paste(as.character(result_i), collapse = "\n")
-          }
-          paste0("Query ", i, " result: ", result_text)
-        },
-        character(1)
+      if (isTRUE(batch_result$provider_calls_known)) {
+        call_counter$provider_calls <- call_counter$provider_calls +
+          batch_result$provider_calls
+      } else {
+        call_counter$provider_calls_known <- FALSE
+      }
+      call_counter$usage <- append(
+        call_counter$usage,
+        batch_result$usage %||%
+          rep(
+            list(canonical_usage_metadata()),
+            n_queries
+          )
       )
-      formatted_output <- paste(formatted_parts, collapse = "\n\n")
 
       if (length(errors) > 0) {
         cli::cli_warn(c(
@@ -1305,20 +2232,39 @@ Code:
         ))
       }
 
+      formatted_output <- paste(
+        vapply(
+          seq_len(n_queries),
+          function(index) {
+            value <- results[[index]] %||% ""
+            paste0(
+              "Query ",
+              index,
+              " result: ",
+              private$format_excerpt(value)
+            )
+          },
+          character(1)
+        ),
+        collapse = "\n\n"
+      )
+
       list(
-        success = length(errors) == 0,
-        formatted_output = formatted_output,
-        error = if (length(errors) > 0) paste(errors, collapse = "; ") else NULL
+        success = TRUE,
+        value = vapply(results, as.character, character(1)),
+        formatted_output = private$format_excerpt(formatted_output),
+        error = NULL,
+        errors = errors
       )
     },
 
     #' Run a batch of sub-LM prompts with bounded parallelism
-    run_batched_sub_lm_queries = function(prompts) {
+    run_batched_sub_lm_queries = function(prompts, sub_lm) {
       n_queries <- length(prompts)
 
       # For a single query, avoid parallel overhead
       if (n_queries <= 1L) {
-        return(private$run_batched_sub_lm_queries_sequential(prompts))
+        return(private$run_batched_sub_lm_queries_sequential(prompts, sub_lm))
       }
 
       has_parallel_chat <- exists(
@@ -1332,18 +2278,20 @@ Code:
           "i" = "Falling back to sequential batch queries.",
           "i" = "{.fn ellmer::parallel_chat} not available; upgrade ellmer for parallel execution."
         ))
-        return(private$run_batched_sub_lm_queries_sequential(prompts))
+        return(private$run_batched_sub_lm_queries_sequential(prompts, sub_lm))
       }
 
       max_active <- private$get_rlm_batch_max_active(n_queries)
+      batch_llm <- clone_rlm_chat(sub_lm)
+      turns_before <- batch_chat_turns(batch_llm)
 
       parallel_turns <- tryCatch(
         {
           ellmer::parallel_chat(
-            chat = self$sub_lm,
+            chat = batch_llm,
             prompts = as.list(prompts),
             max_active = max_active,
-            on_error = "return"
+            on_error = "continue"
           )
         },
         interrupt = function(i) stop(i),
@@ -1353,10 +2301,14 @@ Code:
       )
 
       if (inherits(parallel_turns, "error")) {
-        return(private$build_parallel_batch_failure(
-          n_queries = n_queries,
-          message = conditionMessage(parallel_turns)
-        ))
+        cli::cli_abort(
+          c(
+            "Recursive LLM batch transport failed",
+            "x" = conditionMessage(parallel_turns)
+          ),
+          class = "dsprrr_rlm_batch_transport_error",
+          parent = parallel_turns
+        )
       }
 
       if (
@@ -1364,78 +2316,117 @@ Code:
           !is.list(parallel_turns) ||
           length(parallel_turns) != n_queries
       ) {
-        return(private$build_parallel_batch_failure(
-          n_queries = n_queries,
-          message = "parallel_chat() returned an invalid response shape"
-        ))
+        cli::cli_abort(
+          "Recursive LLM batch returned an invalid response shape",
+          class = "dsprrr_rlm_batch_transport_error"
+        )
       }
 
       results <- vector("list", n_queries)
       errors <- character()
+      usage <- vector("list", n_queries)
 
       for (i in seq_len(n_queries)) {
-        parsed <- private$extract_parallel_query_result(parallel_turns[[i]], i)
+        parsed <- private$extract_parallel_query_result(
+          parallel_turns[[i]],
+          i,
+          turns_before = turns_before
+        )
         results[[i]] <- parsed$result
+        usage[[i]] <- parsed$metadata
         if (!is.null(parsed$error)) {
           errors <- c(errors, parsed$error)
         }
       }
 
-      list(results = results, errors = errors)
-    },
-
-    #' Build per-query failures for infrastructure-level parallel errors
-    build_parallel_batch_failure = function(n_queries, message) {
-      error_msg <- paste0(
-        "Parallel batch infrastructure error (queries not retried): ",
-        message
+      provider_calls <- private$summarize_provider_calls(usage)
+      list(
+        results = results,
+        errors = errors,
+        usage = usage,
+        provider_calls = provider_calls,
+        provider_calls_known = !is.na(provider_calls)
       )
-
-      results <- rep(list(paste0("[Error: ", error_msg, "]")), n_queries)
-      errors <- vapply(
-        seq_len(n_queries),
-        function(i) paste0("Query ", i, ": ", error_msg),
-        character(1)
-      )
-
-      list(results = results, errors = errors)
     },
 
     #' Sequential fallback for batched sub-LM queries
-    run_batched_sub_lm_queries_sequential = function(prompts) {
+    run_batched_sub_lm_queries_sequential = function(prompts, sub_lm) {
       n_queries <- length(prompts)
       results <- vector("list", n_queries)
       errors <- character()
+      usage <- vector("list", n_queries)
 
       for (i in seq_len(n_queries)) {
+        query_llm <- clone_rlm_chat(sub_lm)
+        turns_before <- batch_chat_turns(query_llm)
+        query_failed <- FALSE
         results[[i]] <- tryCatch(
           {
-            normalize_rlm_sub_lm_text(self$sub_lm$chat(prompts[[i]]))
+            normalize_rlm_sub_lm_text(query_llm$chat(prompts[[i]]))
           },
           error = function(e) {
             if (inherits(e, "dsprrr_rlm_sub_lm_response_error")) {
               stop(e)
             }
+            if (!is_rlm_provider_error(e)) {
+              stop(e)
+            }
+            query_failed <<- TRUE
             errors <<- c(errors, paste0("Query ", i, ": ", e$message))
-            paste0("[Error: ", e$message, "]")
+            paste0("[ERROR] ", e$message)
           }
         )
+        usage[[i]] <- if (query_failed) {
+          c(
+            canonical_usage_metadata(),
+            list(provider_calls = NA_integer_)
+          )
+        } else {
+          chat_usage_metadata(query_llm, turns_before)
+        }
       }
 
-      list(results = results, errors = errors)
+      provider_calls <- private$summarize_provider_calls(usage)
+      list(
+        results = results,
+        errors = errors,
+        usage = usage,
+        provider_calls = provider_calls,
+        provider_calls_known = !is.na(provider_calls)
+      )
     },
 
     #' Extract a text result from ellmer::parallel_chat() output
-    extract_parallel_query_result = function(turn_or_error, index) {
-      if (is.null(turn_or_error) || inherits(turn_or_error, "error")) {
-        msg <- if (inherits(turn_or_error, "error")) {
-          conditionMessage(turn_or_error)
-        } else {
-          "Unknown error"
+    extract_parallel_query_result = function(
+      turn_or_error,
+      index,
+      turns_before = NULL
+    ) {
+      if (is.null(turn_or_error)) {
+        cli::cli_abort(
+          "Recursive LLM batch returned a missing result at position {index}",
+          class = "dsprrr_rlm_batch_transport_error"
+        )
+      }
+      if (inherits(turn_or_error, "error")) {
+        if (!is_rlm_provider_error(turn_or_error)) {
+          cli::cli_abort(
+            c(
+              "Recursive LLM batch returned an unexpected error at position {index}",
+              "x" = conditionMessage(turn_or_error)
+            ),
+            class = "dsprrr_rlm_batch_transport_error",
+            parent = turn_or_error
+          )
         }
+        msg <- conditionMessage(turn_or_error)
         return(list(
-          result = paste0("[Error: ", msg, "]"),
-          error = paste0("Query ", index, ": ", msg)
+          result = paste0("[ERROR] ", msg),
+          error = paste0("Query ", index, ": ", msg),
+          metadata = c(
+            canonical_usage_metadata(),
+            list(provider_calls = NA_integer_)
+          )
         ))
       }
 
@@ -1461,7 +2452,11 @@ Code:
         }
       )
 
-      list(result = normalize_rlm_sub_lm_text(text), error = NULL)
+      list(
+        result = normalize_rlm_sub_lm_text(text),
+        error = NULL,
+        metadata = chat_usage_metadata(turn_or_error, turns_before)
+      )
     },
 
     #' Determine bounded parallelism for RLM batch calls
@@ -1516,10 +2511,31 @@ Code:
         result_str <- tryCatch(
           {
             if (is.data.frame(result$result)) {
-              paste(
-                utils::capture.output(print(result$result)),
+              rows <- nrow(result$result)
+              shown <- if (rows <= 20L) {
+                result$result
+              } else {
+                rbind(
+                  utils::head(result$result, 10L),
+                  utils::tail(result$result, 10L)
+                )
+              }
+              rendered <- paste(
+                utils::capture.output(print(shown)),
                 collapse = "\n"
               )
+              if (rows > 20L) {
+                paste0(
+                  rendered,
+                  "\n... [",
+                  rows - 20L,
+                  " data-frame rows omitted; ",
+                  rows,
+                  " total]"
+                )
+              } else {
+                rendered
+              }
             } else if (
               is.atomic(result$result) && length(result$result) <= 10
             ) {
@@ -1537,11 +2553,17 @@ Code:
         return("[No output]")
       }
 
-      paste(parts, collapse = "\n\n")
+      private$format_excerpt(paste(parts, collapse = "\n\n"))
     },
 
     #' Extract answer via fallback when max_iterations reached
-    extract_fallback = function(inputs, history, llm) {
+    extract_fallback = function(
+      inputs,
+      history,
+      llm,
+      trace = TRUE,
+      .cache = NULL
+    ) {
       # Build trajectory summary
       trajectory <- vapply(
         history,
@@ -1550,21 +2572,28 @@ Code:
             "Iteration {h$iteration}:
 Reasoning: {h$reasoning}
 Code: {h$code}
-Output: {substr(h$output, 1, 500)}"
+Output: {private$format_excerpt(h$output, max_chars = self$max_output_chars)}"
           )
         },
         character(1)
       )
 
       input_context <- private$format_inputs_for_prompt(inputs)
+      variable_info <- private$describe_context(inputs)
 
       prompt <- glue::glue(
         "
 The RLM agent ran out of iterations before calling SUBMIT().
 Based on the exploration trajectory below, extract the best possible answer.
 
+## Original Task Instructions
+{self$signature@instructions}
+
 ## Original Query
 {input_context}
+
+## Available Variables
+{variable_info}
 
 ## Exploration Trajectory
 {paste(trajectory, collapse = '
@@ -1578,32 +2607,36 @@ answer possible with what was discovered.
 "
       )
 
-      structured_result <- tryCatch(
-        llm$chat_structured(prompt, type = self$signature@output_type),
+      fallback_result <- tryCatch(
+        self$extract$forward(
+          list(state = prompt),
+          .llm = clone_rlm_chat(llm),
+          trace = FALSE,
+          .cache = .cache
+        ),
         error = function(e) {
-          cli::cli_warn(c(
-            "Structured fallback extraction failed",
-            "x" = "Error: {e$message}",
-            "i" = "Falling back to unstructured extraction"
-          ))
-          NULL
+          cli::cli_abort(
+            c(
+              "RLM fallback extraction failed",
+              "x" = "{conditionMessage(e)}"
+            ),
+            class = "dsprrr_rlm_fallback_error",
+            parent = e
+          )
         }
       )
-
-      if (!is.null(structured_result)) {
-        return(structured_result)
-      }
-
-      tryCatch(
-        llm$chat(prompt),
-        error = function(e) {
-          cli::cli_warn(c(
-            "Fallback extraction failed",
-            "x" = "Error: {e$message}",
-            "i" = "Returning error message as answer"
-          ))
-          paste0("[Fallback extraction failed: ", e$message, "]")
-        }
+      value <- private$normalize_final_answer(
+        fallback_result$output[[1L]],
+        source = "fallback"
+      )
+      metadata <- private$normalize_predictor_metadata(
+        self$extract,
+        fallback_result$metadata[[1L]] %||% list()
+      )
+      list(
+        value = value,
+        metadata = metadata,
+        chat = fallback_result$chat[[1L]] %||% llm
       )
     },
 
@@ -1627,6 +2660,207 @@ answer possible with what was discovered.
       paste(parts, collapse = "\n")
     },
 
+    #' Summarize context without retaining source values in module state
+    summarize_trace_inputs = function(inputs) {
+      lapply(inputs, function(value) {
+        list(
+          class = class(value),
+          length = length(value),
+          bytes = as.numeric(utils::object.size(value)),
+          sha256 = digest::digest(value, algo = "sha256")
+        )
+      })
+    },
+
+    #' Append one trace while keeping module state bounded
+    append_bounded_trace = function(records, record) {
+      limit <- getOption("dsprrr.rlm_trace_limit", 100L)
+      if (
+        !is.numeric(limit) ||
+          length(limit) != 1L ||
+          is.na(limit) ||
+          !is.finite(limit) ||
+          limit < 1L
+      ) {
+        limit <- 100L
+      }
+      records <- append(records, list(record))
+      if (length(records) > floor(limit)) {
+        records <- utils::tail(records, floor(limit))
+      }
+      records
+    },
+
+    #' Aggregate action and fallback usage into the standard result contract
+    summarize_action_usage = function(
+      history,
+      fallback_metadata = NULL,
+      recursive_metadata = list()
+    ) {
+      metadata <- lapply(history, function(entry) {
+        entry$action_metadata %||% list()
+      })
+      if (!is.null(fallback_metadata)) {
+        metadata <- append(metadata, list(fallback_metadata))
+      }
+      metadata <- append(metadata, recursive_metadata)
+      usage_fields <- c(
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cost"
+      )
+      metadata <- lapply(metadata, function(entry) {
+        if (identical(entry$cache %||% NULL, "hit")) {
+          entry[usage_fields] <- list(0L, 0L, 0L, 0L, 0)
+        }
+        entry
+      })
+      sum_field <- function(field, integer = FALSE) {
+        values <- vapply(
+          metadata,
+          function(entry) {
+            value <- entry[[field]] %||% NA_real_
+            if (!is.numeric(value) || length(value) != 1L) NA_real_ else value
+          },
+          numeric(1)
+        )
+        total <- if (length(values) == 0L || anyNA(values)) {
+          NA_real_
+        } else {
+          sum(values, na.rm = TRUE)
+        }
+        if (integer && !is.na(total)) as.integer(total) else total
+      }
+      list(
+        input_tokens = sum_field("input_tokens", integer = TRUE),
+        cached_input_tokens = sum_field("cached_input_tokens", integer = TRUE),
+        output_tokens = sum_field("output_tokens", integer = TRUE),
+        total_tokens = sum_field("total_tokens", integer = TRUE),
+        cost = sum_field("cost")
+      )
+    },
+
+    #' Read a verified provider-call count from child metadata
+    metadata_provider_calls = function(metadata) {
+      if (!is.list(metadata)) {
+        return(NA_integer_)
+      }
+      explicit <- metadata$provider_calls
+      if (
+        is.numeric(explicit) &&
+          length(explicit) == 1L &&
+          !is.na(explicit) &&
+          is.finite(explicit) &&
+          explicit >= 0 &&
+          explicit == floor(explicit) &&
+          explicit <= .Machine$integer.max
+      ) {
+        return(as.integer(explicit))
+      }
+      cache <- metadata$cache
+      if (
+        !is.character(cache) ||
+          length(cache) != 1L ||
+          is.na(cache)
+      ) {
+        return(NA_integer_)
+      }
+      switch(
+        cache,
+        hit = 0L,
+        miss = 1L,
+        bypass = 1L,
+        NA_integer_
+      )
+    },
+
+    #' Attach predictor-aware provider accounting before compacting metadata
+    normalize_predictor_metadata = function(module, metadata) {
+      if (!is.list(metadata)) {
+        metadata <- list()
+      }
+      metadata$provider_calls <- optimizer_metadata_provider_calls(
+        module,
+        metadata
+      )
+      metadata
+    },
+
+    #' Sum provider-call counts while preserving unknown and overflow states
+    sum_provider_call_counts = function(counts) {
+      if (length(counts) == 0L) {
+        return(0L)
+      }
+      valid <- is.numeric(counts) &&
+        !anyNA(counts) &&
+        all(is.finite(counts)) &&
+        all(counts >= 0) &&
+        all(counts == floor(counts))
+      if (!valid) {
+        return(NA_integer_)
+      }
+      total <- sum(as.double(counts))
+      if (total > .Machine$integer.max) {
+        return(NA_integer_)
+      }
+      as.integer(total)
+    },
+
+    #' Sum provider-call evidence from a list of metadata records
+    summarize_provider_calls = function(metadata) {
+      counts <- vapply(
+        metadata,
+        private$metadata_provider_calls,
+        integer(1)
+      )
+      private$sum_provider_call_counts(counts)
+    },
+
+    #' Add recursive provider calls or mark the aggregate unknown
+    record_recursive_provider_calls = function(call_counter, metadata) {
+      count <- private$metadata_provider_calls(metadata)
+      total <- private$sum_provider_call_counts(c(
+        call_counter$provider_calls %||% 0L,
+        count
+      ))
+      if (is.na(total)) {
+        call_counter$provider_calls_known <- FALSE
+      } else {
+        call_counter$provider_calls <- total
+      }
+      invisible(call_counter)
+    },
+
+    #' Keep usage evidence without retaining repeated model-visible prompts
+    compact_action_metadata = function(metadata) {
+      fields <- c(
+        "model",
+        "prompt_length",
+        "input_tokens",
+        "cached_input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "cost",
+        "duration_s",
+        "latency_ms",
+        "cache",
+        "provider_calls"
+      )
+      metadata[intersect(fields, names(metadata))]
+    },
+
+    #' Get a model name without making model metadata mandatory for test doubles
+    rlm_model_name = function(llm) {
+      get_model <- tryCatch(llm[["get_model"]], error = function(e) NULL)
+      if (!is.function(get_model)) {
+        return(NA_character_)
+      }
+      model <- tryCatch(get_model(), error = function(e) NA_character_)
+      if (!is.character(model) || length(model) != 1L) NA_character_ else model
+    },
+
     #' Coerce final answer payload into named signature fields
     normalize_final_answer = function(
       answer,
@@ -1635,101 +2869,60 @@ answer possible with what was discovered.
       source <- match.arg(source)
       output_specs <- private$get_output_specs()
       output_fields <- names(output_specs)
+      required_fields <- private$get_required_output_field_names()
 
-      # Convert arbitrary value into named list of output fields
+      label <- if (identical(source, "submit")) "SUBMIT" else "Fallback"
       normalized <- NULL
-
-      if (is.list(answer)) {
+      if (
+        is.list(answer) && length(answer) == 0L && length(required_fields) == 0L
+      ) {
+        normalized <- list()
+      } else if (
+        is.list(answer) && !is.null(names(answer)) && all(nzchar(names(answer)))
+      ) {
         answer_names <- names(answer)
-
-        # Named list: align by field names
-        if (!is.null(answer_names) && all(nzchar(answer_names))) {
-          # Special compatibility case for legacy single-field answer payloads
-          if (
-            length(output_fields) == 1 &&
-              !output_fields[[1]] %in% answer_names &&
-              "answer" %in% answer_names
-          ) {
-            normalized <- setNames(list(answer[["answer"]]), output_fields)
-          } else {
-            missing <- setdiff(output_fields, answer_names)
-            extra <- setdiff(answer_names, output_fields)
-
-            if (length(missing) == 0 && length(extra) == 0) {
-              normalized <- answer[output_fields]
-            } else if (source == "fallback") {
-              normalized <- setNames(
-                vector("list", length(output_fields)),
-                output_fields
-              )
-              for (field in output_fields) {
-                if (field %in% answer_names) {
-                  normalized[[field]] <- answer[[field]]
-                } else {
-                  normalized[[field]] <- NA
-                }
-              }
-            } else {
-              cli::cli_abort(c(
-                "SUBMIT output does not match signature fields",
+        if (
+          length(output_fields) == 1L &&
+            !output_fields[[1L]] %in% answer_names &&
+            identical(answer_names, "answer")
+        ) {
+          normalized <- stats::setNames(list(answer[["answer"]]), output_fields)
+        } else {
+          missing <- setdiff(required_fields, answer_names)
+          extra <- setdiff(answer_names, output_fields)
+          if (length(missing) > 0L || length(extra) > 0L) {
+            cli::cli_abort(
+              c(
+                "{label} output does not match the signature",
                 "x" = "Expected fields: {.val {output_fields}}",
                 "x" = "Received fields: {.val {answer_names}}"
-              ))
-            }
+              ),
+              class = "dsprrr_rlm_output_validation_error"
+            )
           }
-        } else if (length(answer) == length(output_fields)) {
-          # Positional list
-          normalized <- answer
-          names(normalized) <- output_fields
-        } else if (length(output_fields) == 1 && length(answer) >= 1) {
-          normalized <- setNames(list(answer[[1]]), output_fields)
-        } else if (source == "fallback") {
-          normalized <- setNames(
-            vector("list", length(output_fields)),
-            output_fields
-          )
-          for (i in seq_along(output_fields)) {
-            if (i <= length(answer)) {
-              normalized[[output_fields[[i]]]] <- answer[[i]]
-            } else {
-              normalized[[output_fields[[i]]]] <- NA
-            }
-          }
-        } else {
-          cli::cli_abort(c(
-            "SUBMIT output has invalid length",
-            "x" = "Expected {length(output_fields)} value(s), got {length(answer)}"
-          ))
+          normalized <- answer[intersect(output_fields, answer_names)]
         }
+      } else if (is.list(answer) && length(answer) == length(output_fields)) {
+        normalized <- stats::setNames(answer, output_fields)
       } else if (is.atomic(answer) && length(answer) == length(output_fields)) {
-        # Positional atomic vector for multi-output
-        normalized <- as.list(answer)
-        names(normalized) <- output_fields
-      } else if (length(output_fields) == 1) {
-        normalized <- setNames(list(answer), output_fields)
-      } else if (source == "fallback") {
-        normalized <- setNames(
-          vector("list", length(output_fields)),
-          output_fields
-        )
-        normalized[[output_fields[[1]]]] <- answer
-        if (length(output_fields) > 1) {
-          for (i in 2:length(output_fields)) {
-            normalized[[output_fields[[i]]]] <- NA
-          }
-        }
+        normalized <- stats::setNames(as.list(answer), output_fields)
+      } else if (length(output_fields) == 1L) {
+        normalized <- stats::setNames(list(answer), output_fields)
       } else {
-        cli::cli_abort(c(
-          "SUBMIT output could not be aligned to signature fields",
-          "x" = "Expected fields: {.val {output_fields}}"
-        ))
+        cli::cli_abort(
+          c(
+            "{label} output could not be aligned to the signature",
+            "x" = "Expected fields: {.val {output_fields}}"
+          ),
+          class = "dsprrr_rlm_output_validation_error"
+        )
       }
 
-      # Coerce to declared output types where practical
-      for (field in output_fields) {
+      for (field in names(normalized)) {
         normalized[[field]] <- private$coerce_value_to_type(
           normalized[[field]],
-          output_specs[[field]]
+          output_specs[[field]],
+          path = field
         )
       }
 
@@ -1737,55 +2930,101 @@ answer possible with what was discovered.
     },
 
     #' Coerce a value to an ellmer type when practical
-    coerce_value_to_type = function(value, type_spec) {
+    coerce_value_to_type = function(value, type_spec, path = "value") {
       if (is.null(type_spec)) {
         return(value)
+      }
+
+      required <- tryCatch(isTRUE(type_spec@required), error = function(e) TRUE)
+      if (is.null(value)) {
+        if (!required) {
+          return(NULL)
+        }
+        private$abort_output_type(path, "a non-null value", value)
       }
 
       if (inherits(type_spec, "ellmer::TypeBasic")) {
         type_name <- type_spec@type
         if (identical(type_name, "string")) {
-          return(value)
+          if (!is.atomic(value) || length(value) != 1L || is.na(value)) {
+            private$abort_output_type(path, "one string", value)
+          }
+          return(as.character(value))
         }
         if (identical(type_name, "number")) {
-          return(suppressWarnings(as.numeric(value)[1]))
+          if (!is.atomic(value) || is.logical(value) || length(value) != 1L) {
+            private$abort_output_type(path, "one finite number", value)
+          }
+          candidate <- suppressWarnings(as.numeric(value))
+          if (
+            length(candidate) != 1L || is.na(candidate) || !is.finite(candidate)
+          ) {
+            private$abort_output_type(path, "one finite number", value)
+          }
+          return(candidate)
         }
         if (identical(type_name, "integer")) {
-          return(suppressWarnings(as.integer(value)[1]))
+          if (!is.atomic(value) || is.logical(value) || length(value) != 1L) {
+            private$abort_output_type(path, "one integer", value)
+          }
+          candidate <- suppressWarnings(as.numeric(value))
+          valid <- length(candidate) == 1L &&
+            !is.na(candidate) &&
+            is.finite(candidate) &&
+            candidate == floor(candidate) &&
+            abs(candidate) <= .Machine$integer.max
+          if (!valid) {
+            private$abort_output_type(path, "one integer", value)
+          }
+          return(as.integer(candidate))
         }
         if (identical(type_name, "boolean")) {
-          return(suppressWarnings(as.logical(value)[1]))
+          if (is.logical(value) && length(value) == 1L && !is.na(value)) {
+            return(value)
+          }
+          if (is.character(value) && length(value) == 1L && !is.na(value)) {
+            candidate <- tolower(value)
+            if (candidate %in% c("true", "false")) {
+              return(identical(candidate, "true"))
+            }
+          }
+          private$abort_output_type(path, "TRUE or FALSE", value)
         }
         return(value)
       }
 
       if (inherits(type_spec, "ellmer::TypeEnum")) {
         allowed <- as.character(type_spec@values)
-        candidate <- if (length(value) == 0 || is.null(value)) {
-          ""
-        } else {
-          as.character(value)[1]
+        if (!is.atomic(value) || length(value) != 1L || is.na(value)) {
+          private$abort_output_type(path, "one allowed enum value", value)
         }
-
-        if (candidate %in% allowed || length(allowed) == 0) {
+        candidate <- as.character(value)
+        if (candidate %in% allowed) {
           return(candidate)
         }
-
-        idx <- match(tolower(candidate), tolower(allowed))
-        if (!is.na(idx)) {
-          return(allowed[idx])
+        case_match <- match(tolower(candidate), tolower(allowed))
+        if (!is.na(case_match)) {
+          return(allowed[[case_match]])
         }
-
-        candidate
+        private$abort_output_type(
+          path,
+          paste0("one of ", paste(allowed, collapse = ", ")),
+          value
+        )
       } else if (inherits(type_spec, "ellmer::TypeArray")) {
         items <- if (is.list(value)) value else as.list(value)
-        if (length(items) == 0) {
+        if (length(items) == 0L) {
           return(items)
         }
-
         coerced <- lapply(
-          items,
-          function(item) private$coerce_value_to_type(item, type_spec@items)
+          seq_along(items),
+          function(index) {
+            private$coerce_value_to_type(
+              items[[index]],
+              type_spec@items,
+              path = paste0(path, "[[", index, "]]")
+            )
+          }
         )
 
         if (
@@ -1798,9 +3037,75 @@ answer possible with what was discovered.
           return(unlist(coerced, use.names = FALSE))
         }
         coerced
+      } else if (inherits(type_spec, "ellmer::TypeObject")) {
+        if (
+          !is.list(value) ||
+            (length(value) > 0L &&
+              (is.null(names(value)) || !all(nzchar(names(value)))))
+        ) {
+          private$abort_output_type(path, "a named object", value)
+        }
+        properties <- type_spec@properties
+        properties <- properties[
+          !vapply(
+            properties,
+            inherits,
+            logical(1),
+            what = "ellmer::TypeIgnore"
+          )
+        ]
+        required_fields <- names(properties)[vapply(
+          properties,
+          function(spec) isTRUE(spec@required),
+          logical(1)
+        )]
+        missing <- setdiff(required_fields, names(value))
+        extra <- setdiff(names(value), names(properties))
+        if (length(missing) > 0L) {
+          private$abort_output_type(
+            path,
+            paste0("an object containing ", paste(missing, collapse = ", ")),
+            value
+          )
+        }
+        if (length(extra) > 0L && !isTRUE(type_spec@additional_properties)) {
+          private$abort_output_type(
+            path,
+            paste0(
+              "an object without extra fields: ",
+              paste(extra, collapse = ", ")
+            ),
+            value
+          )
+        }
+        normalized <- value
+        for (name in intersect(names(properties), names(value))) {
+          normalized[[name]] <- private$coerce_value_to_type(
+            value[[name]],
+            properties[[name]],
+            path = paste0(path, "$", name)
+          )
+        }
+        normalized
       } else {
         value
       }
+    },
+
+    #' Raise one consistent recoverable output-contract error
+    abort_output_type = function(path, expected, value) {
+      observed <- if (is.null(value)) {
+        "NULL"
+      } else {
+        paste0(class(value)[[1L]], " of length ", length(value))
+      }
+      cli::cli_abort(
+        c(
+          "RLM output field {.field {path}} has the wrong type",
+          "x" = "Expected {expected}; received {observed}."
+        ),
+        class = "dsprrr_rlm_output_validation_error"
+      )
     },
 
     #' Build output matching signature
@@ -1815,69 +3120,79 @@ answer possible with what was discovered.
 #' Run a Recursive Language Model in one call
 #'
 #' @description
-#' Convenience wrapper that creates a runner, module, and executes an RLM
-#' in a single call. Equivalent to:
-#'
-#' ```r
-#' runner <- r_code_runner(timeout = .timeout)
-#' mod <- rlm_module(
-#'   signature,
-#'   runner = runner,
-#'   max_iterations = .max_iterations,
-#'   max_llm_calls = .max_llm_calls,
-#'   sub_lm = .sub_lm,
-#'   verbose = .verbose,
-#'   tools = .tools
-#' )
-#' run(mod, ..., .llm = .llm)
-#' ```
-#'
-#' For repeated use or optimization, prefer creating a module with
-#' [rlm_module()] and calling [run()] separately.
+#' Run a one-off RLM investigation. By default this creates a fresh managed
+#' [mcp_repl_runner()] for the invocation. Its default OS sandbox disables
+#' network access but permits writes inside the allowed workspace. Pass
+#' `.runner` or `.interpreter_factory` to select another execution backend. For
+#' repeated use, optimization, or explicit lifecycle control, create an
+#' [rlm_module()] instead. The managed default requires the suggested
+#' `mcptools` package and Posit's external `mcp-repl` executable; see
+#' [mcp_repl_runner()] for setup and transport limits.
 #'
 #' @param signature A Signature object or string notation defining inputs/outputs
 #'   (e.g., `"question -> answer"`)
-#' @param ... Named arguments matching the signature's inputs. These are passed
-#'   to [run()].
+#' @param ... Named signature inputs and [run()] controls such as
+#'   `.return_format`. Every supplied input is one scalar REPL variable,
+#'   including vectors, lists, matrices, and data frames. To run multiple
+#'   investigations, create an [rlm_module()] and call [run_dataset()]; store
+#'   rich per-row values in list-columns.
 #' @param .llm An ellmer Chat object. If `NULL`, uses the default Chat from
 #'   [get_default_chat()].
 #' @param .timeout Numeric. Maximum execution time in seconds per code
-#'   evaluation. Default 30.
+#'   evaluation for the implicit managed MCP runner. Explicit runners and
+#'   factories own their timeout settings. Default 30.
 #' @param .max_iterations Integer. Maximum REPL iterations before fallback.
 #'   Default 20.
 #' @param .max_llm_calls Integer. Maximum recursive LLM calls allowed.
 #'   Default 50.
+#' @param .max_output_chars Maximum model-visible characters per execution
+#'   output. Default 10000.
 #' @param .sub_lm Optional ellmer Chat for recursive `llm_query()` calls.
-#'   `NULL` disables recursive queries.
-#' @param .tools Named list of user-defined R functions available in the REPL.
+#'   `NULL` inherits `.llm`; use `.max_llm_calls = 0` to disable recursion.
+#' @param .tools Named list of user-defined R functions or ellmer ToolDef
+#'   objects available in the REPL. They execute in the dsprrr host process,
+#'   outside the guest runner sandbox.
 #' @param .verbose Logical. Print execution progress. Default `FALSE`.
+#' @param .runner Optional caller-owned runner. Supply at most one of this and
+#'   `.interpreter_factory`. Its policy must advertise `persistent = TRUE`.
+#' @param .interpreter_factory Optional zero-argument factory for a fresh,
+#'   invocation-owned runner. When both execution arguments are `NULL`, a
+#'   managed `mcp_repl_runner()` factory is used. Custom factories must return
+#'   a runner whose policy advertises `persistent = TRUE`.
 #'
-#' @return The module output according to the signature.
+#' @return With `.return_format = "simple"` (the default), the output record
+#'   according to the signature. With `.return_format = "structured"`, a
+#'   `dsprrr_result` containing `output`, `chat`, and `metadata`.
 #'
 #' @export
 #' @examples
 #' \dontrun{
-#' # One-liner RLM call
 #' result <- rlm(
 #'   "document, question -> answer",
-#'   document = readLines("big_file.txt") |> paste(collapse = "\n"),
+#'   document = "Owner: team-a\nObligation: rotate keys quarterly",
 #'   question = "What are the main themes?",
-#'   .llm = ellmer::chat_openai()
+#'   .llm = ellmer::chat_openai(),
+#'   .max_iterations = 4L,
+#'   .max_llm_calls = 0L
 #' )
 #'
-#' # With recursive sub-queries
-#' result <- rlm(
-#'   "codebase, question -> answer",
-#'   codebase = source_code,
-#'   question = "How does auth work?",
-#'   .llm = ellmer::chat_openai(),
-#'   .sub_lm = ellmer::chat_openai(model = "gpt-4o-mini")
+#' # Large or rich local R objects require explicit trusted execution.
+#' sessions <- data.frame(
+#'   release = c("2.3.9", "2.4.0"),
+#'   converted = c(TRUE, FALSE)
 #' )
+#' local_runner <- r_code_runner(persistent = TRUE)
+#' result <- rlm("sessions, question -> answer", sessions = sessions,
+#'   question = "Where did conversion fall?",
+#'   .llm = ellmer::chat_openai(),
+#'   .runner = local_runner)
+#' local_runner$close()
 #' }
 #'
 #' @seealso
 #' * [rlm_module()] for creating reusable RLM modules
 #' * [r_code_runner()] for configuring the code execution backend
+#' * [mcp_repl_runner()] for managed sandboxed execution
 #' * [run()] for executing modules
 #' * [dsp()] for simple one-shot LLM calls (no code execution)
 rlm <- function(
@@ -1887,17 +3202,31 @@ rlm <- function(
   .timeout = 30,
   .max_iterations = 20L,
   .max_llm_calls = 50L,
+  .max_output_chars = 10000L,
   .sub_lm = NULL,
   .tools = list(),
-  .verbose = FALSE
+  .verbose = FALSE,
+  .runner = NULL,
+  .interpreter_factory = NULL
 ) {
-  runner <- r_code_runner(timeout = .timeout)
+  if (is.null(.runner) && is.null(.interpreter_factory)) {
+    timeout <- .timeout
+    max_output_chars <- .max_output_chars
+    .interpreter_factory <- function() {
+      mcp_repl_runner(
+        timeout = timeout,
+        max_output_chars = max_output_chars
+      )
+    }
+  }
 
   mod <- rlm_module(
     signature = signature,
-    runner = runner,
+    runner = .runner,
+    interpreter_factory = .interpreter_factory,
     max_iterations = .max_iterations,
     max_llm_calls = .max_llm_calls,
+    max_output_chars = .max_output_chars,
     sub_lm = .sub_lm,
     verbose = .verbose,
     tools = .tools

--- a/R/module.R
+++ b/R/module.R
@@ -5,7 +5,8 @@
 #' "predict" for standard structured prediction, "react" for ReAct-style
 #' tool-using modules, "chain_of_thought" for step-by-step reasoning,
 #' "multichain" for multi-chain comparison, "program_of_thought" for code
-#' execution modules, and experimental "flex" for declarative or
+#' execution, "codeact" for tools plus code, "rlm" for adaptive R-object
+#' investigation, and experimental "flex" for declarative or
 #' interpreter-backed programs.
 #'
 #' @param signature A Signature object defining the module's interface
@@ -21,7 +22,7 @@
 #'   - `"flex"`: Experimental declarative or executable Flex program
 #' @param tools Optional tools configuration:
 #'   - for `type = "react"` or `type = "codeact"`: list of ellmer ToolDef objects.
-#'   - for `type = "rlm"`: named list of R functions exposed to the REPL.
+#'   - for `type = "rlm"`: named host functions or ellmer ToolDef objects.
 #'   - for executable `type = "flex"`: named host functions or ToolDef objects.
 #'   If provided with `type = "predict"`, automatically upgrades to react.
 #' @param max_iterations Maximum iterations for ReAct, CodeAct, or RLM modules
@@ -31,6 +32,8 @@
 #' @param temperature Temperature for multichain diversity (default: 0.7)
 #' @param runner Optional caller-owned code runner implementing `execute()` and
 #'   `policy()` for code execution types. It is never automatically closed.
+#'   For `type = "rlm"`, the policy must advertise `persistent = TRUE`; use
+#'   `r_code_runner(persistent = TRUE)` for the trusted callr backend.
 #' @param max_iters Maximum code repair iterations for program_of_thought
 #'   (default: 3), or the DSPy 3.3-compatible alias for RLM's
 #'   `max_iterations`. For RLM, supply only one spelling.
@@ -45,7 +48,8 @@
 #'   program-of-thought, CodeAct, RLM, and executable Flex modules. It creates
 #'   one fresh runner per invocation. Supply exactly one of `runner` and
 #'   `interpreter_factory` for ordinary code-executing types; Flex accepts only
-#'   the factory so every invocation is isolated.
+#'   the factory so every invocation is isolated. For RLM, every returned
+#'   runner must advertise `persistent = TRUE`.
 #' @param module_src Optional complete source for `type = "flex"`.
 #' @param source_format Flex source language: `"auto"`, `"json"`, or `"r"`.
 #' @param max_predictor_calls Maximum bridged predictor calls allowed by Flex,
@@ -87,17 +91,22 @@
 #'
 #' # Or create module with Chat attached
 #' classifier <- signature("text -> sentiment") |>
-#'   module(type = "predict", chat = chat_openai())
+#'   module(type = "predict", chat = ellmer::chat_openai())
 #' result <- classifier |> run(text = "Great package!")  # No .llm needed
 #'
 #' # Create a ReAct module with tools
+#' search_fn <- function(query) paste("Result for", query)
 #' search_tool <- ellmer::tool(
 #'   search_fn,
 #'   description = "Search for information",
 #'   arguments = list(query = ellmer::type_string())
 #' )
 #' agent <- signature("question -> answer") |>
-#'   module(type = "react", tools = list(search_tool), chat = chat_openai())
+#'   module(
+#'     type = "react",
+#'     tools = list(search_tool),
+#'     chat = ellmer::chat_openai()
+#'   )
 #' }
 module <- function(
   signature,
@@ -214,11 +223,24 @@ module <- function(
       is.null(runner) &&
       is.null(interpreter_factory)
   ) {
+    runner_hint <- if (identical(type, "rlm")) {
+      "Use {.code runner = r_code_runner(persistent = TRUE)} for a caller-owned runner."
+    } else {
+      "Use {.code runner = r_code_runner()} for a caller-owned runner."
+    }
+    factory_hint <- if (identical(type, "rlm")) {
+      paste0(
+        "Use {.code interpreter_factory = function() ",
+        "r_code_runner(persistent = TRUE)} for a fresh runner per invocation."
+      )
+    } else {
+      "Use {.code interpreter_factory = r_code_runner} for a fresh runner per invocation."
+    }
     cli::cli_abort(
       c(
         "{type} requires a runner or interpreter_factory",
-        "i" = "Use {.code runner = r_code_runner()} for a caller-owned runner.",
-        "i" = "Use {.code interpreter_factory = r_code_runner} for a fresh runner per invocation."
+        "i" = runner_hint,
+        "i" = factory_hint
       ),
       class = "dsprrr_interpreter_binding_error"
     )

--- a/R/r-code-runner.R
+++ b/R/r-code-runner.R
@@ -82,6 +82,10 @@ NULL
 #'   Default: c("base", "stats", "utils", "methods").
 #' @param prelude Character vector. R code to run before user code.
 #'   Useful for setting options or loading common utilities.
+#' @param persistent Logical. Whether to reuse one callr session and execution
+#'   environment across calls to `execute()`. This preserves variables and
+#'   supports staging a base context with `prepare_context()`. Default `FALSE`
+#'   preserves one fresh subprocess per execution.
 #'
 #' @return An RCodeRunner R6 object
 #'
@@ -97,7 +101,8 @@ r_code_runner <- function(
   timeout = 30,
   max_output_chars = 100000L,
   allowed_packages = c("base", "stats", "utils", "methods"),
-  prelude = character()
+  prelude = character(),
+  persistent = FALSE
 ) {
   rlang::check_installed("callr", reason = "for code execution")
 
@@ -105,7 +110,8 @@ r_code_runner <- function(
     timeout = timeout,
     max_output_chars = as.integer(max_output_chars),
     allowed_packages = allowed_packages,
-    prelude = prelude
+    prelude = prelude,
+    persistent = persistent
   )
 }
 
@@ -209,7 +215,7 @@ validate_code_runner_result <- function(result) {
     !is.list(result) ||
       is.null(result_names) ||
       anyNA(result_names) ||
-      any(!nzchar(result_names)) ||
+      !all(nzchar(result_names)) ||
       anyDuplicated(result_names)
   ) {
     cli::cli_abort(
@@ -840,6 +846,9 @@ RCodeRunner <- R6::R6Class(
     #' @field prelude Code to run before user code
     prelude = NULL,
 
+    #' @field persistent Whether one subprocess and execution environment persist
+    persistent = FALSE,
+
     #' @field closed Whether this runner has been closed
     closed = FALSE,
 
@@ -858,16 +867,24 @@ RCodeRunner <- R6::R6Class(
     #' @param max_output_chars Integer max output size
     #' @param allowed_packages Character vector of allowed packages
     #' @param prelude Character vector of prelude code
+    #' @param persistent Whether to reuse one subprocess across executions
     initialize = function(
       timeout = 30,
       max_output_chars = 100000L,
       allowed_packages = c("base", "stats", "utils", "methods"),
-      prelude = character()
+      prelude = character(),
+      persistent = FALSE
     ) {
       self$timeout <- timeout
       self$max_output_chars <- max_output_chars
       self$allowed_packages <- allowed_packages
       self$prelude <- prelude
+      if (
+        !is.logical(persistent) || length(persistent) != 1L || is.na(persistent)
+      ) {
+        cli::cli_abort("{.arg persistent} must be TRUE or FALSE")
+      }
+      self$persistent <- persistent
     },
 
     #' @description
@@ -917,6 +934,14 @@ RCodeRunner <- R6::R6Class(
         return(private$error_result(
           error = danger_check,
           duration_ms = 0
+        ))
+      }
+
+      if (self$persistent) {
+        return(private$execute_persistent(
+          code = code,
+          context = context,
+          start_time = start_time
         ))
       }
 
@@ -1067,8 +1092,8 @@ RCodeRunner <- R6::R6Class(
     #' @description
     #' Start the interpreter lifecycle
     #'
-    #' This backend creates a fresh subprocess for every execution, so startup
-    #' is an idempotent lifecycle marker rather than process allocation.
+    #' In the default non-persistent mode, startup is an idempotent lifecycle
+    #' marker. In persistent mode, it starts and initializes one callr session.
     #'
     #' @return The runner, invisibly
     start = function() {
@@ -1088,7 +1113,150 @@ RCodeRunner <- R6::R6Class(
           class = "dsprrr_interpreter_terminal_error"
         )
       }
+      if (self$started) {
+        if (self$persistent && !private$session_is_alive()) {
+          reason <- "The persistent R subprocess is no longer running"
+          private$terminalize_persistent(reason)
+          cli::cli_abort(
+            c(
+              "The R code runner is terminal",
+              "x" = reason
+            ),
+            class = "dsprrr_interpreter_terminal_error"
+          )
+        }
+        return(invisible(self))
+      }
+
+      if (self$persistent) {
+        startup <- private$start_persistent_session()
+        if (!isTRUE(startup$ok)) {
+          cli::cli_abort(
+            c(
+              "Could not start the persistent R code runner",
+              "x" = startup$error
+            ),
+            class = c(
+              "dsprrr_r_code_runner_start_error",
+              "dsprrr_interpreter_start_error"
+            )
+          )
+        }
+      }
       self$started <- TRUE
+      invisible(self)
+    },
+
+    #' @description
+    #' Stage a base context in a persistent subprocess
+    #'
+    #' Each later `execute()` call overlays its `context` fields on this base
+    #' context for that call. The base objects are serialized only while being
+    #' prepared, rather than with every execution.
+    #'
+    #' @param context Named list of base context objects
+    #'
+    #' @return `TRUE`, invisibly, after the context is staged
+    prepare_context = function(context) {
+      private$assert_usable()
+      if (!self$persistent) {
+        cli::cli_abort(
+          c(
+            "Base context staging requires a persistent R code runner",
+            "i" = "Create it with {.code r_code_runner(persistent = TRUE)}."
+          ),
+          class = "dsprrr_r_code_runner_context_error"
+        )
+      }
+      private$validate_persistent_context(context)
+      if (!self$started) {
+        self$start()
+      }
+
+      outcome <- private$session_call(
+        utils::removeSource(private$persistent_prepare_context),
+        args = list(context = context)
+      )
+      if (!isTRUE(outcome$ok)) {
+        cli::cli_abort(
+          c(
+            "Could not prepare the persistent R code runner context",
+            "x" = outcome$error
+          ),
+          class = c(
+            "dsprrr_r_code_runner_context_error",
+            "dsprrr_interpreter_terminal_error"
+          )
+        )
+      }
+      invisible(TRUE)
+    },
+
+    #' @description
+    #' Release a staged base context without resetting persistent variables
+    #'
+    #' This clears both the staged base context and the current `.context`
+    #' binding. It is an idempotent no-op in non-persistent mode.
+    #'
+    #' @return The runner, invisibly
+    release_context = function() {
+      private$assert_usable()
+      if (!self$persistent || !self$started) {
+        return(invisible(self))
+      }
+
+      outcome <- private$session_call(
+        utils::removeSource(private$persistent_prepare_context),
+        args = list(context = list())
+      )
+      if (!isTRUE(outcome$ok)) {
+        cli::cli_abort(
+          c(
+            "Could not release the persistent R code runner context",
+            "x" = outcome$error
+          ),
+          class = c(
+            "dsprrr_r_code_runner_context_error",
+            "dsprrr_interpreter_terminal_error"
+          )
+        )
+      }
+      invisible(self)
+    },
+
+    #' @description
+    #' Reset persistent execution state and staged context
+    #'
+    #' Recreates the execution environment, reruns the prelude, and clears the
+    #' staged base context. This is an idempotent no-op in non-persistent mode.
+    #'
+    #' @return The runner, invisibly
+    reset = function() {
+      private$assert_usable()
+      if (!self$persistent) {
+        return(invisible(self))
+      }
+      if (!self$started) {
+        self$start()
+        return(invisible(self))
+      }
+
+      outcome <- private$session_call(
+        utils::removeSource(private$persistent_reset),
+        args = list()
+      )
+      if (!isTRUE(outcome$ok)) {
+        cli::cli_abort(
+          c(
+            "Could not reset the persistent R code runner",
+            "x" = outcome$error
+          ),
+          class = c(
+            "dsprrr_r_code_runner_reset_error",
+            "dsprrr_interpreter_terminal_error"
+          )
+        )
+      }
       invisible(self)
     },
 
@@ -1101,7 +1269,7 @@ RCodeRunner <- R6::R6Class(
         backend = "callr",
         trust = "trusted-input-only",
         sandboxed = FALSE,
-        persistent = FALSE,
+        persistent = self$persistent,
         process_isolation = TRUE,
         filesystem_access = "host-user",
         network_access = "host-user",
@@ -1114,13 +1282,16 @@ RCodeRunner <- R6::R6Class(
     #' @description
     #' Close the runner
     #'
-    #' `RCodeRunner` starts one subprocess per `execute()` call, so there is no
-    #' persistent session to tear down. Closing marks the object terminal and
-    #' satisfies the managed interpreter lifecycle protocol.
+    #' Closing marks the object closed and tears down a persistent subprocess,
+    #' when present. It is safe to call more than once.
     #'
     #' @return The runner, invisibly
     close = function() {
+      if (self$closed) {
+        return(invisible(self))
+      }
       self$closed <- TRUE
+      private$close_persistent_session()
       invisible(self)
     },
 
@@ -1140,10 +1311,19 @@ RCodeRunner <- R6::R6Class(
     print = function() {
       trust <- self$policy()$trust
       cli::cli_h3("RCodeRunner")
-      cli::cli_bullets(c(
+      details <- c(
         "*" = "Timeout: {.val {self$timeout}} seconds",
         "*" = "Max output: {.val {self$max_output_chars}} chars",
-        "*" = "Allowed packages: {.val {self$allowed_packages}}",
+        "*" = "Allowed packages: {.val {self$allowed_packages}}"
+      )
+      if (self$persistent) {
+        details <- c(
+          details,
+          "*" = "Persistent session: {.val TRUE}"
+        )
+      }
+      cli::cli_bullets(c(
+        details,
         "!" = "Trust: {.val {trust}}; not sandboxed"
       ))
       invisible(self)
@@ -1151,6 +1331,496 @@ RCodeRunner <- R6::R6Class(
   ),
 
   private = list(
+    session = NULL,
+
+    assert_usable = function() {
+      if (self$closed) {
+        cli::cli_abort(
+          "The R code runner is closed",
+          class = "dsprrr_interpreter_closed_error"
+        )
+      }
+      if (self$terminal) {
+        cli::cli_abort(
+          c(
+            "The R code runner is terminal",
+            "x" = self$terminal_reason %||%
+              "A subprocess or protocol failure occurred."
+          ),
+          class = "dsprrr_interpreter_terminal_error"
+        )
+      }
+      invisible(NULL)
+    },
+
+    validate_persistent_context = function(context) {
+      context_names <- names(context)
+      valid_names <- length(context) == 0L ||
+        (!is.null(context_names) &&
+          !anyNA(context_names) &&
+          all(nzchar(context_names)) &&
+          !anyDuplicated(context_names))
+      if (!is.list(context) || is.data.frame(context) || !valid_names) {
+        cli::cli_abort(
+          "{.arg context} must be a uniquely named list",
+          class = "dsprrr_r_code_runner_context_error"
+        )
+      }
+      invisible(context)
+    },
+
+    timeout_ms = function() {
+      if (
+        !is.numeric(self$timeout) ||
+          length(self$timeout) != 1L ||
+          is.na(self$timeout) ||
+          !is.finite(self$timeout) ||
+          self$timeout <= 0
+      ) {
+        cli::cli_abort(
+          "{.arg timeout} must be one positive finite number"
+        )
+      }
+      as.integer(min(
+        .Machine$integer.max,
+        max(1, ceiling(self$timeout * 1000))
+      ))
+    },
+
+    session_is_alive = function() {
+      !is.null(private$session) &&
+        isTRUE(tryCatch(
+          private$session$is_alive(),
+          error = function(e) FALSE
+        ))
+    },
+
+    close_persistent_session = function(force = FALSE) {
+      session <- private$session
+      private$session <- NULL
+      if (is.null(session)) {
+        return(invisible(NULL))
+      }
+
+      close_condition <- NULL
+      if (isTRUE(force)) {
+        try(session$kill(grace = 0), silent = TRUE)
+        try(session$wait(1000), silent = TRUE)
+      } else {
+        close_condition <- tryCatch(
+          {
+            session$close()
+            NULL
+          },
+          interrupt = function(condition) condition,
+          error = function(e) {
+            e
+          }
+        )
+        if (inherits(close_condition, "condition")) {
+          try(session$kill(grace = 0), silent = TRUE)
+          try(session$wait(1000), silent = TRUE)
+        }
+      }
+      try(session$cleanup(), silent = TRUE)
+      if (inherits(close_condition, "interrupt")) {
+        stop(close_condition)
+      }
+      invisible(NULL)
+    },
+
+    terminalize_persistent = function(reason) {
+      private$mark_terminal(reason)
+      private$close_persistent_session(force = TRUE)
+      invisible(NULL)
+    },
+
+    condition_message = function(condition) {
+      if (inherits(condition, "condition")) {
+        return(conditionMessage(condition))
+      }
+      value <- paste(as.character(condition), collapse = "\n")
+      if (nzchar(value)) value else "Unknown persistent R session failure"
+    },
+
+    session_call = function(func, args = list()) {
+      private$timeout_ms()
+      started_at <- proc.time()[["elapsed"]]
+      outcome <- tryCatch(
+        {
+          if (!private$session_is_alive()) {
+            stop("The persistent R subprocess is not running", call. = FALSE)
+          }
+          private$session$call(func = func, args = args)
+
+          answer <- NULL
+          repeat {
+            elapsed <- proc.time()[["elapsed"]] - started_at
+            remaining <- self$timeout - elapsed
+            if (remaining <= 0) {
+              answer <- list(
+                ok = FALSE,
+                error = paste0(
+                  "Execution timed out after ",
+                  self$timeout,
+                  " seconds"
+                )
+              )
+              break
+            }
+
+            poll_timeout <- as.integer(min(
+              .Machine$integer.max,
+              max(1, ceiling(remaining * 1000))
+            ))
+            poll_status <- private$session$poll_process(poll_timeout)
+            if (identical(poll_status, "timeout")) {
+              answer <- list(
+                ok = FALSE,
+                error = paste0(
+                  "Execution timed out after ",
+                  self$timeout,
+                  " seconds"
+                )
+              )
+              break
+            }
+
+            response <- private$session$read()
+            if (is.null(response)) {
+              next
+            }
+            response_code <- as.integer(response$code %||% 0L)
+            if (identical(response_code, 200L)) {
+              if (!is.null(response$error)) {
+                answer <- list(
+                  ok = FALSE,
+                  error = private$condition_message(response$error)
+                )
+              } else {
+                answer <- list(ok = TRUE, result = response$result)
+              }
+              break
+            }
+            if (response_code >= 500L) {
+              answer <- list(
+                ok = FALSE,
+                error = private$condition_message(
+                  response$error %||% response$message
+                )
+              )
+              break
+            }
+          }
+          answer
+        },
+        interrupt = function(condition) {
+          private$terminalize_persistent(
+            "Persistent R execution was interrupted"
+          )
+          stop(condition)
+        },
+        error = function(condition) {
+          list(ok = FALSE, error = conditionMessage(condition))
+        }
+      )
+
+      if (!isTRUE(outcome$ok)) {
+        private$terminalize_persistent(outcome$error)
+      }
+      outcome
+    },
+
+    start_persistent_session = function() {
+      startup <- tryCatch(
+        {
+          wait_timeout <- private$timeout_ms()
+          private$session <- callr::r_session$new(
+            options = callr::r_session_options(
+              user_profile = FALSE,
+              system_profile = FALSE,
+              env = c(
+                callr::rcmd_safe_env(),
+                "R_BROWSER" = "false",
+                "R_PDFVIEWER" = "false"
+              )
+            ),
+            wait_timeout = wait_timeout
+          )
+          private$session_call(
+            utils::removeSource(private$persistent_initialize),
+            args = list(
+              prelude = self$prelude,
+              allowed_packages = self$allowed_packages
+            )
+          )
+        },
+        interrupt = function(condition) {
+          private$terminalize_persistent("Persistent R startup was interrupted")
+          stop(condition)
+        },
+        error = function(condition) {
+          list(ok = FALSE, error = conditionMessage(condition))
+        }
+      )
+      if (!isTRUE(startup$ok)) {
+        private$terminalize_persistent(startup$error)
+      }
+      startup
+    },
+
+    execute_persistent = function(code, context, start_time) {
+      private$validate_persistent_context(context)
+
+      stdout_file <- tempfile("stdout_", fileext = ".txt")
+      stderr_file <- tempfile("stderr_", fileext = ".txt")
+      on.exit(unlink(c(stdout_file, stderr_file)), add = TRUE)
+
+      outcome <- private$session_call(
+        utils::removeSource(private$persistent_execution_wrapper),
+        args = list(
+          code = code,
+          context = context,
+          stdout_path = stdout_file,
+          stderr_path = stderr_file
+        )
+      )
+      duration_ms <- as.numeric(
+        difftime(Sys.time(), start_time, units = "secs")
+      ) *
+        1000
+      stdout_content <- private$read_output_file(stdout_file)
+      stderr_content <- private$read_output_file(stderr_file)
+
+      if (!isTRUE(outcome$ok)) {
+        return(private$error_result(
+          error = outcome$error,
+          stdout = stdout_content,
+          stderr = stderr_content,
+          duration_ms = duration_ms,
+          error_type = "interpreter"
+        ))
+      }
+
+      exec_result <- outcome$result
+      if (
+        !is.list(exec_result) ||
+          !is.logical(exec_result$success) ||
+          length(exec_result$success) != 1L ||
+          is.na(exec_result$success)
+      ) {
+        reason <- paste(
+          "The persistent R subprocess returned no valid structured execution result"
+        )
+        private$terminalize_persistent(reason)
+        return(private$error_result(
+          error = reason,
+          stdout = stdout_content,
+          stderr = stderr_content,
+          duration_ms = duration_ms,
+          error_type = "interpreter"
+        ))
+      }
+
+      combine_output <- function(primary, fallback) {
+        values <- c(primary %||% "", fallback %||% "")
+        values <- values[nzchar(values)]
+        if (length(values) == 0L) "" else paste(values, collapse = "\n")
+      }
+      list(
+        success = exec_result$success,
+        result = exec_result$result,
+        stdout = private$truncate_output(combine_output(
+          exec_result$stdout,
+          stdout_content
+        )),
+        stderr = private$truncate_output(combine_output(
+          exec_result$stderr,
+          stderr_content
+        )),
+        messages = private$truncate_output(exec_result$messages %||% ""),
+        warnings = private$truncate_output(exec_result$warnings %||% ""),
+        error = exec_result$error,
+        error_type = if (isTRUE(exec_result$success)) NULL else "execution",
+        retryable = !isTRUE(exec_result$success),
+        duration_ms = round(duration_ms, 2)
+      )
+    },
+
+    persistent_initialize = function(prelude, allowed_packages) {
+      make_exec_env <- function() {
+        exec_env <- new.env(parent = globalenv())
+        exec_env$.context <- list()
+        exec_env$library <- function(package, ...) {
+          pkg_expr <- substitute(package)
+          pkg_name <- if (is.character(pkg_expr)) {
+            pkg_expr
+          } else {
+            as.character(pkg_expr)
+          }
+          if (!pkg_name %in% allowed_packages) {
+            stop(
+              "Package '",
+              pkg_name,
+              "' is not in allowed_packages. ",
+              "Allowed: ",
+              paste(allowed_packages, collapse = ", "),
+              call. = FALSE
+            )
+          }
+          base::library(pkg_name, character.only = TRUE, ...)
+        }
+        exec_env$require <- function(package, ...) {
+          pkg_expr <- substitute(package)
+          pkg_name <- if (is.character(pkg_expr)) {
+            pkg_expr
+          } else {
+            as.character(pkg_expr)
+          }
+          if (!pkg_name %in% allowed_packages) {
+            stop(
+              "Package '",
+              pkg_name,
+              "' is not in allowed_packages. ",
+              "Allowed: ",
+              paste(allowed_packages, collapse = ", "),
+              call. = FALSE
+            )
+          }
+          base::require(pkg_name, character.only = TRUE, ...)
+        }
+        if (length(prelude) > 0L) {
+          for (statement in prelude) {
+            base::eval(base::parse(text = statement), envir = exec_env)
+          }
+        }
+        exec_env
+      }
+
+      state <- new.env(parent = emptyenv())
+      state$base_context <- list()
+      state$make_exec_env <- make_exec_env
+      state$exec_env <- make_exec_env()
+      # This function runs inside an owned callr session. Keep the persistent
+      # interpreter state in that child session's global environment without
+      # exposing a package-process global assignment to static checkers.
+      session_env <- globalenv()
+      session_env$.dsprrr_r_code_runner_state <- state
+      TRUE
+    },
+
+    persistent_prepare_context = function(context) {
+      state <- get(
+        ".dsprrr_r_code_runner_state",
+        envir = globalenv(),
+        inherits = FALSE
+      )
+      state$base_context <- context
+      state$exec_env$.context <- context
+      TRUE
+    },
+
+    persistent_reset = function() {
+      state <- get(
+        ".dsprrr_r_code_runner_state",
+        envir = globalenv(),
+        inherits = FALSE
+      )
+      state$base_context <- list()
+      state$exec_env <- state$make_exec_env()
+      TRUE
+    },
+
+    persistent_execution_wrapper = function(
+      code,
+      context,
+      stdout_path,
+      stderr_path
+    ) {
+      state <- get(
+        ".dsprrr_r_code_runner_state",
+        envir = globalenv(),
+        inherits = FALSE
+      )
+      effective_context <- state$base_context
+      if (length(context) > 0L) {
+        for (name in names(context)) {
+          effective_context[name] <- context[name]
+        }
+      }
+      state$exec_env$.context <- effective_context
+
+      messages <- character()
+      warnings <- character()
+      stdout_connection <- file(stdout_path, open = "wt")
+      stderr_connection <- file(stderr_path, open = "wt")
+      output_sinks <- sink.number(type = "output")
+      message_sink <- sink.number(type = "message")
+      sink(stdout_connection, type = "output")
+      sink(stderr_connection, type = "message")
+      restore_sinks <- function() {
+        while (sink.number(type = "message") != message_sink) {
+          sink(type = "message")
+        }
+        while (sink.number(type = "output") > output_sinks) {
+          sink(type = "output")
+        }
+        close(stdout_connection)
+        close(stderr_connection)
+        invisible(NULL)
+      }
+      on.exit(restore_sinks(), add = TRUE)
+
+      result <- tryCatch(
+        {
+          withCallingHandlers(
+            base::eval(
+              base::parse(text = code),
+              envir = state$exec_env
+            ),
+            message = function(message) {
+              messages <<- c(messages, conditionMessage(message))
+              invokeRestart("muffleMessage")
+            },
+            warning = function(warning) {
+              warnings <<- c(warnings, conditionMessage(warning))
+              invokeRestart("muffleWarning")
+            }
+          )
+        },
+        error = function(error) {
+          structure(
+            list(msg = conditionMessage(error)),
+            class = "code_error"
+          )
+        }
+      )
+      restore_sinks()
+      on.exit(NULL, add = FALSE)
+
+      if (inherits(result, "code_error")) {
+        list(
+          success = FALSE,
+          result = NULL,
+          stdout = "",
+          stderr = "",
+          messages = paste(messages, collapse = "\n"),
+          warnings = paste(warnings, collapse = "\n"),
+          error = result$msg
+        )
+      } else {
+        list(
+          success = TRUE,
+          result = result,
+          stdout = "",
+          stderr = "",
+          messages = paste(messages, collapse = "\n"),
+          warnings = paste(warnings, collapse = "\n"),
+          error = NULL
+        )
+      }
+    },
+
     #' Wrapper function that runs inside the subprocess
     #' NOTE: Intentionally uses eval() - this is the core purpose of
     #' ProgramOfThought/CodeAct modules (execute LLM-generated code)
@@ -1407,6 +2077,16 @@ RCodeRunner <- R6::R6Class(
     mark_terminal = function(reason) {
       self$terminal <- TRUE
       self$terminal_reason <- as.character(reason)[[1L]]
+      invisible(NULL)
+    },
+
+    finalize = function() {
+      # Do not call processx/callr methods from an R garbage-collection
+      # finalizer. Native process setup may be active for another session, and
+      # re-entering processx teardown from GC can crash the host R process.
+      # Invocation-owned runners are closed by with_code_runner_lease(); callers
+      # that retain a runner own its explicit close(). The callr session's own
+      # processx finalizer remains responsible for abandoned resources.
       invisible(NULL)
     }
   )

--- a/R/rlm-tools.R
+++ b/R/rlm-tools.R
@@ -10,13 +10,16 @@
 #' - `SUBMIT(...)`: Terminate and return final output values
 #' - `peek(var, start, end)`: View a slice of a variable
 #' - `search(var, pattern)`: Regex search in variable
-#' - `llm_query(query, context_slice)`: Request a recursive LLM call (returns marker for interception)
-#' - `llm_query_batched(queries, slices)`: Request batched LLM calls (returns marker for interception)
+#' - `llm_query(query, context_slice)`: Request a recursive LLM call
+#' - `llm_query_batched(queries, slices)`: Request batched LLM calls
 #' - `rlm_query()` / `rlm_query_batch()`: Backward-compatible aliases
 #'
-#' The recursive-query helper functions return special marker objects
-#' that the main RLM process intercepts and handles. The actual LLM calls happen
-#' in the parent R process, not in the sandboxed code execution environment.
+#' Recursive-query helpers suspend execution with a nonce-bound, schema-checked
+#' request. The main RLM process handles the request and replays the code with
+#' an immutable response, so the helpers behave like ordinary value-returning R
+#' functions.
+#' The actual LLM calls happen in the parent R process, not in the sandboxed code
+#' execution environment.
 #'
 #' @keywords internal
 #' @name rlm-tools
@@ -28,6 +31,16 @@ rlm_host_tool_replay_field <- function() {
 }
 
 
+rlm_query_replay_field <- function() {
+  ".dsprrr_rlm_query_replay"
+}
+
+
+rlm_control_replay_field <- function() {
+  ".dsprrr_rlm_control_replay"
+}
+
+
 #' Create RLM Prelude Code
 #'
 #' @description
@@ -35,9 +48,13 @@ rlm_host_tool_replay_field <- function() {
 #'
 #' @param max_llm_calls Maximum allowed recursive LLM calls
 #' @param has_sub_lm Logical indicating if recursive queries are enabled
-#' @param custom_tools Named list of user-defined R functions
-#' @param output_fields Character vector of required output field names for SUBMIT()
-#' @param control_nonce Per-invocation nonce used to authenticate control frames
+#' @param custom_tools Named list of user-defined R functions or ellmer ToolDef
+#'   objects. Bridge arguments use a lossless JSON-compatible domain: unclassed
+#'   logical, integer, double, character, NULL, and recursively nested lists;
+#'   missing and non-finite values are rejected.
+#' @param output_fields Character vector of output field names for SUBMIT()
+#' @param required_output_fields Character vector of required output fields
+#' @param control_nonce Per-invocation nonce used to correlate control frames
 #' @param control_frame_limit Maximum encoded control-frame size in bytes
 #'
 #' @return Character string of R code defining RLM tools
@@ -49,20 +66,34 @@ create_rlm_prelude <- function(
   has_sub_lm = FALSE,
   custom_tools = list(),
   output_fields = "answer",
+  required_output_fields = output_fields,
   control_nonce = rlm_control_nonce(),
   control_frame_limit = Inf
 ) {
-  if (!is.character(output_fields) || length(output_fields) < 1) {
+  if (!is.character(output_fields)) {
     output_fields <- "answer"
   }
 
   output_fields <- trimws(output_fields)
   output_fields <- output_fields[nzchar(output_fields)]
-  if (length(output_fields) < 1) {
-    output_fields <- "answer"
+  if (
+    !is.character(required_output_fields) ||
+      anyNA(required_output_fields) ||
+      !all(nzchar(required_output_fields)) ||
+      anyDuplicated(required_output_fields) ||
+      !all(required_output_fields %in% output_fields)
+  ) {
+    cli::cli_abort(
+      "Internal required RLM output fields must be a unique subset of output fields",
+      class = "dsprrr_rlm_control_error"
+    )
   }
 
   quoted_fields <- paste(sprintf("\"%s\"", output_fields), collapse = ", ")
+  quoted_required_fields <- paste(
+    sprintf("\"%s\"", required_output_fields),
+    collapse = ", "
+  )
 
   if (
     !is.character(control_nonce) ||
@@ -122,15 +153,163 @@ create_rlm_prelude <- function(
   )
   if (base::nchar(frame, type = "bytes") > %s) {
     base::stop(
-      "Authenticated RLM control frame exceeds the runner transport limit"
+      "RLM control frame exceeds the runner transport limit"
     )
   }
   frame
 }
+
+# One ordered ledger covers recursive queries and host tools. A shared sequence
+# prevents a replay from changing the next privileged operation kind.
+.rlm_control_replay <- .context[[%s]]
+if (base::is.null(.rlm_control_replay)) {
+  .rlm_control_replay <- base::list()
+}
+if (!base::is.list(.rlm_control_replay)) {
+  base::stop("Malformed RLM control replay state")
+}
+.rlm_control_call <- base::local({
+  .replay <- .rlm_control_replay
+  .index <- 0L
+  .encode <- .rlm_control_encode
+  .validate <- function(value, path = "request") {
+    if (base::is.null(value)) {
+      return(base::invisible(TRUE))
+    }
+    if (base::inherits(value, "AsIs")) {
+      value <- base::unclass(value)
+    }
+    if (base::is.object(value)) {
+      base::stop(
+        path,
+        " must use unclassed JSON-compatible values",
+        call. = FALSE
+      )
+    }
+    if (base::is.list(value)) {
+      value_names <- base::names(value)
+      if (
+        !base::is.null(value_names) &&
+          (
+            base::anyNA(value_names) ||
+              base::any(!base::nzchar(value_names)) ||
+              base::anyDuplicated(value_names)
+          )
+      ) {
+        base::stop(
+          path,
+          " must have unique non-empty names or no names",
+          call. = FALSE
+        )
+      }
+      for (i in base::seq_along(value)) {
+        child <- if (base::is.null(value_names)) {
+          base::paste0(path, "[[", i, "]]" )
+        } else {
+          base::paste0(path, "$", value_names[[i]])
+        }
+        .validate(value[[i]], child)
+      }
+      return(base::invisible(TRUE))
+    }
+    supported <- base::is.atomic(value) &&
+      base::typeof(value) %%in%% base::c(
+        "logical",
+        "integer",
+        "double",
+        "character"
+      ) &&
+      base::is.null(base::attributes(value))
+    if (!supported) {
+      base::stop(
+        path,
+        " must use unclassed JSON-compatible values",
+        call. = FALSE
+      )
+    }
+    if (base::anyNA(value)) {
+      base::stop(path, " cannot contain missing values", call. = FALSE)
+    }
+    if (base::is.numeric(value) && base::any(!base::is.finite(value))) {
+      base::stop(path, " cannot contain NaN or infinite values", call. = FALSE)
+    }
+    base::invisible(TRUE)
+  }
+  .canonicalize <- function(value) {
+    if (base::is.object(value)) {
+      value <- base::unclass(value)
+    }
+    if (base::is.list(value)) {
+      value <- base::lapply(value, .canonicalize)
+      value_names <- base::names(value)
+      if (!base::is.null(value_names) && base::length(value_names) > 0L) {
+        value <- value[base::order(value_names)]
+      }
+    }
+    value
+  }
+  .canonical <- function(value) {
+    base::as.character(jsonlite::toJSON(
+      .canonicalize(value),
+      auto_unbox = TRUE,
+      null = "null",
+      na = "null",
+      dataframe = "rows",
+      digits = NA
+    ))
+  }
+  .suspend <- function(frame) {
+    if (!base::is.null(base::findRestart(".dsprrr_rlm_control"))) {
+      base::invokeRestart(".dsprrr_rlm_control", frame)
+    }
+    base::stop(frame, call. = FALSE)
+  }
+
+  function(kind, request) {
+    .index <<- .index + 1L
+    request <- base::c(base::list(index = .index), request)
+    .validate(request)
+    if (.index <= base::length(.replay)) {
+      response <- .replay[[.index]]
+      valid <- base::is.list(response) &&
+        base::identical(response$kind, kind) &&
+        base::is.list(response$request) &&
+        base::is.logical(response$success) &&
+        base::length(response$success) == 1L &&
+        !base::is.na(response$success)
+      if (!valid) {
+        base::stop("Malformed RLM control replay state", call. = FALSE)
+      }
+      if (!base::identical(.canonical(response$request), .canonical(request))) {
+        base::stop(
+          "RLM control replay diverged from its recorded request",
+          call. = FALSE
+        )
+      }
+      if (base::isTRUE(response$success)) {
+        if (!"value" %%in%% base::names(response)) {
+          base::stop("Malformed RLM control replay state", call. = FALSE)
+        }
+        return(response$value)
+      }
+      if (
+        !base::is.character(response$error) ||
+          base::length(response$error) != 1L ||
+          base::is.na(response$error) ||
+          !base::nzchar(response$error)
+      ) {
+        base::stop("Malformed RLM control replay state", call. = FALSE)
+      }
+      base::stop(response$error, call. = FALSE)
+    }
+    .suspend(.encode(kind, request))
+  }
+})
 ',
     control_nonce_literal,
     rlm_control_prefix(),
-    control_frame_limit_literal
+    control_frame_limit_literal,
+    encodeString(rlm_control_replay_field(), quote = "\"")
   )
 
   submit_prelude <- sprintf(
@@ -139,12 +318,16 @@ create_rlm_prelude <- function(
 # Supports positional args (SUBMIT(v1, v2)) or named args
 # (SUBMIT(field1 = v1, field2 = v2)).
 SUBMIT <- base::local({
-  .encode <- .rlm_control_encode
+  .call <- .rlm_control_call
   .output_fields <- base::c(%s)
+  .required_output_fields <- base::c(%s)
 
   function(...) {
     args <- base::list(...)
-    if (base::length(args) == 0) {
+    if (
+      base::length(args) == 0 &&
+        base::length(.required_output_fields) > 0
+    ) {
       base::stop("SUBMIT() requires at least one output value")
     }
 
@@ -154,7 +337,9 @@ SUBMIT <- base::local({
     }
     has_any_names <- base::any(base::nzchar(arg_names))
 
-    if (!has_any_names) {
+    if (base::length(args) == 0) {
+      args <- base::list()
+    } else if (!has_any_names) {
       if (base::length(args) != base::length(.output_fields)) {
         base::stop(
           "SUBMIT() expected ",
@@ -172,7 +357,7 @@ SUBMIT <- base::local({
         base::stop("SUBMIT() output names must be unique")
       }
 
-      missing <- base::setdiff(.output_fields, arg_names)
+      missing <- base::setdiff(.required_output_fields, arg_names)
       extra <- base::setdiff(arg_names, .output_fields)
 
       if (base::length(missing) > 0) {
@@ -188,14 +373,15 @@ SUBMIT <- base::local({
         )
       }
 
-      args <- args[.output_fields]
+      args <- args[base::intersect(.output_fields, arg_names)]
     }
 
-    .encode("final", args)
+    .call("final", base::list(output = args))
   }
 })
 ',
-    quoted_fields
+    quoted_fields,
+    quoted_required_fields
   )
 
   # Base tools (always available)
@@ -206,30 +392,55 @@ SUBMIT <- base::local({
 
 # peek: View a slice of a character variable
 # Useful for exploring large text contexts
-peek <- function(var, start = 1L, end = 1000L) {
-  if (!base::is.character(var)) {
-    var <- base::as.character(var)
+peek <- base::local({
+  .index <- function(value, name) {
+    valid <- base::is.numeric(value) &&
+      base::length(value) == 1L &&
+      !base::is.na(value) &&
+      base::is.finite(value) &&
+      value == base::floor(value)
+    if (!valid) {
+      base::stop(name, " must be one finite whole number", call. = FALSE)
+    }
+    value
   }
 
-  if (base::length(var) > 1) {
-    # For character vectors, show elements in range
-    n <- base::length(var)
-    start <- base::max(1L, base::as.integer(start))
-    end <- base::min(n, base::as.integer(end))
-    return(var[start:end])
+  function(var, start = 1L, end = 1000L) {
+    if (!base::is.character(var)) {
+      var <- base::as.character(var)
+    }
+    start <- .index(start, "start")
+    end <- .index(end, "end")
+
+    if (base::length(var) == 0L) {
+      return(base::character())
+    }
+
+    if (base::length(var) > 1L) {
+      # For character vectors, show elements in range.
+      n <- base::length(var)
+      start <- base::max(1, start)
+      end <- base::min(n, end)
+      if (start > n || end < start) {
+        return(base::character())
+      }
+      return(var[base::seq.int(start, end)])
+    }
+
+    # For single strings, show character range.
+    if (base::is.na(var)) {
+      return(NA_character_)
+    }
+    total_chars <- base::nchar(var)
+    start <- base::max(1, start)
+    end <- base::min(total_chars, end)
+    if (start > total_chars || end < start) {
+      return("")
+    }
+
+    base::substr(var, start, end)
   }
-
-  # For single strings, show character range
-  total_chars <- base::nchar(var)
-  start <- base::max(1L, base::as.integer(start))
-  end <- base::min(total_chars, base::as.integer(end))
-
-  if (start > total_chars) {
-    return("")
-  }
-
-  base::substr(var, start, end)
-}
+})
 
 # search: Regex search in a variable
 # Returns all matches as a character vector
@@ -257,13 +468,33 @@ search <- function(var, pattern, ignore_case = FALSE) {
   if (has_sub_lm) {
     recursive_prelude <- sprintf(
       '
+# Non-local recursive-query replay bridge
+
 # llm_query: Recursive LLM query
-# Returns a request marker - main process will intercept and handle
 llm_query <- base::local({
-  .encode <- .rlm_control_encode
+  .call <- .rlm_control_call
   function(query, context_slice = NULL) {
-    # The actual LLM call happens in the parent R process.
-    .encode(
+    if (
+      !base::is.character(query) ||
+        base::length(query) != 1L ||
+        base::is.na(query) ||
+        !base::nzchar(query)
+    ) {
+      base::stop("query must be one non-empty character string")
+    }
+    if (
+      !base::is.null(context_slice) &&
+        (
+          !base::is.character(context_slice) ||
+            base::length(context_slice) != 1L ||
+            base::is.na(context_slice)
+        )
+    ) {
+      base::stop(
+        "context_slice must be NULL or one non-missing character string"
+      )
+    }
+    .call(
       "query",
       base::list(query = query, context = context_slice, batch = FALSE)
     )
@@ -271,12 +502,15 @@ llm_query <- base::local({
 })
 
 # llm_query_batched: Batched recursive queries
-# Returns a request marker for batch processing
 llm_query_batched <- base::local({
-  .encode <- .rlm_control_encode
+  .call <- .rlm_control_call
   function(queries, slices = NULL) {
-    if (!base::is.character(queries) || base::anyNA(queries)) {
-      base::stop("queries must be a non-missing character vector")
+    if (
+      !base::is.character(queries) ||
+        base::anyNA(queries) ||
+        base::any(!base::nzchar(queries))
+    ) {
+      base::stop("queries must be a non-empty character vector")
     }
 
     if (!base::is.null(slices)) {
@@ -299,7 +533,7 @@ llm_query_batched <- base::local({
       }
     }
 
-    .encode(
+    .call(
       "query",
       base::list(
         queries = base::I(queries),
@@ -336,8 +570,8 @@ rlm_query_batch <- llm_query_batched
 '
   }
 
-  # Custom tools remain in the host process. The guest emits one authenticated
-  # request, then the host replays the program with an immutable response. This
+  # Custom tools remain in the host process. The guest emits one nonce-bound,
+  # schema-checked request, then the host replays the program with an immutable response. This
   # preserves closure identity and works across both local and remote runners
   # without serializing or deparsing privileged functions into generated code.
   custom_prelude <- ""
@@ -362,59 +596,19 @@ rlm_query_batch <- llm_query_batched
 
     custom_prelude <- sprintf(
       '
-# Authenticated host-tool replay bridge
-.rlm_host_tool_replay <- .context[[%s]]
-if (base::is.null(.rlm_host_tool_replay)) {
-  .rlm_host_tool_replay <- base::list()
-}
-if (!base::is.list(.rlm_host_tool_replay)) {
-  base::stop("Malformed RLM host-tool replay state")
-}
+# Non-local host-tool replay bridge
 .rlm_host_tool_call <- base::local({
-  .replay <- .rlm_host_tool_replay
-  .index <- 0L
-  .encode <- .rlm_control_encode
-  .canonical <- function(value) {
-    base::as.character(jsonlite::toJSON(
-      value,
-      auto_unbox = TRUE,
-      null = "null",
-      na = "null",
-      dataframe = "rows",
-      digits = NA
-    ))
-  }
-
+  .call <- .rlm_control_call
   function(name, arguments) {
-    .index <<- .index + 1L
-    request <- base::list(
-      index = .index,
-      name = name,
-      arguments = arguments
+    .call(
+      "host_tool",
+      base::list(name = name, arguments = arguments)
     )
-    if (.index <= base::length(.replay)) {
-      response <- .replay[[.index]]
-      valid <- base::is.list(response) &&
-        base::is.list(response$request) &&
-        base::identical(.canonical(response$request), .canonical(request)) &&
-        base::is.logical(response$success) &&
-        base::length(response$success) == 1L &&
-        !base::is.na(response$success)
-      if (!valid) {
-        base::stop("RLM host-tool replay diverged from its authenticated request")
-      }
-      if (base::isTRUE(response$success)) {
-        return(response$value)
-      }
-      base::stop(base::as.character(response$error)[[1L]], call. = FALSE)
-    }
-    base::stop(.encode("host_tool", request), call. = FALSE)
   }
 })
 
 %s
 ',
-      encodeString(rlm_host_tool_replay_field(), quote = "\""),
       paste(tool_wrappers, collapse = "\n")
     )
   }
@@ -428,7 +622,7 @@ if (!base::is.list(.rlm_host_tool_replay)) {
     base_prelude,
     recursive_prelude,
     custom_prelude,
-    "\nbase::rm(.rlm_control_encode)\n",
+    "\nbase::rm(.rlm_control_encode, .rlm_control_call, .rlm_control_replay)\n",
     "\n# ============================================\n"
   )
 }
@@ -459,9 +653,51 @@ abort_rlm_control <- function(message) {
 }
 
 
-decode_rlm_control <- function(x, control_nonce = NULL) {
-  if (inherits(x, "rlm_final") || inherits(x, "rlm_query_request")) {
-    return(x)
+rlm_control_attestation_attribute <- function() {
+  ".dsprrr_rlm_control_attestation"
+}
+
+
+rlm_control_attestation_token <- local({
+  token <- new.env(parent = emptyenv())
+  function() token
+})
+
+
+attest_rlm_control <- function(x) {
+  attr(
+    x,
+    rlm_control_attestation_attribute()
+  ) <- rlm_control_attestation_token()
+  x
+}
+
+
+consume_attested_rlm_control <- function(x) {
+  attestation <- attr(
+    x,
+    rlm_control_attestation_attribute(),
+    exact = TRUE
+  )
+  if (!identical(attestation, rlm_control_attestation_token())) {
+    return(NULL)
+  }
+  attr(x, rlm_control_attestation_attribute()) <- NULL
+  x
+}
+
+
+decode_rlm_control <- function(
+  x,
+  control_nonce = NULL,
+  .attest = FALSE
+) {
+  if (
+    inherits(x, "rlm_final") ||
+      inherits(x, "rlm_query_request") ||
+      inherits(x, "rlm_host_tool_request")
+  ) {
+    return(consume_attested_rlm_control(x))
   }
   if (
     !is.character(x) ||
@@ -491,7 +727,7 @@ decode_rlm_control <- function(x, control_nonce = NULL) {
   matches <- regmatches(text, gregexpr(pattern, text, perl = TRUE))[[1L]]
   if (
     length(matches) != prefix_count ||
-      any(!nzchar(matches))
+      !all(nzchar(matches))
   ) {
     abort_rlm_control("Malformed RLM control frame")
   }
@@ -541,13 +777,43 @@ decode_rlm_control <- function(x, control_nonce = NULL) {
   envelope <- envelopes[[which(current)]]
 
   if (identical(envelope$kind, "final")) {
-    return(structure(
-      envelope$payload,
-      class = c("rlm_final", class(envelope$payload)),
-      rlm_final = TRUE
-    ))
+    index <- envelope$payload$index
+    output <- envelope$payload$output
+    valid_index <- is.numeric(index) &&
+      length(index) == 1L &&
+      !is.na(index) &&
+      is.finite(index) &&
+      index == floor(index) &&
+      index >= 1L &&
+      index <= .Machine$integer.max
+    if (
+      !valid_index ||
+        !is.list(output) ||
+        !identical(names(envelope$payload), c("index", "output"))
+    ) {
+      abort_rlm_control("Malformed RLM final control frame")
+    }
+    control <- structure(
+      output,
+      class = c("rlm_final", class(output)),
+      rlm_final = TRUE,
+      rlm_control_index = as.integer(index)
+    )
+    return(if (isTRUE(.attest)) attest_rlm_control(control) else control)
   }
   if (identical(envelope$kind, "query")) {
+    index <- envelope$payload$index
+    valid_index <- is.numeric(index) &&
+      length(index) == 1L &&
+      !is.na(index) &&
+      is.finite(index) &&
+      index == floor(index) &&
+      index >= 1L &&
+      index <= .Machine$integer.max
+    if (!valid_index) {
+      abort_rlm_control("Malformed RLM query control frame")
+    }
+    envelope$payload$index <- as.integer(index)
     batch <- envelope$payload$batch
     if (!is.logical(batch) || length(batch) != 1L || is.na(batch)) {
       abort_rlm_control("Malformed RLM query control frame")
@@ -596,17 +862,25 @@ decode_rlm_control <- function(x, control_nonce = NULL) {
         )
         envelope$payload$slices <- slices
       }
-    } else if (
-      !is.character(envelope$payload$query) ||
-        length(envelope$payload$query) != 1L ||
-        is.na(envelope$payload$query)
-    ) {
-      abort_rlm_control("Malformed RLM query control frame")
+    } else {
+      query <- envelope$payload$query
+      context <- envelope$payload$context
+      valid_query <- is.character(query) &&
+        length(query) == 1L &&
+        !is.na(query)
+      valid_context <- is.null(context) ||
+        (is.character(context) &&
+          length(context) == 1L &&
+          !is.na(context))
+      if (!valid_query || !valid_context) {
+        abort_rlm_control("Malformed RLM query control frame")
+      }
     }
-    return(structure(
+    control <- structure(
       envelope$payload,
       class = c("rlm_query_request", class(envelope$payload))
-    ))
+    )
+    return(if (isTRUE(.attest)) attest_rlm_control(control) else control)
   }
   if (identical(envelope$kind, "host_tool")) {
     index <- envelope$payload$index
@@ -626,10 +900,11 @@ decode_rlm_control <- function(x, control_nonce = NULL) {
       abort_rlm_control("Malformed RLM host-tool control frame")
     }
     envelope$payload$index <- as.integer(index)
-    return(structure(
+    control <- structure(
       envelope$payload,
       class = c("rlm_host_tool_request", class(envelope$payload))
-    ))
+    )
+    return(if (isTRUE(.attest)) attest_rlm_control(control) else control)
   }
   abort_rlm_control("Unknown RLM control frame kind")
 }
@@ -693,6 +968,7 @@ extract_rlm_final <- function(x, control_nonce = NULL) {
 
   class(x) <- setdiff(class(x), "rlm_final")
   attr(x, "rlm_final") <- NULL
+  attr(x, "rlm_control_index") <- NULL
   x
 }
 

--- a/R/run.R
+++ b/R/run.R
@@ -10,7 +10,9 @@
 #'
 #' @param module A DSPrrr module (e.g., created with `module()`)
 #' @param ... Named arguments corresponding to the module's signature inputs.
-#'   Can be single values or vectors for batch processing. Additional parameters:
+#'   Can be single values or vectors for batch processing. RLM is the exception:
+#'   every supplied value is one context variable regardless of its R length;
+#'   use [run_dataset()] for multiple RLM invocations. Additional parameters:
 #'   \describe{
 #'     \item{.llm}{An ellmer chat object for LLM interaction (optional)}
 #'     \item{.verbose}{Logical indicating whether to print debug information}
@@ -41,6 +43,11 @@
 #' Empty batches return immediately without resolving a Chat or touching cache,
 #' trace, or prompt-history state. Mixing zero-length and non-empty inputs is an
 #' error.
+#'
+#' RLM inputs use scalar object semantics: vectors, lists, matrices, data frames,
+#' and fitted models each remain one `.context` variable for one investigation.
+#' Use [run_dataset()] for multiple RLM invocations and list-columns for rich
+#' per-row objects.
 #'
 #' Scalar and batch Predict calls record one trace per attempted row. Structured
 #' metadata reports usage, error, cache, backend, and batch-index fields. Native
@@ -164,11 +171,12 @@ batch_input_contract <- function(inputs) {
 #' Classify module inputs without confusing schema collections with batches
 #'
 #' Flex owns exact recursive validation for its scalar array and object fields.
-#' Their R lengths describe one schema value, not a collection of dataset rows,
-#' and Flex batch execution goes through [run_dataset()] instead.
+#' RLM stages each supplied value as one REPL variable, regardless of its R
+#' length. Those lengths therefore describe scalar module inputs, not dataset
+#' rows. Explicit Flex and RLM batch execution goes through [run_dataset()].
 #' @noRd
 module_input_contract <- function(module, inputs) {
-  if (inherits(module, "FlexModule")) {
+  if (inherits(module, c("FlexModule", "RLMModule"))) {
     return(list(
       kind = "scalar",
       size = 1L,
@@ -177,6 +185,16 @@ module_input_contract <- function(module, inputs) {
   }
 
   batch_input_contract(inputs)
+}
+
+
+#' Recycle module inputs using module-specific scalar object semantics
+#' @noRd
+module_batch_recycle_input <- function(module, value, size) {
+  if (inherits(module, "RLMModule") && is.data.frame(value)) {
+    return(rep(list(value), size))
+  }
+  batch_recycle_input(value, size)
 }
 
 #' Treat opaque runtime values as scalar batch inputs
@@ -313,8 +331,9 @@ run.Module <- function(
     if (interpreter_workflow_module(module)) {
       inputs <- lapply(
         inputs,
-        batch_recycle_input,
-        size = input_contract$size
+        function(value) {
+          module_batch_recycle_input(module, value, input_contract$size)
+        }
       )
       return(run_factory_interpreter_batch(
         module = module,
@@ -323,7 +342,8 @@ run.Module <- function(
         .llm = .llm,
         .progress = .progress,
         .return_format = .return_format,
-        .concurrency = concurrency_runtime
+        .concurrency = concurrency_runtime,
+        .cache = .cache
       ))
     }
     unsupported_control <- is.finite(concurrency$max_errors) ||
@@ -342,7 +362,12 @@ run.Module <- function(
         module_class = class(module)[1]
       )
     }
-    inputs <- lapply(inputs, batch_recycle_input, size = input_contract$size)
+    inputs <- lapply(
+      inputs,
+      function(value) {
+        module_batch_recycle_input(module, value, input_contract$size)
+      }
+    )
     results <- run_scalar_dataset_rows(
       module = module,
       input_args = inputs,
@@ -777,7 +802,7 @@ verified_chat_turn_delta <- function(chat, turns_before) {
   turns_after[seq.int(before_n + 1L, length(turns_after))]
 }
 
-#' Extract usage metadata from a verified current-call assistant turn
+#' Extract usage metadata from verified current-call assistant turns
 #'
 #' @param chat An ellmer Chat or compatible object
 #' @param turns_before Verified Chat history captured immediately before the call
@@ -793,30 +818,66 @@ chat_usage_metadata <- function(chat, turns_before = NULL) {
       turn_delta
     )
   }
-  assistant_turn <- if (length(assistant_turns) > 0L) {
-    assistant_turns[[length(assistant_turns)]]
-  } else {
-    NULL
-  }
-  if (is.null(assistant_turn)) {
+  if (length(assistant_turns) == 0L) {
     return(list(
       input_tokens = NA_integer_,
       output_tokens = NA_integer_,
       cached_input_tokens = NA_integer_,
       total_tokens = NA_integer_,
       cost = NA_real_,
-      duration_s = NA_real_
+      duration_s = NA_real_,
+      provider_calls = NA_integer_
     ))
   }
 
-  tokens <- tryCatch(assistant_turn@tokens, error = function(e) NULL)
-  input_tokens <- as.integer(tokens[1] %||% NA_integer_)
-  output_tokens <- as.integer(tokens[2] %||% NA_integer_)
-  cached_input_tokens <- as.integer(tokens[3] %||% NA_integer_)
+  strict_sum <- function(values, integer = FALSE) {
+    values <- vapply(
+      values,
+      function(value) {
+        if (
+          !is.numeric(value) ||
+            length(value) != 1L ||
+            is.na(value) ||
+            !is.finite(value) ||
+            value < 0
+        ) {
+          return(NA_real_)
+        }
+        as.numeric(value)
+      },
+      numeric(1)
+    )
+    if (length(values) == 0L || anyNA(values)) {
+      return(if (integer) NA_integer_ else NA_real_)
+    }
+    total <- sum(values)
+    if (
+      integer &&
+        (total > .Machine$integer.max || total != floor(total))
+    ) {
+      return(NA_integer_)
+    }
+    if (integer) as.integer(total) else total
+  }
+  tokens <- lapply(assistant_turns, function(turn) {
+    tryCatch(turn@tokens, error = function(e) NULL)
+  })
+  token_field <- function(index) {
+    lapply(tokens, function(value) {
+      if (length(value) < index) NA_real_ else value[[index]]
+    })
+  }
+  input_tokens <- strict_sum(token_field(1L), integer = TRUE)
+  output_tokens <- strict_sum(token_field(2L), integer = TRUE)
+  cached_input_tokens <- strict_sum(token_field(3L), integer = TRUE)
   total_tokens <- if (anyNA(c(input_tokens, output_tokens))) {
     NA_integer_
+  } else if (
+    as.double(input_tokens) + as.double(output_tokens) > .Machine$integer.max
+  ) {
+    NA_integer_
   } else {
-    input_tokens + output_tokens
+    as.integer(input_tokens + output_tokens)
   }
 
   list(
@@ -824,11 +885,13 @@ chat_usage_metadata <- function(chat, turns_before = NULL) {
     output_tokens = output_tokens,
     cached_input_tokens = cached_input_tokens,
     total_tokens = total_tokens,
-    cost = tryCatch(assistant_turn@cost, error = function(e) NA_real_),
-    duration_s = tryCatch(
-      assistant_turn@duration,
-      error = function(e) NA_real_
-    )
+    cost = strict_sum(lapply(assistant_turns, function(turn) {
+      tryCatch(turn@cost, error = function(e) NA_real_)
+    })),
+    duration_s = strict_sum(lapply(assistant_turns, function(turn) {
+      tryCatch(turn@duration, error = function(e) NA_real_)
+    })),
+    provider_calls = as.integer(length(assistant_turns))
   )
 }
 
@@ -4517,10 +4580,16 @@ run_dataset.Module <- function(
     ))
   }
 
-  # Get required input names from signature
+  # Get declared and required input names from signature
   sig_inputs <- module$signature@inputs
   if (length(sig_inputs) > 0) {
-    required_names <- vapply(sig_inputs, function(x) x$name, character(1))
+    declared_names <- vapply(sig_inputs, function(x) x$name, character(1))
+    required <- vapply(
+      sig_inputs,
+      function(x) tryCatch(isTRUE(x$type@required), error = function(e) TRUE),
+      logical(1)
+    )
+    required_names <- declared_names[required]
     missing_cols <- setdiff(required_names, names(data))
 
     if (length(missing_cols) > 0) {
@@ -4548,6 +4617,7 @@ run_dataset.Module <- function(
       cli::cli_abort(msg)
     }
   } else {
+    declared_names <- character(0)
     required_names <- character(0)
   }
 
@@ -4562,8 +4632,9 @@ run_dataset.Module <- function(
   }
 
   # Extract input columns as list
-  if (length(required_names) > 0) {
-    input_args <- as.list(data[required_names])
+  provided_input_names <- intersect(declared_names, names(data))
+  if (length(provided_input_names) > 0) {
+    input_args <- as.list(data[provided_input_names])
   } else {
     # Rows still represent distinct evaluation attempts for a zero-input
     # signature. Dataset-only columns (for example metric truth) are not module
@@ -4582,9 +4653,45 @@ run_dataset.Module <- function(
   }
   specialized_predict <- inherits(module, "PredictModule") &&
     !identical(class(module)[1], "PredictModule")
-  scalar_row_adapter <- specialized_predict || length(required_names) == 0L
+  factory_interpreter_adapter <- inherits(module, "RLMModule") &&
+    factory_interpreter_module(module)
+  scalar_row_adapter <- (specialized_predict ||
+    inherits(module, "RLMModule") ||
+    length(input_args) == 0L) &&
+    !factory_interpreter_adapter
 
-  results <- if (scalar_row_adapter) {
+  results <- if (factory_interpreter_adapter) {
+    runtime_chat <- resolve_dataset_row_chat(module, .llm)
+    concurrency_runtime <- normalize_concurrency_runtime(
+      concurrency,
+      .llm = .llm,
+      .chat = runtime_chat
+    )
+    concurrency_runtime <- normalize_factory_interpreter_batch_runtime(
+      concurrency_runtime,
+      explicit_llm = !is.null(.llm)
+    )
+    factory_rows <- run_factory_interpreter_batch(
+      module = module,
+      inputs = input_args,
+      n = nrow(data),
+      .llm = .llm,
+      .progress = .progress,
+      .return_format = .return_format,
+      .concurrency = concurrency_runtime,
+      .cache = dots$.cache %||% NULL
+    )
+    if (identical(.return_format, "simple") && nrow(data) == 1L) {
+      row_trace_events <- attr(
+        factory_rows,
+        "dsprrr_row_trace_events",
+        exact = TRUE
+      )
+      factory_rows <- factory_rows[[1L]]
+      attr(factory_rows, "dsprrr_row_trace_events") <- row_trace_events
+    }
+    factory_rows
+  } else if (scalar_row_adapter) {
     concurrent_request <- concurrency$backend %in%
       c("ellmer", "mirai") ||
       (identical(concurrency$backend, "auto") && concurrency$max_active > 1L)
@@ -4706,6 +4813,16 @@ run_dataset.Module <- function(
     results <- list(results)
   }
 
+  row_trace_events <- attr(
+    results,
+    "dsprrr_row_trace_events",
+    exact = TRUE
+  )
+  # This attribute is an evaluation-internal transport channel. Remove it from
+  # the list before assigning dataset result columns so it cannot leak onto the
+  # public list-column; restore it only on the returned data frame below.
+  attr(results, "dsprrr_row_trace_events") <- NULL
+
   error_conditions <- attr(
     results,
     "dsprrr_error_conditions",
@@ -4747,6 +4864,9 @@ run_dataset.Module <- function(
 
   output <- tibble::as_tibble(data)
   attr(output, "dsprrr_error_conditions") <- error_conditions
+  if (!is.null(row_trace_events)) {
+    attr(output, "dsprrr_row_trace_events") <- row_trace_events
+  }
   output
 }
 
@@ -4787,8 +4907,15 @@ run_scalar_dataset_rows <- function(
   dots
 ) {
   results <- vector("list", n)
+  row_trace_events <- vector("list", n)
   row_llms <- if (is.null(.runtime_chat)) {
     rep(list(NULL), n)
+  } else if (inherits(module, "RLMModule")) {
+    # RLMModule creates and clears a fresh action Chat inside each forward()
+    # call. Requiring an additional opaque-Chat branch here rejects valid
+    # sequential test/provider adapters whose closure state is intentionally
+    # shared, without adding isolation at the provider boundary.
+    rep(list(.runtime_chat), n)
   } else {
     batch_chat_branches(.runtime_chat, n)
   }
@@ -4803,7 +4930,7 @@ run_scalar_dataset_rows <- function(
 
   for (i in seq_len(n)) {
     row_inputs <- lapply(input_args, `[[`, i)
-    trace_count_before <- length(module$state$traces %||% list())
+    trace_count_before <- evaluation_trace_cursor(module)
     history_generation_before <- prompt_history_generation()
     row_result <- tryCatch(
       do.call(
@@ -4843,6 +4970,10 @@ run_scalar_dataset_rows <- function(
       row_index = i,
       runtime = .concurrency_runtime
     )
+    row_trace_events[[i]] <- new_evaluation_trace_events(
+      module,
+      trace_count_before
+    )
     if (identical(.return_format, "simple")) {
       results[i] <- list(extract_simple_output(
         results[[i]],
@@ -4868,6 +4999,7 @@ run_scalar_dataset_rows <- function(
   if (!is.null(progress_id)) {
     cli::cli_progress_done(id = progress_id)
   }
+  attr(results, "dsprrr_row_trace_events") <- row_trace_events
   if (identical(.return_format, "simple") && n == 1L) {
     results[[1]]
   } else {
@@ -4889,12 +5021,7 @@ reconcile_dataset_row_observability <- function(
   fields$batch_index <- as.integer(row_index)
 
   traces <- module$state$traces %||% list()
-  trace_count_after <- length(traces)
-  trace_indices <- if (trace_count_after > trace_count_before) {
-    seq.int(trace_count_before + 1L, trace_count_after)
-  } else {
-    integer()
-  }
+  trace_indices <- evaluation_trace_indices(module, trace_count_before)
   patched_traces <- vector("list", length(trace_indices))
   for (offset in seq_along(trace_indices)) {
     index <- trace_indices[[offset]]

--- a/R/teleprompter-bootstrap-rs.R
+++ b/R/teleprompter-bootstrap-rs.R
@@ -19,6 +19,10 @@
 #' 3. BootstrapFewShot with unshuffled examples
 #' 4. BootstrapFewShot with various random seeds
 #'
+#' Programs containing Flex or RLM modules are rejected before candidate
+#' evaluation because their predictor-local demonstration contracts are not
+#' currently available to this optimizer.
+#'
 #' @param metric A metric function for evaluating predictions (required).
 #' @param metric_threshold Minimum score for a demo to be accepted.
 #'   If NULL, accepts any successful prediction. Default is NULL.
@@ -53,6 +57,10 @@
 #' )
 #'
 #' # Compile with validation set (required)
+#' qa_module <- module(signature("question -> answer"))
+#' trainset <- data.frame(question = "Capital of France?", answer = "Paris")
+#' valset <- data.frame(question = "Capital of Japan?", answer = "Tokyo")
+#' llm <- ellmer::chat_openai()
 #' compiled <- compile(tp, qa_module, trainset, valset = valset, .llm = llm)
 #'
 #' # Access ranked candidates
@@ -198,6 +206,10 @@ compile_bootstrap_rs <- function(
       "BootstrapFewShotWithRandomSearch currently only supports Module objects"
     )
   }
+  bootstrap_assert_demo_eligible(
+    program,
+    optimizer_name = "BootstrapFewShotWithRandomSearch"
+  )
 
   if (!is.data.frame(trainset)) {
     cli::cli_abort("{.arg trainset} must be a data frame")

--- a/R/teleprompter-bootstrap.R
+++ b/R/teleprompter-bootstrap.R
@@ -32,6 +32,10 @@
 #' therefore receive demos even though the training set only labels the
 #' final output. Labeled demos (`max_labeled_demos`) are applied to the
 #' final step only, and only when its input fields exist in the trainset.
+#' Programs containing Flex or an RLM, at the root or nested, are rejected.
+#' Flex constructs its inner predictors per invocation; RLM root examples do
+#' not match its children's `state -> ...` signatures. Use GEPA for these
+#' programs, or instruction-only MIPROv2 for an RLM graph.
 #'
 #' @param metric A metric function for evaluating predictions (required).
 #' @param metric_threshold Minimum score for a demo to be accepted.
@@ -60,6 +64,9 @@
 #' )
 #'
 #' # Compile a module
+#' qa_module <- module(signature("question -> answer"))
+#' trainset <- data.frame(question = "Capital of France?", answer = "Paris")
+#' llm <- ellmer::chat_openai()
 #' compiled <- compile(tp, qa_module, trainset, .llm = llm)
 #' }
 BootstrapFewShot <- S7::new_class(
@@ -506,7 +513,7 @@ compile_bootstrap <- function(
 
       # Run teacher with temperature for diversity
       teacher_condition <- NULL
-      trace_count_before <- length(teacher$state$traces %||% list())
+      trace_count_before <- evaluation_trace_cursor(teacher)
       result <- tryCatch(
         {
           # Apply teacher settings (like temperature)
@@ -784,44 +791,69 @@ compile_bootstrap <- function(
   student
 }
 
-bootstrap_flex_paths <- function(program, path = "$") {
-  if (inherits(program, "FlexModule")) {
-    return(path)
-  }
-  if (!inherits(program, "PipelineModule")) {
-    return(character())
-  }
-
-  unlist(
-    lapply(seq_along(program$steps), function(index) {
-      bootstrap_flex_paths(
-        program$steps[[index]]@module,
-        paste0(path, "/steps/", index)
-      )
-    }),
-    use.names = FALSE
+bootstrap_flex_paths <- function(program) {
+  modules <- named_modules(
+    program,
+    include_root = TRUE,
+    boundaries = "respect"
   )
+  names(modules)[vapply(
+    modules,
+    inherits,
+    logical(1),
+    what = "FlexModule"
+  )]
 }
 
-bootstrap_assert_demo_eligible <- function(program) {
+bootstrap_assert_demo_eligible <- function(
+  program,
+  optimizer_name = "BootstrapFewShot"
+) {
   paths <- bootstrap_flex_paths(program)
-  if (length(paths) == 0L) {
-    return(invisible(program))
+  if (length(paths) > 0L) {
+    cli::cli_abort(
+      c(
+        "{optimizer_name} cannot optimize Flex demonstrations",
+        "x" = "Flex constructs fresh inner predictors for every invocation, so assigning demos to the outer module has no effect.",
+        "i" = "Unsupported Flex path{?s}: {.path {paths}}.",
+        "i" = "Use GEPA for Flex structure and instruction optimization."
+      ),
+      class = c(
+        "dsprrr_flex_demo_unsupported_error",
+        "dsprrr_optimizer_ineligible_error"
+      ),
+      paths = paths
+    )
   }
 
-  cli::cli_abort(
-    c(
-      "BootstrapFewShot cannot optimize Flex demonstrations",
-      "x" = "Flex constructs fresh inner predictors for every invocation, so assigning demos to the outer module has no effect.",
-      "i" = "Unsupported Flex path{?s}: {.path {paths}}.",
-      "i" = "Use GEPA for Flex structure and instruction optimization."
-    ),
-    class = c(
-      "dsprrr_flex_demo_unsupported_error",
-      "dsprrr_optimizer_ineligible_error"
-    ),
-    paths = paths
+  modules <- named_modules(
+    program,
+    include_root = TRUE,
+    boundaries = "respect"
   )
+  rlm_paths <- names(modules)[vapply(
+    modules,
+    inherits,
+    logical(1),
+    what = "RLMModule"
+  )]
+  if (length(rlm_paths) > 0L) {
+    cli::cli_abort(
+      c(
+        "{optimizer_name} cannot derive demos for RLM predictors",
+        "x" = "Root training examples do not match the child predictor signatures.",
+        "i" = "Unsupported RLM path{?s}: {.path {rlm_paths}}.",
+        "i" = "Use GEPA for RLM child instructions, or MIPROv2 with {.code max_bootstrapped_demos = 0L}."
+      ),
+      class = c(
+        "dsprrr_bootstrap_graph_unsupported",
+        "dsprrr_optimizer_ineligible_error"
+      ),
+      paths = rlm_paths
+    )
+  }
+
+  invisible(program)
 }
 
 #' Joint compile method for BootstrapFewShot on pipelines

--- a/R/teleprompter-mipro.R
+++ b/R/teleprompter-mipro.R
@@ -10,7 +10,11 @@
 #'
 #' @description
 #' MIPROv2 jointly optimizes instructions and few-shot demonstrations using
-#' a discrete Bayesian optimization loop with minibatch evaluation.
+#' a discrete Bayesian optimization loop with minibatch evaluation for a root
+#' Predict module. For graphs with nested predictors such as RLM, it optimizes
+#' child instructions only and requires `max_bootstrapped_demos = 0L`; nested
+#' demo bootstrapping fails explicitly until predictor-local evidence is
+#' available.
 #'
 #' @param metric A metric function for evaluating predictions (required).
 #' @param prompt_model Optional model to propose instructions.
@@ -39,6 +43,10 @@
 #'   max_bootstrapped_demos = 4L
 #' )
 #'
+#' qa_module <- module(signature("question -> answer"))
+#' trainset <- data.frame(question = "Capital of France?", answer = "Paris")
+#' valset <- data.frame(question = "Capital of Japan?", answer = "Tokyo")
+#' llm <- ellmer::chat_openai()
 #' compiled <- compile(tp, qa_module, trainset, valset = valset, .llm = llm)
 #' }
 MIPROv2 <- S7::new_class(
@@ -155,8 +163,64 @@ MIPROv2 <- S7::new_class(
 
 #' Compile method for MIPROv2
 #' @noRd
+mipro_named_predictors <- function(program, boundaries = "respect") {
+  parameters <- named_parameters(
+    program,
+    include_root = TRUE,
+    boundaries = boundaries
+  )
+  parameters[vapply(
+    parameters,
+    inherits,
+    logical(1),
+    what = "PredictModule"
+  )]
+}
+
+mipro_uses_component_candidates <- function(program) {
+  predictors <- mipro_named_predictors(program, boundaries = "cross")
+  length(predictors) > 0L &&
+    !(length(predictors) == 1L &&
+      identical(names(predictors), "$") &&
+      identical(predictors[[1L]], program))
+}
+
 mipro_apply_candidate <- function(program, candidate) {
   compiled <- copy_module(program)
+
+  if (!is.null(candidate$components)) {
+    predictors <- mipro_named_predictors(compiled, boundaries = "respect")
+    component_paths <- names(candidate$components)
+    predictor_paths <- names(predictors)
+    if (
+      is.null(component_paths) ||
+        !setequal(component_paths, predictor_paths)
+    ) {
+      cli::cli_abort(
+        c(
+          "MIPROv2 component candidate does not match the program graph",
+          "x" = "Candidate paths: {toString(component_paths)}",
+          "x" = "Predictor paths: {toString(predictor_paths)}"
+        ),
+        class = "dsprrr_mipro_component_mismatch"
+      )
+    }
+
+    for (path in predictor_paths) {
+      component <- candidate$components[[path]]
+      predictor <- predictors[[path]]
+      if (!is.null(component$demos)) {
+        predictor$demos <- lapply(component$demos, identity)
+      }
+      if (!is.null(component$instructions)) {
+        predictor$apply_optimization_params(list(
+          instructions = component$instructions
+        ))
+      }
+    }
+    return(compiled)
+  }
+
   compiled$demos <- candidate$demos %||% list()
   compiled$signature <- Signature(
     inputs = compiled$signature@inputs,
@@ -225,6 +289,24 @@ compile_mipro <- function(
     cli::cli_abort("MIPROv2 requires a metric function")
   }
 
+  component_mode <- mipro_uses_component_candidates(program)
+  if (component_mode && teleprompter@max_bootstrapped_demos > 0L) {
+    cli::cli_abort(
+      c(
+        "MIPROv2 cannot bootstrap demonstrations for nested predictors yet",
+        "x" = paste(
+          "The root trace does not provide bounded predictor-local inputs and",
+          "outputs for each child."
+        ),
+        "i" = paste(
+          "Set {.arg max_bootstrapped_demos = 0} to optimize child",
+          "instructions without changing their demonstrations."
+        )
+      ),
+      class = "dsprrr_mipro_graph_bootstrap_unsupported"
+    )
+  }
+
   evalset <- valset %||% trainset
   control <- optimizer_control_for_teleprompter(
     teleprompter,
@@ -257,6 +339,11 @@ compile_mipro <- function(
         metric_threshold = teleprompter@metric_threshold,
         seed = teleprompter@seed,
         init_temperature = teleprompter@init_temperature,
+        candidate_scope = if (component_mode) {
+          "predictor_components"
+        } else {
+          "root"
+        },
         settings = settings,
         demo_runtime = optimizer_checkpoint_effective_runtime_identity(
           program,
@@ -328,22 +415,31 @@ compile_mipro <- function(
     invisible(NULL)
   }
 
-  demo_result <- generate_mipro_demo_candidates(
-    program = program,
-    trainset = trainset,
-    teleprompter = teleprompter,
-    .llm = .llm,
-    max_candidates = settings$demo_candidates,
-    control = control,
-    budget = budget,
-    resume_state = state$demo_generation,
-    on_progress = function(...) {
-      update <- list(...)
-      state$demo_generation <<- update$state
-      write_checkpoint("demo_candidates", update$best_program)
-    },
-    return_state = TRUE
-  )
+  demo_result <- if (component_mode) {
+    generate_mipro_component_demo_candidates(
+      program = program,
+      teleprompter = teleprompter,
+      budget = budget,
+      resume_state = state$demo_generation
+    )
+  } else {
+    generate_mipro_demo_candidates(
+      program = program,
+      trainset = trainset,
+      teleprompter = teleprompter,
+      .llm = .llm,
+      max_candidates = settings$demo_candidates,
+      control = control,
+      budget = budget,
+      resume_state = state$demo_generation,
+      on_progress = function(...) {
+        update <- list(...)
+        state$demo_generation <<- update$state
+        write_checkpoint("demo_candidates", update$best_program)
+      },
+      return_state = TRUE
+    )
+  }
   if (is.null(demo_result$candidates)) {
     # Compatibility for test doubles and third-party overrides of the private
     # helper that return the historical candidate-list shape.
@@ -373,27 +469,49 @@ compile_mipro <- function(
       partial_result,
       partial = TRUE
     )
+    if (component_mode) {
+      partial$config$optimizer$candidate_scope <- "predictor_components"
+      partial$config$optimizer$demo_mode <- "preserved"
+      partial$config$optimizer$effective_labeled_demos <- 0L
+      partial$config$optimizer$effective_bootstrapped_demos <- 0L
+    }
     write_checkpoint("demo_candidates", partial)
     return(partial)
   }
 
   instruction_candidates <- state$instruction_candidates
   if (length(instruction_candidates) == 0L) {
-    instruction_candidates <- generate_mipro_instruction_candidates(
-      program = program,
-      trainset = trainset,
-      demo_candidates = demo_candidates,
-      teleprompter = teleprompter,
-      max_candidates = settings$instruction_candidates
-    )
+    instruction_candidates <- if (component_mode) {
+      generate_mipro_component_instruction_candidates(
+        program = program,
+        trainset = trainset,
+        teleprompter = teleprompter,
+        max_candidates = settings$instruction_candidates
+      )
+    } else {
+      generate_mipro_instruction_candidates(
+        program = program,
+        trainset = trainset,
+        demo_candidates = demo_candidates,
+        teleprompter = teleprompter,
+        max_candidates = settings$instruction_candidates
+      )
+    }
     state$instruction_candidates <- instruction_candidates
     write_checkpoint("discrete_bo", best_partial)
   }
 
-  candidate_grid <- expand_mipro_candidates(
-    demo_candidates = demo_candidates,
-    instruction_candidates = instruction_candidates
-  )
+  candidate_grid <- if (component_mode) {
+    expand_mipro_component_candidates(
+      demo_candidates = demo_candidates,
+      instruction_candidates = instruction_candidates
+    )
+  } else {
+    expand_mipro_candidates(
+      demo_candidates = demo_candidates,
+      instruction_candidates = instruction_candidates
+    )
+  }
   if (length(candidate_grid) == 0L) {
     cli::cli_abort(
       c(
@@ -490,6 +608,12 @@ compile_mipro <- function(
     bo_result,
     partial = !isTRUE(bo_result$complete)
   )
+  if (component_mode) {
+    compiled$config$optimizer$candidate_scope <- "predictor_components"
+    compiled$config$optimizer$demo_mode <- "preserved"
+    compiled$config$optimizer$effective_labeled_demos <- 0L
+    compiled$config$optimizer$effective_bootstrapped_demos <- 0L
+  }
   write_checkpoint(
     if (isTRUE(bo_result$complete)) "complete" else "discrete_bo",
     compiled
@@ -531,6 +655,59 @@ resolve_mipro_settings <- function(auto, num_candidates, n_train) {
       instruction_candidates = 12L
     )
   }
+}
+
+generate_mipro_component_demo_candidates <- function(
+  program,
+  teleprompter,
+  budget,
+  resume_state = NULL
+) {
+  predictors <- mipro_named_predictors(program)
+  if (length(predictors) == 0L) {
+    cli::cli_abort(
+      "MIPROv2 found no mutable Predict children in the program graph",
+      class = "dsprrr_mipro_no_component_predictors"
+    )
+  }
+
+  state <- resume_state %||%
+    list(
+      kind = "mipro_component_demos_v1",
+      candidates = NULL
+    )
+  if (
+    !is.list(state) ||
+      !setequal(names(state), c("kind", "candidates")) ||
+      !identical(state$kind, "mipro_component_demos_v1")
+  ) {
+    cli::cli_abort(
+      "MIPRO component demo-candidate state is malformed",
+      class = "dsprrr_optimizer_checkpoint_malformed"
+    )
+  }
+
+  if (is.null(state$candidates)) {
+    demo_counts <- vapply(predictors, function(x) length(x$demos), integer(1))
+    state$candidates <- list(list(
+      id = "preserved_component_demos",
+      params = list(
+        id = "preserved_component_demos",
+        type = "component_instruction_only",
+        demo_counts = as.list(demo_counts),
+        requested_labeled_demos = teleprompter@max_labeled_demos,
+        effective_labeled_demos = 0L,
+        effective_bootstrapped_demos = 0L
+      )
+    ))
+  }
+
+  list(
+    candidates = state$candidates,
+    state = state,
+    complete = TRUE,
+    budget = budget
+  )
 }
 
 generate_mipro_demo_candidates <- function(
@@ -735,12 +912,28 @@ generate_mipro_instruction_candidates <- function(
   teleprompter,
   max_candidates
 ) {
-  base <- program$signature@instructions
+  generate_mipro_instruction_candidates_for_signature(
+    signature = program$signature,
+    summary_signature = program$signature,
+    trainset = trainset,
+    max_candidates = max_candidates,
+    seed = teleprompter@seed
+  )
+}
+
+generate_mipro_instruction_candidates_for_signature <- function(
+  signature,
+  summary_signature,
+  trainset,
+  max_candidates,
+  seed
+) {
+  base <- signature@instructions
   if (!nzchar(base)) {
     base <- "Use the inputs to produce the requested output."
   }
 
-  dataset_summary <- summarize_mipro_dataset(trainset, program$signature)
+  dataset_summary <- summarize_mipro_dataset(trainset, summary_signature)
 
   tips <- c(
     "Be concise and accurate.",
@@ -753,13 +946,13 @@ generate_mipro_instruction_candidates <- function(
   tip_count <- max(0L, max_candidates - 1L)
   sampled_tips <- if (tip_count == 0L) {
     character(0)
-  } else if (!is.null(teleprompter@seed)) {
+  } else if (!is.null(seed)) {
     old_seed <- if (exists(".Random.seed", envir = globalenv())) {
       get(".Random.seed", envir = globalenv())
     } else {
       NULL
     }
-    set.seed(teleprompter@seed)
+    set.seed(seed)
     on.exit(
       {
         if (is.null(old_seed)) {
@@ -792,6 +985,53 @@ generate_mipro_instruction_candidates <- function(
   }
 
   candidates
+}
+
+generate_mipro_component_instruction_candidates <- function(
+  program,
+  trainset,
+  teleprompter,
+  max_candidates
+) {
+  predictors <- mipro_named_predictors(program)
+  if (length(predictors) == 0L) {
+    cli::cli_abort(
+      "MIPROv2 found no mutable Predict children in the program graph",
+      class = "dsprrr_mipro_no_component_predictors"
+    )
+  }
+
+  by_path <- Map(
+    function(predictor, index) {
+      seed <- if (is.null(teleprompter@seed)) {
+        NULL
+      } else {
+        as.integer(teleprompter@seed + index - 1L)
+      }
+      generate_mipro_instruction_candidates_for_signature(
+        signature = predictor$signature,
+        summary_signature = program$signature,
+        trainset = trainset,
+        max_candidates = max_candidates,
+        seed = seed
+      )
+    },
+    predictor = unname(predictors),
+    index = seq_along(predictors)
+  )
+  names(by_path) <- names(predictors)
+
+  list(list(
+    id = "component_instruction_candidates",
+    by_path = by_path,
+    params = list(
+      id = "component_instruction_candidates",
+      type = "predictor_components",
+      paths = lapply(by_path, function(candidates) {
+        lapply(candidates, function(candidate) candidate$params)
+      })
+    )
+  ))
 }
 
 summarize_mipro_dataset <- function(trainset, signature) {
@@ -836,6 +1076,117 @@ expand_mipro_candidates <- function(demo_candidates, instruction_candidates) {
         )
       )
       idx <- idx + 1L
+    }
+  }
+
+  candidates
+}
+
+mipro_component_instruction_index_sets <- function(by_path) {
+  candidate_counts <- lengths(by_path)
+  if (length(candidate_counts) == 0L || any(candidate_counts == 0L)) {
+    return(list())
+  }
+
+  # RLM has two predictors, so its complete component product remains small.
+  # Bound generic graphs before materializing their Cartesian product.
+  if (prod(as.double(candidate_counts)) <= 512) {
+    grid <- do.call(
+      expand.grid,
+      c(
+        unname(lapply(candidate_counts, seq_len)),
+        list(KEEP.OUT.ATTRS = FALSE, stringsAsFactors = FALSE)
+      )
+    )
+    names(grid) <- names(by_path)
+    return(lapply(seq_len(nrow(grid)), function(index) {
+      values <- as.integer(grid[index, , drop = TRUE])
+      stats::setNames(values, names(by_path))
+    }))
+  }
+
+  index_sets <- list(stats::setNames(
+    rep.int(1L, length(by_path)),
+    names(by_path)
+  ))
+
+  for (path in names(by_path)) {
+    if (candidate_counts[[path]] < 2L) {
+      next
+    }
+    for (index in seq.int(2L, candidate_counts[[path]])) {
+      coordinate <- index_sets[[1L]]
+      coordinate[[path]] <- index
+      index_sets[[length(index_sets) + 1L]] <- coordinate
+    }
+  }
+
+  max_count <- max(candidate_counts)
+  if (max_count >= 2L) {
+    for (index in seq.int(2L, max_count)) {
+      aligned <- vapply(
+        candidate_counts,
+        function(count) min(index, count),
+        integer(1)
+      )
+      index_sets[[length(index_sets) + 1L]] <- aligned
+    }
+  }
+
+  keys <- vapply(index_sets, paste, character(1), collapse = ",")
+  index_sets[!duplicated(keys)]
+}
+
+expand_mipro_component_candidates <- function(
+  demo_candidates,
+  instruction_candidates
+) {
+  if (
+    length(instruction_candidates) != 1L ||
+      is.null(instruction_candidates[[1L]]$by_path)
+  ) {
+    cli::cli_abort(
+      "MIPRO component instruction candidates are malformed",
+      class = "dsprrr_mipro_component_mismatch"
+    )
+  }
+
+  by_path <- instruction_candidates[[1L]]$by_path
+  index_sets <- mipro_component_instruction_index_sets(by_path)
+  candidates <- list()
+  candidate_index <- 1L
+
+  for (demo in demo_candidates) {
+    for (indices in index_sets) {
+      selected <- Map(
+        function(path, index) by_path[[path]][[index]],
+        path = names(by_path),
+        index = unname(indices)
+      )
+      names(selected) <- names(by_path)
+      components <- lapply(selected, function(candidate) {
+        list(instructions = candidate$instructions)
+      })
+      instruction_ids <- vapply(selected, `[[`, character(1), "id")
+      aggregate_instruction_id <- paste(
+        paste(names(instruction_ids), instruction_ids, sep = "="),
+        collapse = "|"
+      )
+      demo_counts <- demo$params$demo_counts %||% list()
+
+      candidates[[candidate_index]] <- list(
+        id = sprintf("components_%03d", candidate_index),
+        demo_id = demo$id,
+        instruction_id = aggregate_instruction_id,
+        components = components,
+        params = list(
+          demo_id = demo$id,
+          instruction_ids = as.list(instruction_ids),
+          instructions = lapply(selected, `[[`, "instructions"),
+          n_demos = sum(unlist(demo_counts), na.rm = TRUE)
+        )
+      )
+      candidate_index <- candidate_index + 1L
     }
   }
 

--- a/R/teleprompter.R
+++ b/R/teleprompter.R
@@ -68,7 +68,9 @@ compile_default <- function(teleprompter, program, trainset, ...) {
 #' @description
 #' A simple teleprompter that adds labeled examples from the training set
 #' as demonstrations to the module. This is the simplest form of few-shot
-#' learning.
+#' learning. The target must be a root Predict module; programs with nested
+#' predictors (including RLM) are rejected because root examples do not define
+#' predictor-local demonstrations.
 #'
 #' @param metric A metric function for evaluating predictions. If NULL,
 #'   uses exact_match() by default.
@@ -137,7 +139,7 @@ LabeledFewShot <- S7::new_class(
 compile_labeled <- function(teleprompter, program, trainset, .llm = NULL, ...) {
   # Validate inputs
   if (!inherits(program, "Module")) {
-    cli::cli_abort("LabeledFewShot currently only supports Predict modules")
+    cli::cli_abort("LabeledFewShot requires a Module object")
   }
 
   if (!is.data.frame(trainset)) {
@@ -147,6 +149,24 @@ compile_labeled <- function(teleprompter, program, trainset, .llm = NULL, ...) {
   if (nrow(trainset) == 0) {
     cli::cli_warn("Empty trainset provided, returning unmodified program")
     return(program)
+  }
+
+  if (!inherits(program, "PredictModule")) {
+    cli::cli_abort(
+      c(
+        "LabeledFewShot cannot label nested predictors from root examples",
+        "x" = "The program is {.cls {class(program)[1]}}, not a Predict module.",
+        "i" = paste(
+          "Root examples can have a different signature from child predictors;",
+          "attaching them would create invalid demonstrations."
+        ),
+        "i" = paste(
+          "Use an optimizer with predictor-local evidence, or compile each",
+          "predictor with examples matching its own signature."
+        )
+      ),
+      class = "dsprrr_labeled_graph_unsupported"
+    )
   }
 
   # Create a copy of the program

--- a/R/utils.R
+++ b/R/utils.R
@@ -143,7 +143,13 @@ validate_signature_inputs <- function(
     return(invisible(NULL))
   }
 
-  required_names <- vapply(sig@inputs, function(x) x$name, character(1))
+  declared_names <- vapply(sig@inputs, function(x) x$name, character(1))
+  required <- vapply(
+    sig@inputs,
+    function(x) tryCatch(isTRUE(x$type@required), error = function(e) TRUE),
+    logical(1)
+  )
+  required_names <- declared_names[required]
   provided_names <- names(inputs) %||% character()
 
   missing_names <- setdiff(required_names, provided_names)
@@ -162,21 +168,21 @@ validate_signature_inputs <- function(
     }
   }
 
-  extra_names <- setdiff(provided_names, required_names)
+  extra_names <- setdiff(provided_names, declared_names)
   if (length(extra_names) > 0 && extra != "ignore") {
     for (field in extra_names) {
-      suggestion <- find_closest_match(field, required_names)
+      suggestion <- find_closest_match(field, declared_names)
       message <- if (!is.null(suggestion)) {
         c(
           "Unknown input: {.field {field}}",
           "i" = "Did you mean: {.field {suggestion}}?",
-          "i" = "Available fields: {.field {required_names}}"
+          "i" = "Available fields: {.field {declared_names}}"
         )
       } else {
         c(
           "Extra input not declared in the signature: {.field {field}}",
           "i" = "The field remains available to custom templates but is not declared in the signature.",
-          "i" = "Signature fields: {.field {required_names}}"
+          "i" = "Signature fields: {.field {declared_names}}"
         )
       }
       if (extra == "error") {

--- a/README.Rmd
+++ b/README.Rmd
@@ -174,7 +174,7 @@ result <- run(
 | `multichain` | Ensemble reasoning with multiple chains |
 | `program_of_thought` | Generate and execute R code |
 | `codeact` | Combine tools with R code execution |
-| `rlm` | Explore large context through an R REPL |
+| `rlm` | Adaptively investigate large or awkward R objects (experimental) |
 | `flex` | Let GEPA optimize how a module uses predictors, R logic, and selected tools (experimental) |
 
 ```{r module-types, eval=FALSE}
@@ -189,7 +189,70 @@ agent <- module(
 mod <- module(signature("question -> answer"), type = "chain_of_thought")
 ```
 
-### Optimize the program, not only the prompt
+## Find the cohort that regressed
+
+A release-level average tells you that checkout conversion fell. It does not
+tell you which cohort changed or which release note matters. When the useful
+grouping is not known in advance, an RLM can inspect the source object with R,
+show the model only bounded observations, and revise the investigation between
+steps.
+
+The deterministic tutorial uses 40,000 sessions and 200 change records. A
+successful run must recover this independently checkable result:
+
+```text
+release:      2.4.0
+cohort:       platform=mobile / plan=pro
+before_rate:  0.92
+after_rate:   0.61
+drop_pp:      31
+change_id:    CHG-1842
+```
+
+For that rich data-frame input, opt into a persistent trusted callr runner:
+
+```{r rlm-example, eval=FALSE}
+investigator <- rlm_module(
+  paste(
+    "sessions, changes, question ->",
+    "release: string, cohort: string, before_rate: number,",
+    "after_rate: number, drop_pp: number, change_id: string, evidence: string"
+  ),
+  interpreter_factory = function() {
+    r_code_runner(timeout = 30, persistent = TRUE)
+  },
+  max_iters = 8,
+  max_llm_calls = 0L
+)
+```
+
+This persistent `r_code_runner()` preserves rich R objects but is
+trusted-input-only, not a security sandbox. The one-call `rlm()` helper instead
+creates a fresh managed `mcp-repl` OS sandbox by default. It disables network
+access but permits writes inside the allowed workspace. Install the suggested R
+package `mcptools` and the external `mcp-repl` executable first (for example,
+`uv tool install posit-mcp-repl`). This path currently suits compact,
+JSON-compatible context: the final JSON-RPC request has a 7 KB wire bound, with
+gzip/base64 attempted when the raw request is too large, and RLM control frames
+have a 3,000-byte encoded bound.
+
+[Work through the release-regression investigation](https://jameshwade.github.io/dsprrr/articles/tutorial-rlm-dsprrr.html),
+then read [the RLM execution contract](https://jameshwade.github.io/dsprrr/articles/how-rlm-works.html).
+
+### Choose the right kind of code generation
+
+| If the task requires... | Use... |
+|---|---|
+| A calculation whose steps are already known | `program_of_thought()` |
+| A new exploration path for this input at inference time | `rlm_module()` |
+| A reusable implementation discovered from labeled examples | `flex()` with GEPA |
+
+RLM is not an optimizer. It adapts its investigation for each invocation.
+Its action and fallback instructions can still be compiled with a supported
+optimizer, but the exploration remains inference-time work. Flex searches
+during compilation for a program to reuse on later invocations.
+
+## Optimize the program, not only the prompt
 
 Most optimizers improve instructions inside a workflow you designed. `flex()`
 lets GEPA change the workflow itself: which predictors run, where deterministic
@@ -236,10 +299,12 @@ dsprrr uses ellmer for all LLM calls. The integration is straightforward:
 **How-to guides:**
 - [Compile & Optimize](https://jameshwade.github.io/dsprrr/articles/compilation-optimization.html)
 - [Build RAG Pipelines](https://jameshwade.github.io/dsprrr/articles/rag-workflows.html)
+- [Investigate a Release Regression with an RLM](https://jameshwade.github.io/dsprrr/articles/tutorial-rlm-dsprrr.html)
 
 **Concepts:**
 - [The DSPy Philosophy](https://jameshwade.github.io/dsprrr/articles/concepts-dspy-philosophy.html)
 - [How Optimization Works](https://jameshwade.github.io/dsprrr/articles/concepts-optimization-theory.html)
+- [How the RLM Works](https://jameshwade.github.io/dsprrr/articles/how-rlm-works.html)
 
 **Reference:**
 - [Quick Reference](https://jameshwade.github.io/dsprrr/articles/cheatsheet.html)

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ result <- run(
 | `multichain` | Ensemble reasoning with multiple chains |
 | `program_of_thought` | Generate and execute R code |
 | `codeact` | Combine tools with R code execution |
-| `rlm` | Explore large context through an R REPL |
+| `rlm` | Adaptively investigate large or awkward R objects (experimental) |
 | `flex` | Let GEPA optimize how a module uses predictors, R logic, and selected tools (experimental) |
 
 ``` r
@@ -249,7 +249,75 @@ agent <- module(
 mod <- module(signature("question -> answer"), type = "chain_of_thought")
 ```
 
-### Optimize the program, not only the prompt
+## Find the cohort that regressed
+
+A release-level average tells you that checkout conversion fell. It does
+not tell you which cohort changed or which release note matters. When
+the useful grouping is not known in advance, an RLM can inspect the
+source object with R, show the model only bounded observations, and
+revise the investigation between steps.
+
+The deterministic tutorial uses 40,000 sessions and 200 change records.
+A successful run must recover this independently checkable result:
+
+``` text
+release:      2.4.0
+cohort:       platform=mobile / plan=pro
+before_rate:  0.92
+after_rate:   0.61
+drop_pp:      31
+change_id:    CHG-1842
+```
+
+For that rich data-frame input, opt into a persistent trusted callr
+runner:
+
+``` r
+investigator <- rlm_module(
+  paste(
+    "sessions, changes, question ->",
+    "release: string, cohort: string, before_rate: number,",
+    "after_rate: number, drop_pp: number, change_id: string, evidence: string"
+  ),
+  interpreter_factory = function() {
+    r_code_runner(timeout = 30, persistent = TRUE)
+  },
+  max_iters = 8,
+  max_llm_calls = 0L
+)
+```
+
+This persistent `r_code_runner()` preserves rich R objects but is
+trusted-input-only, not a security sandbox. The one-call `rlm()` helper
+instead creates a fresh managed `mcp-repl` OS sandbox by default. It
+disables network access but permits writes inside the allowed workspace.
+Install the suggested R package `mcptools` and the external `mcp-repl`
+executable first (for example, `uv tool install posit-mcp-repl`). This
+path currently suits compact, JSON-compatible context: the final
+JSON-RPC request has a 7 KB wire bound, with gzip/base64 attempted when
+the raw request is too large, and RLM control frames have a 3,000-byte
+encoded bound.
+
+[Work through the release-regression
+investigation](https://jameshwade.github.io/dsprrr/articles/tutorial-rlm-dsprrr.html),
+then read [the RLM execution
+contract](https://jameshwade.github.io/dsprrr/articles/how-rlm-works.html).
+
+### Choose the right kind of code generation
+
+| If the task requires… | Use… |
+|----|----|
+| A calculation whose steps are already known | `program_of_thought()` |
+| A new exploration path for this input at inference time | `rlm_module()` |
+| A reusable implementation discovered from labeled examples | `flex()` with GEPA |
+
+RLM is not an optimizer. It adapts its investigation for each
+invocation. Its action and fallback instructions can still be compiled
+with a supported optimizer, but the exploration remains inference-time
+work. Flex searches during compilation for a program to reuse on later
+invocations.
+
+## Optimize the program, not only the prompt
 
 Most optimizers improve instructions inside a workflow you designed.
 `flex()` lets GEPA change the workflow itself: which predictors run,
@@ -305,12 +373,16 @@ Examples](https://jameshwade.github.io/dsprrr/articles/tutorial-improve-with-dem
 **How-to guides:** - [Compile &
 Optimize](https://jameshwade.github.io/dsprrr/articles/compilation-optimization.html) -
 [Build RAG
-Pipelines](https://jameshwade.github.io/dsprrr/articles/rag-workflows.html)
+Pipelines](https://jameshwade.github.io/dsprrr/articles/rag-workflows.html) -
+[Investigate a Release Regression with an
+RLM](https://jameshwade.github.io/dsprrr/articles/tutorial-rlm-dsprrr.html)
 
 **Concepts:** - [The DSPy
 Philosophy](https://jameshwade.github.io/dsprrr/articles/concepts-dspy-philosophy.html) -
 [How Optimization
-Works](https://jameshwade.github.io/dsprrr/articles/concepts-optimization-theory.html)
+Works](https://jameshwade.github.io/dsprrr/articles/concepts-optimization-theory.html) -
+[How the RLM
+Works](https://jameshwade.github.io/dsprrr/articles/how-rlm-works.html)
 
 **Reference:** - [Quick
 Reference](https://jameshwade.github.io/dsprrr/articles/cheatsheet.html) -

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -13,9 +13,8 @@ template:
 home:
   title: "dsprrr: Programming—not prompting—LLMs in R"
   description: >
-    dsprrr brings the power of DSPy to R. Instead of wrestling with prompt strings,
-    declare what you want, compose modules into pipelines, and optimize prompts,
-    examples, or even the program that executes them.
+    Declare typed LLM tasks in R, compose them into programs, optimize them with
+    data, or adaptively investigate large and awkward R objects.
 
 navbar:
   structure:
@@ -47,7 +46,7 @@ navbar:
           href: articles/text-adventure.html
         - text: "Generate Package Docs"
           href: articles/llms-txt.html
-        - text: "Explore Codebases with RLMs"
+        - text: "Investigate a Regression with RLM"
           href: articles/tutorial-rlm-dsprrr.html
     howto:
       text: How-to Guides

--- a/man/BootstrapFewShot.Rd
+++ b/man/BootstrapFewShot.Rd
@@ -66,6 +66,10 @@ demonstration for the corresponding step module. Intermediate steps
 therefore receive demos even though the training set only labels the
 final output. Labeled demos (\code{max_labeled_demos}) are applied to the
 final step only, and only when its input fields exist in the trainset.
+Programs containing Flex or an RLM, at the root or nested, are rejected.
+Flex constructs its inner predictors per invocation; RLM root examples do
+not match its children's \code{state -> ...} signatures. Use GEPA for these
+programs, or instruction-only MIPROv2 for an RLM graph.
 }
 }
 \examples{
@@ -78,6 +82,9 @@ tp <- BootstrapFewShot(
 )
 
 # Compile a module
+qa_module <- module(signature("question -> answer"))
+trainset <- data.frame(question = "Capital of France?", answer = "Paris")
+llm <- ellmer::chat_openai()
 compiled <- compile(tp, qa_module, trainset, .llm = llm)
 }
 }

--- a/man/BootstrapFewShotWithRandomSearch.Rd
+++ b/man/BootstrapFewShotWithRandomSearch.Rd
@@ -64,6 +64,10 @@ The optimizer generates candidates including:
 \item BootstrapFewShot with unshuffled examples
 \item BootstrapFewShot with various random seeds
 }
+
+Programs containing Flex or RLM modules are rejected before candidate
+evaluation because their predictor-local demonstration contracts are not
+currently available to this optimizer.
 }
 \examples{
 \dontrun{
@@ -76,6 +80,10 @@ tp <- BootstrapFewShotWithRandomSearch(
 )
 
 # Compile with validation set (required)
+qa_module <- module(signature("question -> answer"))
+trainset <- data.frame(question = "Capital of France?", answer = "Paris")
+valset <- data.frame(question = "Capital of Japan?", answer = "Tokyo")
+llm <- ellmer::chat_openai()
 compiled <- compile(tp, qa_module, trainset, valset = valset, .llm = llm)
 
 # Access ranked candidates

--- a/man/LabeledFewShot.Rd
+++ b/man/LabeledFewShot.Rd
@@ -32,7 +32,9 @@ Default is 5.}
 \description{
 A simple teleprompter that adds labeled examples from the training set
 as demonstrations to the module. This is the simplest form of few-shot
-learning.
+learning. The target must be a root Predict module; programs with nested
+predictors (including RLM) are rejected because root examples do not define
+predictor-local demonstrations.
 }
 \examples{
 # A teleprompter that adds 2 labeled training examples as demonstrations

--- a/man/MIPROv2.Rd
+++ b/man/MIPROv2.Rd
@@ -55,7 +55,11 @@ MIPROv2(
 }
 \description{
 MIPROv2 jointly optimizes instructions and few-shot demonstrations using
-a discrete Bayesian optimization loop with minibatch evaluation.
+a discrete Bayesian optimization loop with minibatch evaluation for a root
+Predict module. For graphs with nested predictors such as RLM, it optimizes
+child instructions only and requires \code{max_bootstrapped_demos = 0L}; nested
+demo bootstrapping fails explicitly until predictor-local evidence is
+available.
 }
 \examples{
 
@@ -66,6 +70,10 @@ tp <- MIPROv2(
   max_bootstrapped_demos = 4L
 )
 
+qa_module <- module(signature("question -> answer"))
+trainset <- data.frame(question = "Capital of France?", answer = "Paris")
+valset <- data.frame(question = "Capital of Japan?", answer = "Tokyo")
+llm <- ellmer::chat_openai()
 compiled <- compile(tp, qa_module, trainset, valset = valset, .llm = llm)
 }
 }

--- a/man/mcp_repl_runner.Rd
+++ b/man/mcp_repl_runner.Rd
@@ -50,7 +50,7 @@ Creates a dsprrr code runner backed by Posit's
 operating-system primitives. This makes it suitable for code proposed by an
 optimizer or language model.
 
-For authenticated RLM submit/query traffic, dsprrr caps each encoded control
+For nonce-bound RLM submit/query traffic, dsprrr caps each encoded control
 frame at 3,000 bytes so it stays below mcp-repl's inline-output threshold.
 If mcp-repl nevertheless returns a file-preview or active-pager marker (for
 example because user code printed a large value first), the runner fails the
@@ -77,10 +77,11 @@ By default, \code{mcp_repl_runner()} starts \code{mcp-repl} through
 \item oversized output written to sandbox-visible files.
 }
 
-The sandbox is deliberately on by default. Setting \code{sandbox = "off"} is
-rejected because this runner advertises itself as safe for untrusted code.
-Use \code{\link[=r_code_runner]{r_code_runner()}} explicitly for trusted-input-only subprocess
-isolation.
+The sandbox is deliberately on by default. It disables network access but
+the \code{workspace-write} policy still permits mutation inside allowed workspace
+paths. Setting \code{sandbox = "off"} is rejected because this runner advertises
+an enforced sandbox. Use \code{\link[=r_code_runner]{r_code_runner()}} explicitly for trusted-input-only
+subprocess isolation.
 
 Supplying \code{repl} is useful for an externally managed MCP connection and for
 deterministic tests. It must be a function with the mcp-repl tool contract:
@@ -99,5 +100,6 @@ ownership cannot be captured. This path is tested against mcptools 1.0.1.
 runner <- mcp_repl_runner()
 runner$execute("mean(1:10)")
 runner$reset()
+runner$close()
 }
 }

--- a/man/module-rlm.Rd
+++ b/man/module-rlm.Rd
@@ -4,79 +4,69 @@
 \alias{module-rlm}
 \title{Recursive Language Model (RLM) Module}
 \description{
-A module that transforms context from "input" to "environment", enabling LLMs
-to programmatically explore large contexts through a REPL interface rather
-than embedding them in prompts.
+An experimental inference-time analyst for inputs whose useful evidence is
+too large, irregular, or unpredictable to place in one prompt. RLM keeps the
+inputs in an R environment and lets the model iteratively inspect summaries,
+run computations, and decide what to examine next.
 }
 \details{
-Instead of \code{llm(prompt, context=huge_document)}, RLM stores context as R
-variables that the LLM can peek, slice, search, and recursively query.
+Each input is available under \code{.context}. Generated R code can use ordinary R
+plus \code{peek()}, \code{search()}, value-returning \code{llm_query()} calls, declared host
+tools, and \code{SUBMIT(...)}. RLM requires a runner whose \code{policy()} advertises
+\code{persistent = TRUE}; variables therefore remain available across turns within
+one invocation. Invalid submitted fields or types become iteration errors
+that the model can repair. If no valid submission is produced, the separate
+\code{extract} predictor performs one typed fallback.
+RLM validates explicit ellmer string, number, integer, boolean, enum, array,
+and object outputs. Opaque \code{TypeJsonSchema} nodes are rejected at
+construction because they cannot participate in this strict repair loop.
 
-The execution flow is:
-\enumerate{
-\item Context is made available as variables in an R execution environment
-\item LLM generates R code to explore and analyze the context
-\item Code is executed by the configured code runner
-\item Results are fed back to the LLM for the next iteration
-\item Process continues until SUBMIT() is called or max_iterations reached
-\item If max_iterations reached without SUBMIT(), fallback extraction is used
-}
+The \code{generate_action} and \code{extract} predictors are graph-visible through
+\code{\link[=named_modules]{named_modules()}}. GEPA can tune them; nested MIPROv2 is instruction-only
+with bootstrapped demos disabled. BootstrapFewShot and LabeledFewShot reject
+programs containing an RLM until predictor-local demonstrations are
+available.
+Model-visible execution evidence defaults to a 10,000-character head-and-tail view
+after any runner-level transport limit; that formatted evidence is retained
+in the returned trajectory. Trace state retains hashes and sizes for input
+objects, not their full values.
+Structured metadata separates logical action, recursive, and extraction
+counts from verified provider calls. A child-predictor cache hit contributes
+zero provider calls and zero current-run usage; totals remain \code{NA} whenever
+every contributing provider turn cannot be verified.
 
-Available REPL tools:
-\itemize{
-\item \code{SUBMIT(...)}: Terminate and return final output values
-\item \code{peek(var, start, end)}: View a slice of a variable (default: first 1000 chars)
-\item \code{search(var, pattern)}: Regex search in variable
-\item \code{llm_query(query, context_slice)}: Recursive LLM call (requires sub_lm)
-\item \code{llm_query_batched(queries, slices)}: Batched recursive calls
-}
+For generated code, prefer a fresh sandboxed \code{\link[=mcp_repl_runner]{mcp_repl_runner()}} factory.
+Its managed transport is intentionally bounded and is best for compact,
+JSON-compatible context. Its default policy disables network access but
+allows writes within the configured workspace. Declared host tools execute
+in the dsprrr host process, outside that guest sandbox. This backend requires
+the suggested \code{mcptools} package and Posit's external \code{mcp-repl} executable.
+For large data frames or richer local R objects,
+\code{r_code_runner(persistent = TRUE)} can stage context once, but it is
+trusted-input-only: the child process retains the host user's file, network,
+and environment permissions.
 
-Security: Code execution requires explicit opt-in via \code{runner} or
-\code{interpreter_factory}.
-The built-in runner uses a separate process but is NOT a security sandbox.
-Inspect \code{runner$policy()} before execution. For untrusted inputs, provide a
-runner backed by OS-level sandboxing, such as \code{\link[=mcp_repl_runner]{mcp_repl_runner()}}.
-Authenticated RLM control frames sent through mcp-repl are limited to 3,000
-encoded bytes. If aggregate output is compacted into a file preview or pager,
-the iteration fails closed because mcp-repl does not expose structured
-compaction metadata; dsprrr does not read a sandbox-disclosed path from the
-host process.
-
-Runner lifecycle: supply exactly one runtime source. \code{runner} is
-caller-owned, reused across calls, and never closed by dsprrr. The backend determines
-whether execution state persists and whether \code{reset()} is available;
-serialize access to stateful backends. \code{interpreter_factory} is a
-zero-argument function that returns a fresh runner implementing \code{execute()},
-\code{policy()}, optional \code{start()}, and terminal \code{shutdown()} or \code{close()}. The
-module owns that runner for one invocation and shuts it down exactly once on
-success, error, or interrupt.
-
-\code{\link[=run_async]{run_async()}} supports factory-backed RLM in an isolated mirai process and
-rejects caller-owned runners. \code{\link[=stream_async]{stream_async()}} and a module's \verb{$stream()}
-method remain unavailable because streaming would bypass execution. The
-\code{\link[=run_stream]{run_stream()}} one-shot \code{forward()} fallback remains available.
+Supply exactly one runtime source. A caller-owned \code{runner} is reused and
+never closed by dsprrr. An \code{interpreter_factory} creates one invocation-owned
+runner which dsprrr shuts down on success, error, or interrupt. Factory-backed
+RLM supports \code{\link[=run_async]{run_async()}} and isolated \code{\link[=run_dataset]{run_dataset()}} execution; token
+streaming is unavailable. A direct \code{\link[=run]{run()}} call always stages each supplied
+value as one REPL variable, regardless of its R length. Use \code{\link[=run_dataset]{run_dataset()}}
+for multiple invocations, with list-columns for data frames, vectors, lists,
+matrices, or other rich per-row values.
 }
 \examples{
 \dontrun{
-# Create a runner (required for code execution)
-runner <- r_code_runner(timeout = 30)
-
-# Create an RLM module for exploring large documents
-rlm <- rlm_module(
+analyst <- rlm_module(
   signature = "document, question -> answer",
-  runner = runner
+  interpreter_factory = function() mcp_repl_runner(timeout = 30)
 )
-
-# Use it for context exploration
-long_doc <- paste(readLines("large_file.txt"), collapse = "\n")
-result <- run(rlm, document = long_doc, question = "What are the main themes?", .llm = llm)
-
-# Enable recursive LLM calls for complex reasoning
-rlm_recursive <- rlm_module(
-  signature = "document -> summary",
-  runner = runner,
-  sub_lm = ellmer::chat_openai(model = "gpt-4o-mini"),
-  max_llm_calls = 10
+compact_doc <- "Section 1: ...\nSection 2: ..."
+result <- run(
+  analyst,
+  document = compact_doc,
+  question = "What evidence supports the conclusion?",
+  .llm = ellmer::chat_openai()
 )
 }
 

--- a/man/module.Rd
+++ b/man/module.Rd
@@ -46,7 +46,7 @@ module(
 \item{tools}{Optional tools configuration:
 \itemize{
 \item for \code{type = "react"} or \code{type = "codeact"}: list of ellmer ToolDef objects.
-\item for \code{type = "rlm"}: named list of R functions exposed to the REPL.
+\item for \code{type = "rlm"}: named host functions or ellmer ToolDef objects.
 \item for executable \code{type = "flex"}: named host functions or ToolDef objects.
 If provided with \code{type = "predict"}, automatically upgrades to react.
 }}
@@ -60,7 +60,9 @@ caps tool calls within one invocation; exceeding that inner budget errors.}
 \item{temperature}{Temperature for multichain diversity (default: 0.7)}
 
 \item{runner}{Optional caller-owned code runner implementing \code{execute()} and
-\code{policy()} for code execution types. It is never automatically closed.}
+\code{policy()} for code execution types. It is never automatically closed.
+For \code{type = "rlm"}, the policy must advertise \code{persistent = TRUE}; use
+\code{r_code_runner(persistent = TRUE)} for the trusted callr backend.}
 
 \item{max_iters}{Maximum code repair iterations for program_of_thought
 (default: 3), or the DSPy 3.3-compatible alias for RLM's
@@ -85,7 +87,8 @@ module will use this Chat for all predictions unless overridden with \code{.llm}
 program-of-thought, CodeAct, RLM, and executable Flex modules. It creates
 one fresh runner per invocation. Supply exactly one of \code{runner} and
 \code{interpreter_factory} for ordinary code-executing types; Flex accepts only
-the factory so every invocation is isolated.}
+the factory so every invocation is isolated. For RLM, every returned
+runner must advertise \code{persistent = TRUE}.}
 
 \item{module_src}{Optional complete source for \code{type = "flex"}.}
 
@@ -108,7 +111,8 @@ The primary function for creating executable LLM modules. Supports
 "predict" for standard structured prediction, "react" for ReAct-style
 tool-using modules, "chain_of_thought" for step-by-step reasoning,
 "multichain" for multi-chain comparison, "program_of_thought" for code
-execution modules, and experimental "flex" for declarative or
+execution, "codeact" for tools plus code, "rlm" for adaptive R-object
+investigation, and experimental "flex" for declarative or
 interpreter-backed programs.
 }
 \examples{
@@ -139,16 +143,21 @@ result <- classifier |> run(text = "Great package!", .llm = llm)
 
 # Or create module with Chat attached
 classifier <- signature("text -> sentiment") |>
-  module(type = "predict", chat = chat_openai())
+  module(type = "predict", chat = ellmer::chat_openai())
 result <- classifier |> run(text = "Great package!")  # No .llm needed
 
 # Create a ReAct module with tools
+search_fn <- function(query) paste("Result for", query)
 search_tool <- ellmer::tool(
   search_fn,
   description = "Search for information",
   arguments = list(query = ellmer::type_string())
 )
 agent <- signature("question -> answer") |>
-  module(type = "react", tools = list(search_tool), chat = chat_openai())
+  module(
+    type = "react",
+    tools = list(search_tool),
+    chat = ellmer::chat_openai()
+  )
 }
 }

--- a/man/program-artifact.Rd
+++ b/man/program-artifact.Rd
@@ -49,11 +49,15 @@ Callables and runtime objects are never captured implicitly. Supply a named
 \code{registry} to store stable IDs, or set \code{trusted = TRUE} to embed them. Embedded
 values are restored only when \code{trusted = TRUE} is also supplied while loading.
 Registry IDs are the recommended contract for tools, custom functions,
-retrievers, stores, code runners, and interpreter factories. Format version 4
-records exactly one runner or factory for each code-executing module without
-invoking a factory during write or restore. Valid version 3 runner-only
-manifests are checked against their original schema and integrity digest,
-then upgraded in memory; other historical versions are rejected.
+retrievers, stores, code runners, and interpreter factories. Format version 5
+adds graph-visible RLM action and extraction predictors. Version 4 records
+exactly one runner or factory for each code-executing module. Valid version 3
+runner-only and version 4 manifests are checked against their original schema
+and integrity digest. Non-RLM manifests are upgraded in memory. A legacy
+childless RLM is restored under its original schema with fresh default child
+predictors and becomes a complete version 5 graph when it is next saved.
+Other historical versions are rejected. Factories are never invoked during
+write or restore.
 
 Declarative ellmer text, JSON, inline/remote image, and PDF content is stored
 through a closed codec. Remote content URLs must be stable HTTPS URLs without

--- a/man/r_code_runner.Rd
+++ b/man/r_code_runner.Rd
@@ -8,7 +8,8 @@ r_code_runner(
   timeout = 30,
   max_output_chars = 100000L,
   allowed_packages = c("base", "stats", "utils", "methods"),
-  prelude = character()
+  prelude = character(),
+  persistent = FALSE
 )
 }
 \arguments{
@@ -24,6 +25,11 @@ Default: c("base", "stats", "utils", "methods").}
 
 \item{prelude}{Character vector. R code to run before user code.
 Useful for setting options or loading common utilities.}
+
+\item{persistent}{Logical. Whether to reuse one callr session and execution
+environment across calls to \code{execute()}. This preserves variables and
+supports staging a base context with \code{prepare_context()}. Default \code{FALSE}
+preserves one fresh subprocess per execution.}
 }
 \value{
 An RCodeRunner R6 object

--- a/man/rlm-tools.Rd
+++ b/man/rlm-tools.Rd
@@ -13,13 +13,16 @@ The prelude defines these functions in the execution environment:
 \item \code{SUBMIT(...)}: Terminate and return final output values
 \item \code{peek(var, start, end)}: View a slice of a variable
 \item \code{search(var, pattern)}: Regex search in variable
-\item \code{llm_query(query, context_slice)}: Request a recursive LLM call (returns marker for interception)
-\item \code{llm_query_batched(queries, slices)}: Request batched LLM calls (returns marker for interception)
+\item \code{llm_query(query, context_slice)}: Request a recursive LLM call
+\item \code{llm_query_batched(queries, slices)}: Request batched LLM calls
 \item \code{rlm_query()} / \code{rlm_query_batch()}: Backward-compatible aliases
 }
 
-The recursive-query helper functions return special marker objects
-that the main RLM process intercepts and handles. The actual LLM calls happen
-in the parent R process, not in the sandboxed code execution environment.
+Recursive-query helpers suspend execution with a nonce-bound, schema-checked
+request. The main RLM process handles the request and replays the code with
+an immutable response, so the helpers behave like ordinary value-returning R
+functions.
+The actual LLM calls happen in the parent R process, not in the sandboxed code
+execution environment.
 }
 \keyword{internal}

--- a/man/rlm.Rd
+++ b/man/rlm.Rd
@@ -11,23 +11,30 @@ rlm(
   .timeout = 30,
   .max_iterations = 20L,
   .max_llm_calls = 50L,
+  .max_output_chars = 10000L,
   .sub_lm = NULL,
   .tools = list(),
-  .verbose = FALSE
+  .verbose = FALSE,
+  .runner = NULL,
+  .interpreter_factory = NULL
 )
 }
 \arguments{
 \item{signature}{A Signature object or string notation defining inputs/outputs
 (e.g., \code{"question -> answer"})}
 
-\item{...}{Named arguments matching the signature's inputs. These are passed
-to \code{\link[=run]{run()}}.}
+\item{...}{Named signature inputs and \code{\link[=run]{run()}} controls such as
+\code{.return_format}. Every supplied input is one scalar REPL variable,
+including vectors, lists, matrices, and data frames. To run multiple
+investigations, create an \code{\link[=rlm_module]{rlm_module()}} and call \code{\link[=run_dataset]{run_dataset()}}; store
+rich per-row values in list-columns.}
 
 \item{.llm}{An ellmer Chat object. If \code{NULL}, uses the default Chat from
 \code{\link[=get_default_chat]{get_default_chat()}}.}
 
 \item{.timeout}{Numeric. Maximum execution time in seconds per code
-evaluation. Default 30.}
+evaluation for the implicit managed MCP runner. Explicit runners and
+factories own their timeout settings. Default 30.}
 
 \item{.max_iterations}{Integer. Maximum REPL iterations before fallback.
 Default 20.}
@@ -35,54 +42,63 @@ Default 20.}
 \item{.max_llm_calls}{Integer. Maximum recursive LLM calls allowed.
 Default 50.}
 
-\item{.sub_lm}{Optional ellmer Chat for recursive \code{llm_query()} calls.
-\code{NULL} disables recursive queries.}
+\item{.max_output_chars}{Maximum model-visible characters per execution
+output. Default 10000.}
 
-\item{.tools}{Named list of user-defined R functions available in the REPL.}
+\item{.sub_lm}{Optional ellmer Chat for recursive \code{llm_query()} calls.
+\code{NULL} inherits \code{.llm}; use \code{.max_llm_calls = 0} to disable recursion.}
+
+\item{.tools}{Named list of user-defined R functions or ellmer ToolDef
+objects available in the REPL. They execute in the dsprrr host process,
+outside the guest runner sandbox.}
 
 \item{.verbose}{Logical. Print execution progress. Default \code{FALSE}.}
+
+\item{.runner}{Optional caller-owned runner. Supply at most one of this and
+\code{.interpreter_factory}. Its policy must advertise \code{persistent = TRUE}.}
+
+\item{.interpreter_factory}{Optional zero-argument factory for a fresh,
+invocation-owned runner. When both execution arguments are \code{NULL}, a
+managed \code{mcp_repl_runner()} factory is used. Custom factories must return
+a runner whose policy advertises \code{persistent = TRUE}.}
 }
 \value{
-The module output according to the signature.
+With \code{.return_format = "simple"} (the default), the output record
+according to the signature. With \code{.return_format = "structured"}, a
+\code{dsprrr_result} containing \code{output}, \code{chat}, and \code{metadata}.
 }
 \description{
-Convenience wrapper that creates a runner, module, and executes an RLM
-in a single call. Equivalent to:
-
-\if{html}{\out{<div class="sourceCode r">}}\preformatted{runner <- r_code_runner(timeout = .timeout)
-mod <- rlm_module(
-  signature,
-  runner = runner,
-  max_iterations = .max_iterations,
-  max_llm_calls = .max_llm_calls,
-  sub_lm = .sub_lm,
-  verbose = .verbose,
-  tools = .tools
-)
-run(mod, ..., .llm = .llm)
-}\if{html}{\out{</div>}}
-
-For repeated use or optimization, prefer creating a module with
-\code{\link[=rlm_module]{rlm_module()}} and calling \code{\link[=run]{run()}} separately.
+Run a one-off RLM investigation. By default this creates a fresh managed
+\code{\link[=mcp_repl_runner]{mcp_repl_runner()}} for the invocation. Its default OS sandbox disables
+network access but permits writes inside the allowed workspace. Pass
+\code{.runner} or \code{.interpreter_factory} to select another execution backend. For
+repeated use, optimization, or explicit lifecycle control, create an
+\code{\link[=rlm_module]{rlm_module()}} instead. The managed default requires the suggested
+\code{mcptools} package and Posit's external \code{mcp-repl} executable; see
+\code{\link[=mcp_repl_runner]{mcp_repl_runner()}} for setup and transport limits.
 }
 \examples{
 \dontrun{
-# One-liner RLM call
 result <- rlm(
   "document, question -> answer",
-  document = readLines("big_file.txt") |> paste(collapse = "\n"),
+  document = "Owner: team-a\nObligation: rotate keys quarterly",
   question = "What are the main themes?",
-  .llm = ellmer::chat_openai()
+  .llm = ellmer::chat_openai(),
+  .max_iterations = 4L,
+  .max_llm_calls = 0L
 )
 
-# With recursive sub-queries
-result <- rlm(
-  "codebase, question -> answer",
-  codebase = source_code,
-  question = "How does auth work?",
-  .llm = ellmer::chat_openai(),
-  .sub_lm = ellmer::chat_openai(model = "gpt-4o-mini")
+# Large or rich local R objects require explicit trusted execution.
+sessions <- data.frame(
+  release = c("2.3.9", "2.4.0"),
+  converted = c(TRUE, FALSE)
 )
+local_runner <- r_code_runner(persistent = TRUE)
+result <- rlm("sessions, question -> answer", sessions = sessions,
+  question = "Where did conversion fall?",
+  .llm = ellmer::chat_openai(),
+  .runner = local_runner)
+local_runner$close()
 }
 
 }
@@ -90,6 +106,7 @@ result <- rlm(
 \itemize{
 \item \code{\link[=rlm_module]{rlm_module()}} for creating reusable RLM modules
 \item \code{\link[=r_code_runner]{r_code_runner()}} for configuring the code execution backend
+\item \code{\link[=mcp_repl_runner]{mcp_repl_runner()}} for managed sandboxed execution
 \item \code{\link[=run]{run()}} for executing modules
 \item \code{\link[=dsp]{dsp()}} for simple one-shot LLM calls (no code execution)
 }

--- a/man/rlm_module.Rd
+++ b/man/rlm_module.Rd
@@ -9,7 +9,7 @@ rlm_module(
   runner = NULL,
   max_iterations = 20L,
   max_llm_calls = 50L,
-  max_output_chars = 100000L,
+  max_output_chars = 10000L,
   sub_lm = NULL,
   verbose = FALSE,
   tools = list(),
@@ -19,26 +19,38 @@ rlm_module(
 )
 }
 \arguments{
-\item{signature}{A Signature object or string notation defining inputs/outputs}
+\item{signature}{A Signature object or string notation defining inputs/outputs
+with explicit ellmer string, number, integer, boolean, enum, array, or
+object output types. Opaque \code{TypeJsonSchema} outputs are unsupported.}
 
 \item{runner}{Optional caller-owned code runner implementing \code{execute()} and
-\code{policy()}. It is retained, never automatically closed, and must not be
-shared concurrently when persistent.}
+\code{policy()}. Its policy must declare \code{persistent = TRUE}. It is retained,
+never automatically closed, and must not be shared concurrently. For the
+trusted callr backend, use \code{r_code_runner(persistent = TRUE)}.}
 
 \item{max_iterations}{Maximum REPL iterations before fallback (default 20)}
 
 \item{max_llm_calls}{Maximum recursive LLM calls allowed (default 50)}
 
-\item{max_output_chars}{Maximum characters per execution output (default 100000)}
+\item{max_output_chars}{Maximum model-visible characters per execution output.
+Longer output is shown as a head-and-tail excerpt. Default 10000.}
 
-\item{sub_lm}{Optional ellmer Chat for recursive queries. NULL = disabled.}
+\item{sub_lm}{Optional ellmer Chat for recursive queries. \code{NULL} inherits the
+invocation's outer Chat. Set \code{max_llm_calls = 0} to disable recursion.}
 
 \item{verbose}{Logical. Print execution progress (default FALSE)}
 
-\item{tools}{Named list of user-defined host functions. Guest code emits an
-authenticated request, dsprrr invokes the original function in the host,
+\item{tools}{Named list of user-defined host functions or ellmer ToolDef
+objects. Guest code emits an
+invocation-bound request, dsprrr validates it and invokes the original
+function in the host,
 and the guest is replayed with the response. Closures are never deparsed or
-serialized into generated code.}
+serialized into generated code. These tools execute in the host process,
+outside the guest runner sandbox, with the host's permissions. ToolDef
+schemas guide generation; the callable must still enforce semantic
+constraints beyond the bridge's lossless JSON-compatible value checks.
+A protocol safety ceiling permits at most 1,000 host-tool calls in one
+generated R step.}
 
 \item{max_iters}{DSPy 3.3-compatible alias for \code{max_iterations}. Supply only
 one of these arguments.}
@@ -47,24 +59,30 @@ one of these arguments.}
 
 \item{interpreter_factory}{Optional zero-argument function returning a fresh
 runner with \code{execute()}, \code{policy()}, optional \code{start()}, and idempotent
-terminal \code{shutdown()} or \code{close()}.
+terminal \code{shutdown()} or \code{close()}. Its policy must advertise
+\code{persistent = TRUE} for RLM.
 Supply exactly one of \code{runner} and \code{interpreter_factory}.}
 }
 \value{
 An RLMModule object
 }
 \description{
-Factory function to create an RLMModule that enables LLMs to programmatically
-explore large contexts through a REPL interface.
-Use \code{\link[=run]{run()}} to execute it. \code{\link[=run_async]{run_async()}} supports factory-backed modules;
-async streaming and module \verb{$stream()} reject RLM. \code{\link[=run_stream]{run_stream()}} preserves
-the synchronous \code{forward()} fallback unless a matching token-stream request
-is active; that request is rejected first.
+Create an RLM whose implementation can adaptively explore R objects at
+inference time. Use RLM when the inspection path is not known in advance;
+use ordinary R when that path becomes stable, or Flex when labeled examples
+should discover a reusable implementation.
 }
 \examples{
 \dontrun{
-runner <- r_code_runner(timeout = 30)
-rlm <- rlm_module("question -> answer", runner = runner)
-result <- run(rlm, question = "What is the 10th Fibonacci number?", .llm = llm)
+analyst <- rlm_module(
+  "document, question -> answer",
+  interpreter_factory = function() mcp_repl_runner(timeout = 30)
+)
+result <- run(
+  analyst,
+  document = "Owner: team-a\nObligation: rotate keys quarterly",
+  question = "Which obligations have no owner?",
+  .llm = ellmer::chat_openai()
+)
 }
 }

--- a/man/run.Rd
+++ b/man/run.Rd
@@ -10,7 +10,9 @@ run(module, ...)
 \item{module}{A DSPrrr module (e.g., created with \code{module()})}
 
 \item{...}{Named arguments corresponding to the module's signature inputs.
-Can be single values or vectors for batch processing. Additional parameters:
+Can be single values or vectors for batch processing. RLM is the exception:
+every supplied value is one context variable regardless of its R length;
+use \code{\link[=run_dataset]{run_dataset()}} for multiple RLM invocations. Additional parameters:
 \describe{
 \item{.llm}{An ellmer chat object for LLM interaction (optional)}
 \item{.verbose}{Logical indicating whether to print debug information}
@@ -62,6 +64,11 @@ Zero-length inputs form an empty batch only when every input is zero length.
 Empty batches return immediately without resolving a Chat or touching cache,
 trace, or prompt-history state. Mixing zero-length and non-empty inputs is an
 error.
+
+RLM inputs use scalar object semantics: vectors, lists, matrices, data frames,
+and fitted models each remain one \code{.context} variable for one investigation.
+Use \code{\link[=run_dataset]{run_dataset()}} for multiple RLM invocations and list-columns for rich
+per-row objects.
 
 Scalar and batch Predict calls record one trace per attempted row. Structured
 metadata reports usage, error, cache, backend, and batch-index fields. Native

--- a/pkgdown/index.md
+++ b/pkgdown/index.md
@@ -11,7 +11,7 @@ that executes them.
 # Install
 pak::pak("JamesHWade/dsprrr")
 
-# That's it. Start using LLMs.
+# Configure credentials for an ellmer-supported provider, then:
 library(dsprrr)
 dsp("question -> answer", question = "What is the capital of France?")
 #> "Paris"
@@ -83,7 +83,8 @@ classify <- module(sig, type = "react", tools = list(lookup_tool))
 
 ### Optimizers
 
-**Compile your program against a metric.** Give dsprrr examples and a scoring function; it tunes prompts and demos automatically until quality converges.
+**Compile your program against a metric.** Give dsprrr examples and a scoring
+function; it selects the best candidate observed within the configured budget.
 
 [Try optimizers &rarr;](articles/compilation-optimization.html)
 
@@ -107,6 +108,65 @@ pin_module_config(board, "ticket-router-v2", optimized)
 
 </div>
 </div>
+
+## Find the release cohort that broke
+
+A release-level average can reveal a regression without explaining it. If the
+useful grouping and calculation are not known in advance, an RLM keeps the
+source object in an R environment, lets the model inspect it with R code, and
+returns only bounded observations between steps.
+
+The deterministic tutorial asks an RLM to explore 40,000 checkout sessions and
+200 change records. The answer is fixed and independently validated:
+
+```text
+release:      2.4.0
+cohort:       platform=mobile / plan=pro
+before_rate:  0.92
+after_rate:   0.61
+drop_pp:      31
+change_id:    CHG-1842
+```
+
+```r
+investigator <- rlm_module(
+  paste(
+    "sessions, changes, question ->",
+    "release: string, cohort: string, before_rate: number,",
+    "after_rate: number, drop_pp: number, change_id: string, evidence: string"
+  ),
+  interpreter_factory = function() {
+    r_code_runner(timeout = 30, persistent = TRUE)
+  },
+  max_iters = 8,
+  max_llm_calls = 0L
+)
+```
+
+This persistent callr runner stages rich R objects once, but it is explicitly
+trusted-input-only. For compact JSON-compatible context, the one-call `rlm()`
+helper creates a fresh managed `mcp-repl` OS sandbox by default. It disables
+network access but allows writes inside the workspace. Install `mcptools` and
+the external `mcp-repl` executable first. The final JSON-RPC request has a 7 KB
+wire bound, with gzip/base64 attempted when the raw request is too large, and
+RLM control frames have a 3,000-byte encoded bound.
+
+[Investigate the deterministic regression &rarr;](articles/tutorial-rlm-dsprrr.html)
+&nbsp;&middot;&nbsp;
+[Understand the RLM execution contract &rarr;](articles/how-rlm-works.html)
+
+### ProgramOfThought, RLM, or Flex?
+
+| If the task requires... | Use... |
+|---|---|
+| A calculation whose steps are already known | `program_of_thought()` |
+| A new exploration path for this input at inference time | `rlm_module()` |
+| A reusable implementation discovered from labeled examples | `flex()` with GEPA |
+
+RLM is experimental inference-time exploration; one invocation does not learn
+an exploration program. Supported optimizers can still tune its action and
+fallback instructions. Flex searches during compilation for an implementation
+to reuse.
 
 ## Optimize the program, not only the prompt
 
@@ -524,14 +584,14 @@ solver <- as_vitals_solver(classifier)
 <div class="card h-100 border-start border-primary border-4">
 <div class="card-body">
 <h5 class="card-title">Observable</h5>
-<p class="card-text">Every LLM call is traced. Inspect prompts, debug failures, track costs.</p>
+<p class="card-text">Inspect bounded module traces, debug failures, and track usage when providers report it.</p>
 </div>
 </div>
 </div>
 <div class="col">
 <div class="card h-100 border-start border-primary border-4">
 <div class="card-body">
-<h5 class="card-title">Production-Ready</h5>
+<h5 class="card-title">Deployment building blocks</h5>
 <p class="card-text">Persistence with pins, orchestration with targets, deployment with vetiver.</p>
 </div>
 </div>
@@ -544,6 +604,7 @@ solver <- as_vitals_solver(classifier)
 
 - [Getting Started](articles/getting-started.html) — Your first dsprrr module
 - [Compilation & Optimization](articles/compilation-optimization.html) — Improve with data
+- [Release Regression with an RLM](articles/tutorial-rlm-dsprrr.html) — Investigate a large R object adaptively
 - [Agentic Optimization Harnesses](articles/agentic-optimization-harnesses.html) — Run sandboxed AutoResearch and Meta-Harness loops
 - [Vitals Integration](articles/vitals-integration.html) — Advanced evaluation
 - [Production Orchestration](articles/orchestration.html) — Deploy to production
@@ -551,6 +612,7 @@ solver <- as_vitals_solver(classifier)
 ### Reference
 
 - [Function Reference](reference/index.html) — All functions documented
+- [How the RLM Works](articles/how-rlm-works.html) — Execution, replay, typed submission, and runner boundaries
 
 ## Ecosystem
 

--- a/tests/testthat/_snaps/artifact.md
+++ b/tests/testthat/_snaps/artifact.md
@@ -80,7 +80,7 @@
     Condition
       Error in `artifact_validate_manifest()`:
       ! Unsupported dsprrr program artifact version
-      x Got version 999; this package supports versions 3 and 4.
+      x Got version 999; this package supports versions 3, 4, and 5.
 
 ---
 

--- a/tests/testthat/helper-rlm-optimizer.R
+++ b/tests/testthat/helper-rlm-optimizer.R
@@ -1,0 +1,105 @@
+rlm_optimizer_type_fields <- function(type) {
+  if (
+    inherits(type, "ellmer::TypeObject") &&
+      methods::.hasSlot(type, "properties")
+  ) {
+    return(names(type@properties))
+  }
+  character()
+}
+
+make_rlm_optimizer_chat <- function() {
+  state <- new.env(parent = emptyenv())
+  state$action_tuned <- FALSE
+  state$action_prompts <- character()
+  state$extract_prompts <- character()
+  state$reflection_prompts <- character()
+
+  new_chat <- NULL
+  new_chat <- function() {
+    chat <- list(
+      clone = function(...) new_chat(),
+      set_turns = function(turns) invisible(NULL),
+      get_turns = function() list(),
+      get_model = function() "rlm-optimizer-test",
+      chat_structured = function(prompt, type, ...) {
+        fields <- rlm_optimizer_type_fields(type)
+
+        if (identical(fields, "instructions")) {
+          state$reflection_prompts <- c(state$reflection_prompts, prompt)
+          if (
+            grepl("Choose the next useful R operation", prompt, fixed = TRUE) ||
+              grepl("ACTION-TUNED", prompt, fixed = TRUE)
+          ) {
+            return(list(instructions = "ACTION-TUNED"))
+          }
+          return(list(instructions = "EXTRACT-TUNED"))
+        }
+
+        if (setequal(fields, c("reasoning", "code"))) {
+          state$action_prompts <- c(state$action_prompts, prompt)
+          state$action_tuned <- grepl("ACTION-TUNED", prompt, fixed = TRUE) ||
+            grepl("ACTION-HARNESS", prompt, fixed = TRUE)
+          return(list(
+            reasoning = "Inspect a bounded piece of evidence.",
+            code = paste0(
+              "paste0('TRACE_HEAD_', strrep('x', 500L), ",
+              "'_TRACE_TAIL')"
+            )
+          ))
+        }
+
+        state$extract_prompts <- c(state$extract_prompts, prompt)
+        extract_tuned <- grepl("EXTRACT-TUNED", prompt, fixed = TRUE) ||
+          grepl("EXTRACT-HARNESS", prompt, fixed = TRUE)
+        list(answer = if (state$action_tuned && extract_tuned) "yes" else "no")
+      }
+    )
+    class(chat) <- c("Chat", class(chat))
+    chat
+  }
+
+  chat <- new_chat()
+  chat$optimizer_state <- state
+  chat
+}
+
+make_rlm_optimizer_program <- function(runner, max_output_chars = 96L) {
+  rlm_module(
+    signature(
+      "question -> answer",
+      instructions = "Answer from the inspected evidence."
+    ),
+    runner = runner,
+    max_iterations = 1L,
+    max_llm_calls = 0L,
+    max_output_chars = max_output_chars
+  )
+}
+
+rlm_optimizer_accuracy <- function(prediction, expected) {
+  predicted <- if (is.list(prediction)) prediction$answer else prediction
+  as.numeric(identical(as.character(predicted), expected$answer))
+}
+
+capture_rlm_optimizer_warnings <- function(expr) {
+  messages <- character()
+  value <- withCallingHandlers(
+    force(expr),
+    warning = function(warning) {
+      messages <<- c(messages, conditionMessage(warning))
+      invokeRestart("muffleWarning")
+    }
+  )
+  list(value = value, messages = messages)
+}
+
+expect_only_rlm_fallback_warnings <- function(result) {
+  expect_gt(length(result$messages), 0L)
+  expect_true(all(grepl(
+    "RLM reached max_iterations",
+    result$messages,
+    fixed = TRUE
+  )))
+  invisible(result$value)
+}

--- a/tests/testthat/test-artifact-v4-runtime.R
+++ b/tests/testthat/test-artifact-v4-runtime.R
@@ -44,7 +44,27 @@ artifact_v4_rehash <- function(artifact) {
   artifact
 }
 
-test_that("v4 interpreter factories round-trip without being invoked", {
+artifact_v4_strip_rlm_children <- function(artifact, node_id = "$") {
+  child_ids <- vapply(
+    artifact$graph$nodes[[node_id]]$children,
+    `[[`,
+    character(1),
+    ".node"
+  )
+  artifact$graph$nodes[[node_id]]$children <- list()
+  artifact$graph$nodes <- artifact$graph$nodes[
+    !names(artifact$graph$nodes) %in% child_ids
+  ]
+  artifact$graph$edges <- Filter(
+    function(edge) {
+      !edge$from %in% child_ids && !edge$to %in% child_ids
+    },
+    artifact$graph$edges
+  )
+  artifact
+}
+
+test_that("v5 interpreter factories round-trip without being invoked", {
   calls <- 0L
   interpreter_factory <- function(.unused = NULL) {
     calls <<- calls + 1L
@@ -54,7 +74,7 @@ test_that("v4 interpreter factories round-trip without being invoked", {
 
   for (program in artifact_v4_modules(interpreter_factory)) {
     artifact <- program_artifact(program, registry = registry)
-    expect_identical(artifact$format_version, 4L)
+    expect_identical(artifact$format_version, 5L)
     fields <- artifact$graph$nodes[["$"]]$fields
     expect_null(fields$runner)
     expect_identical(
@@ -84,7 +104,124 @@ test_that("v4 interpreter factories round-trip without being invoked", {
   }
 })
 
-test_that("v4 interpreter factories support explicit trusted embedding", {
+test_that("v5 RLM predictor children preserve tuned state", {
+  calls <- 0L
+  interpreter_factory <- function(.unused = NULL) {
+    calls <<- calls + 1L
+    artifact_v4_runner()
+  }
+  action <- dsprrr:::new_rlm_action_module()
+  extract <- dsprrr:::new_rlm_extract_module(
+    signature("question -> answer")@output_type
+  )
+  action$signature@instructions <- "Use the tuned action policy."
+  action$demos <- list(list(
+    state = "trajectory",
+    reasoning = "inspect the evidence",
+    code = "summary(.context$data)"
+  ))
+  action$state$compiled <- TRUE
+  action$state$best_score <- 0.8
+  action$state$best_trial <- 2L
+  action$state$best_params <- list(temperature = 0.2)
+  extract$signature@instructions <- "Use the tuned extraction policy."
+  extract$demos <- list(list(state = "trajectory", answer = "supported"))
+  program <- dsprrr:::RLMModule$new(
+    signature = signature("question -> answer"),
+    interpreter_factory = interpreter_factory,
+    max_llm_calls = 0L,
+    generate_action = action,
+    extract = extract
+  )
+  registry <- list(interpreter_factory = interpreter_factory)
+
+  artifact <- program_artifact(program, registry = registry)
+  restored <- restore_module_config(artifact, registry = registry)
+
+  expect_named(
+    artifact$graph$nodes[["$"]]$children,
+    c("generate_action", "extract")
+  )
+  expect_named(
+    artifact$graph$nodes,
+    c("$", "$/generate_action", "$/extract")
+  )
+  expect_identical(
+    restored$generate_action$signature@instructions,
+    "Use the tuned action policy."
+  )
+  expect_identical(restored$generate_action$demos, action$demos)
+  expect_identical(restored$generate_action$state$compiled, TRUE)
+  expect_identical(restored$generate_action$state$best_score, 0.8)
+  expect_identical(restored$generate_action$state$best_trial, 2L)
+  expect_identical(
+    restored$generate_action$state$best_params,
+    list(temperature = 0.2)
+  )
+  expect_identical(
+    restored$extract$signature@instructions,
+    "Use the tuned extraction policy."
+  )
+  expect_identical(restored$extract$demos, extract$demos)
+  expect_identical(restored$interpreter_factory, interpreter_factory)
+  expect_identical(calls, 0L)
+  expect_identical(
+    program_artifact(restored, registry = registry)$graph,
+    artifact$graph
+  )
+})
+
+test_that("childless v4 RLM artifacts restore with default predictors", {
+  calls <- 0L
+  interpreter_factory <- function(.unused = NULL) {
+    calls <<- calls + 1L
+    artifact_v4_runner()
+  }
+  registry <- list(interpreter_factory = interpreter_factory)
+  program <- dsprrr:::RLMModule$new(
+    signature = signature("question -> answer"),
+    interpreter_factory = interpreter_factory,
+    max_llm_calls = 0L
+  )
+  artifact <- program_artifact(program, registry = registry) |>
+    artifact_v4_strip_rlm_children()
+  artifact$format_version <- 4L
+  artifact <- artifact_v4_rehash(artifact)
+
+  expect_no_error(dsprrr:::artifact_validate_manifest(artifact))
+  restored <- restore_module_config(artifact, registry = registry)
+
+  expect_named(module_children(restored), c("generate_action", "extract"))
+  expect_s3_class(restored$generate_action, "PredictModule")
+  expect_s3_class(restored$extract, "PredictModule")
+  expect_identical(restored$interpreter_factory, interpreter_factory)
+  expect_identical(calls, 0L)
+  upgraded <- program_artifact(restored, registry = registry)
+  expect_named(
+    upgraded$graph$nodes[["$"]]$children,
+    c("generate_action", "extract")
+  )
+})
+
+test_that("v5 RLM artifacts reject partial predictor child schemas", {
+  interpreter_factory <- function(.unused = NULL) artifact_v4_runner()
+  registry <- list(interpreter_factory = interpreter_factory)
+  program <- dsprrr:::RLMModule$new(
+    signature = signature("question -> answer"),
+    interpreter_factory = interpreter_factory,
+    max_llm_calls = 0L
+  )
+  artifact <- program_artifact(program, registry = registry)
+  artifact$graph$nodes[["$"]]$children$extract <- NULL
+  artifact <- artifact_v4_rehash(artifact)
+
+  expect_error(
+    dsprrr:::artifact_validate_manifest(artifact),
+    class = "dsprrr_artifact_malformed"
+  )
+})
+
+test_that("v5 interpreter factories support explicit trusted embedding", {
   calls <- 0L
   interpreter_factory <- function(.unused = NULL) {
     calls <<- calls + 1L
@@ -106,7 +243,7 @@ test_that("v4 interpreter factories support explicit trusted embedding", {
   expect_identical(calls, 0L)
 })
 
-test_that("v4 runtime bindings enforce exact XOR", {
+test_that("v5 runtime bindings enforce exact XOR", {
   runner <- artifact_v4_runner()
   factory <- function(.unused = NULL) artifact_v4_runner()
   registry <- list(runner = runner, factory = factory)
@@ -152,6 +289,7 @@ test_that("validated v3 runner artifacts upgrade before restoration", {
     max_llm_calls = 1L
   )
   artifact <- program_artifact(program, registry = registry)
+  artifact <- artifact_v4_strip_rlm_children(artifact)
   fields <- artifact$graph$nodes[["$"]]$fields
   fields$interpreter_factory <- NULL
   fields <- fields[setdiff(names(fields), "interpreter_factory")]
@@ -182,7 +320,7 @@ test_that("validated v3 runner artifacts upgrade before restoration", {
   )
 })
 
-test_that("Flex modules have a resource-free v4 artifact codec", {
+test_that("Flex modules keep their resource-free codec in v5", {
   program <- suppressWarnings(
     dsprrr:::FlexModule$new(
       signature = signature("question -> answer"),
@@ -196,7 +334,7 @@ test_that("Flex modules have a resource-free v4 artifact codec", {
   fields <- artifact$graph$nodes[["$"]]$fields
   restored <- restore_module_config(artifact)
 
-  expect_identical(artifact$format_version, 4L)
+  expect_identical(artifact$format_version, 5L)
   expect_named(
     fields,
     c(

--- a/tests/testthat/test-artifact.R
+++ b/tests/testthat/test-artifact.R
@@ -691,6 +691,7 @@ test_that("chat configuration records only provider and model", {
     list(
       api_key = sentinel,
       turns = list(sentinel),
+      chat = function(prompt) "safe response",
       get_model = function() "safe-model"
     ),
     class = c("SafeProviderChat", "Chat")
@@ -1972,7 +1973,7 @@ test_that("pins transports the exact graph manifest", {
   restored <- restore_module_config(artifact)
 
   expect_identical(artifact$format, "dsprrr-program")
-  expect_identical(artifact$format_version, 4L)
+  expect_identical(artifact$format_version, 5L)
   expect_identical(
     artifact$integrity,
     dsprrr:::artifact_integrity(artifact)

--- a/tests/testthat/test-cache.R
+++ b/tests/testthat/test-cache.R
@@ -746,6 +746,105 @@ test_that("cached_chat_structured uses cache for repeated calls", {
   expect_equal(stats$misses, 1L)
 })
 
+test_that("Predict metadata distinguishes cache hits from provider calls", {
+  local_reset_cache()
+  configure_cache(enable_memory = TRUE, enable_disk = FALSE)
+  clear_cache()
+
+  calls <- new.env(parent = emptyenv())
+  calls$n <- 0L
+  local_cache_openai_backend(calls)
+  base <- cache_real_chat()
+  predictor <- module(signature("question -> answer"), type = "predict")
+
+  miss <- predictor$forward(
+    list(question = "same prompt"),
+    .llm = base$clone(deep = TRUE),
+    .cache = TRUE,
+    trace = FALSE
+  )
+  hit <- predictor$forward(
+    list(question = "same prompt"),
+    .llm = base$clone(deep = TRUE),
+    .cache = TRUE,
+    trace = FALSE
+  )
+
+  expect_identical(calls$n, 1L)
+  expect_identical(miss$metadata[[1L]]$cache, "miss")
+  expect_identical(miss$metadata[[1L]]$provider_calls, 1L)
+  expect_identical(miss$metadata[[1L]]$total_tokens, 10L)
+  expect_identical(hit$metadata[[1L]]$cache, "hit")
+  expect_identical(hit$metadata[[1L]]$provider_calls, 0L)
+  expect_true(is.na(hit$metadata[[1L]]$input_tokens))
+  expect_true(is.na(hit$metadata[[1L]]$output_tokens))
+  expect_true(is.na(hit$metadata[[1L]]$total_tokens))
+})
+
+test_that("RLM cache accounting counts only current provider work", {
+  skip_if_not_installed("callr")
+  local_reset_cache()
+  configure_cache(enable_memory = TRUE, enable_disk = FALSE)
+  clear_cache()
+
+  calls <- new.env(parent = emptyenv())
+  calls$n <- 0L
+  local_cache_openai_backend(
+    calls,
+    response = function(index) {
+      if (index %% 2L == 1L) {
+        list(reasoning = "Inspect once", code = "1 + 1")
+      } else {
+        list(answer = "done")
+      }
+    }
+  )
+  base <- cache_real_chat()
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  analyst <- rlm_module(
+    "question -> answer: string",
+    runner = runner,
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+
+  first <- suppressWarnings(analyst$forward(
+    list(question = "same task"),
+    .llm = base,
+    .cache = TRUE
+  ))
+  second <- suppressWarnings(analyst$forward(
+    list(question = "same task"),
+    .llm = base,
+    .cache = TRUE
+  ))
+
+  expect_identical(calls$n, 2L)
+  expect_identical(first$metadata[[1L]]$action_calls, 1L)
+  expect_identical(first$metadata[[1L]]$extraction_calls, 1L)
+  expect_identical(first$metadata[[1L]]$action_provider_calls, 1L)
+  expect_identical(first$metadata[[1L]]$extraction_provider_calls, 1L)
+  expect_identical(first$metadata[[1L]]$provider_calls, 2L)
+  expect_identical(first$metadata[[1L]]$total_tokens, 20L)
+  expect_identical(second$metadata[[1L]]$action_provider_calls, 0L)
+  expect_identical(second$metadata[[1L]]$extraction_provider_calls, 0L)
+  expect_identical(second$metadata[[1L]]$provider_calls, 0L)
+  expect_identical(second$metadata[[1L]]$input_tokens, 0L)
+  expect_identical(second$metadata[[1L]]$output_tokens, 0L)
+  expect_identical(second$metadata[[1L]]$total_tokens, 0L)
+
+  bypass <- suppressWarnings(analyst$forward(
+    list(question = "same task"),
+    .llm = base,
+    .cache = FALSE
+  ))
+  expect_identical(calls$n, 4L)
+  expect_identical(bypass$metadata[[1L]]$action_provider_calls, 1L)
+  expect_identical(bypass$metadata[[1L]]$extraction_provider_calls, 1L)
+  expect_identical(bypass$metadata[[1L]]$provider_calls, 2L)
+})
+
 test_that("real structured Chat branches replay ContentJson equivalently", {
   local_reset_cache()
   configure_cache(enable_memory = TRUE, enable_disk = FALSE)

--- a/tests/testthat/test-interpreter-factory.R
+++ b/tests/testthat/test-interpreter-factory.R
@@ -83,6 +83,28 @@ factory_test_pot_chat <- function(error = NULL) {
   chat
 }
 
+factory_test_rlm_chat <- function() {
+  generator <- R6::R6Class(
+    "FactoryRlmChat",
+    public = list(
+      chat_structured = function(prompt, type, ...) {
+        list(
+          reasoning = "Return this row's question",
+          code = "SUBMIT(answer = .context$question)"
+        )
+      },
+      chat = function(prompt, ...) {
+        stop("recursive queries are disabled in this test", call. = FALSE)
+      },
+      get_model = function() "factory-rlm-test"
+    ),
+    cloneable = TRUE
+  )
+  chat <- generator$new()
+  class(chat) <- c("Chat", class(chat))
+  chat
+}
+
 test_that("interpreter factories are validated without being invoked", {
   log <- factory_test_log()
   factory <- factory_test_factory(log)
@@ -965,6 +987,74 @@ test_that("factory batches reject controls the adapter cannot enforce", {
   expect_length(log$created, 0L)
 })
 
+test_that("factory RLM batches forward cache control to action and fallback", {
+  skip_if_not_installed("callr")
+  observed <- logical()
+  testthat::local_mocked_bindings(
+    cached_chat_structured = function(
+      llm,
+      prompt,
+      output_type,
+      rollout_id = NULL,
+      .cache = NULL,
+      .observer = NULL
+    ) {
+      observed <<- c(observed, .cache)
+      if (is.function(.observer)) {
+        if (isTRUE(.cache)) {
+          .observer("miss", "cache_miss")
+        } else {
+          .observer("bypass", "disabled")
+        }
+      }
+      fields <- names(output_type@properties)
+      if (identical(fields, c("reasoning", "code"))) {
+        return(list(reasoning = "Inspect before fallback", code = "1 + 1"))
+      }
+      list(answer = "done")
+    },
+    .package = "dsprrr"
+  )
+  make_module <- function() {
+    rlm_module(
+      "question -> answer: string",
+      interpreter_factory = function() {
+        r_code_runner(timeout = 10, persistent = TRUE)
+      },
+      max_iterations = 1L,
+      max_llm_calls = 0L
+    )
+  }
+  chat <- factory_test_rlm_chat()
+
+  enabled <- suppressWarnings(run_dataset(
+    make_module(),
+    data.frame(question = c("first", "second")),
+    .llm = chat,
+    .cache = TRUE,
+    .progress = FALSE
+  ))
+  expect_identical(
+    enabled$result,
+    list(list(answer = "done"), list(answer = "done"))
+  )
+  expect_identical(observed, rep(TRUE, 4L))
+
+  observed <- logical()
+  disabled <- suppressWarnings(run_dataset(
+    make_module(),
+    data.frame(question = c("first", "second")),
+    .llm = chat,
+    .cache = FALSE,
+    .progress = FALSE
+  ))
+  expect_identical(
+    disabled$result,
+    list(list(answer = "done"), list(answer = "done"))
+  )
+  expect_identical(observed, rep(FALSE, 4L))
+})
+
 test_that("run_async owns an isolated profile after default topology stops", {
   skip_if_not_installed("mirai")
   skip_if_not_installed("promises")
@@ -1203,6 +1293,390 @@ test_that("factory-backed batches support isolated mirai concurrency", {
   expect_identical(sum(events == "start"), 2L)
   expect_identical(sum(events == "shutdown"), 2L)
   expect_length(module$get_executions(), 2L)
+})
+
+test_that("factory RLM mirai batches restore ordered canonical traces", {
+  skip_if_not_installed("callr")
+  skip_if_not_installed("mirai")
+  skip_if(nzchar(Sys.getenv("R_COVR")), "mirai workers interfere with covr")
+
+  clear_prompt_history()
+  withr::defer(clear_prompt_history())
+  withr::local_options(list(dsprrr.rlm_trace_limit = 1L))
+
+  chat <- factory_test_rlm_chat()
+  module <- rlm_module(
+    "question -> answer: string",
+    interpreter_factory = function() {
+      dsprrr::r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L,
+    chat = chat
+  )
+
+  initial <- run(
+    module,
+    question = "before",
+    .progress = FALSE
+  )
+  expect_identical(initial$answer, "before")
+  cursor <- dsprrr:::evaluation_trace_cursor(module)
+
+  testthat::local_mocked_bindings(
+    new_dsprrr_mirai_profile = function() "rlm-trace-test",
+    shutdown_dsprrr_mirai_profile = function(...) TRUE,
+    .package = "dsprrr"
+  )
+  testthat::local_mocked_bindings(
+    daemons = function(...) invisible(TRUE),
+    mirai_map = function(.x, .f, .args, ...) {
+      lapply(.x, function(input_set) {
+        package_state <- get(".dsprrr_env", envir = asNamespace("dsprrr"))
+        history_before <- package_state$prompt_history
+        generation_before <- package_state$prompt_history_generation
+        worker_args <- .args
+        worker_args$module <- .args$module$deepcopy()
+        worker_args$llm <- .args$llm$clone(deep = TRUE)
+        worker_args$namespace_path <- file.path(
+          tempdir(),
+          "no-source-package"
+        )
+        tryCatch(
+          do.call(.f, c(list(input_set = input_set), worker_args)),
+          finally = {
+            package_state$prompt_history <- history_before
+            package_state$prompt_history_generation <- generation_before
+          }
+        )
+      })
+    },
+    .package = "mirai"
+  )
+
+  observed <- list()
+  metric <- metric_with_trace(
+    function(
+      prediction,
+      expected,
+      program_trace
+    ) {
+      observed[[length(observed) + 1L]] <<- program_trace
+      as.numeric(identical(prediction$answer, expected$answer[[1L]]))
+    },
+    field = "answer"
+  )
+  data <- tibble::tibble(
+    question = c("second", "third"),
+    answer = c("second", "third")
+  )
+
+  result <- evaluate(
+    module,
+    data,
+    metric,
+    .concurrency = concurrency_control(
+      backend = "mirai",
+      max_active = 2L
+    ),
+    .progress = FALSE
+  )
+
+  expect_identical(result$scores, c(1, 1))
+  expect_identical(module$state$trace_sequence, 3)
+  expect_length(module$state$traces, 1L)
+  expect_identical(
+    vapply(
+      module$state$traces,
+      function(trace) trace$output$answer,
+      character(1)
+    ),
+    "third"
+  )
+  expect_identical(
+    vapply(
+      module$state$traces,
+      function(trace) trace$metadata$batch_index,
+      integer(1)
+    ),
+    2L
+  )
+  expect_length(module$get_repl_history(), 1L)
+  expect_identical(
+    module$get_repl_history()[[1L]]$final_answer$answer,
+    "third"
+  )
+
+  new_events <- dsprrr:::new_evaluation_trace_events(module, cursor)
+  expect_identical(
+    vapply(new_events, function(trace) trace$output$answer, character(1)),
+    "third"
+  )
+  expect_length(observed, 2L)
+  expect_true(all(vapply(
+    observed,
+    function(trace) {
+      identical(trace$status, "ok") && length(trace$events) == 1L
+    },
+    logical(1)
+  )))
+  expect_identical(
+    vapply(
+      observed,
+      function(trace) trace$events[[1L]]$output$answer,
+      character(1)
+    ),
+    c("second", "third")
+  )
+
+  history <- .dsprrr_env$prompt_history
+  expect_length(history, 3L)
+  expect_identical(
+    vapply(history, `[[`, character(1), "source"),
+    rep("RLMModule", 3L)
+  )
+  expect_identical(
+    vapply(history, `[[`, character(1), "response"),
+    c(
+      '{"answer":"before"}',
+      '{"answer":"second"}',
+      '{"answer":"third"}'
+    )
+  )
+  expect_identical(dsprrr:::prompt_history_generation(), 3)
+})
+
+test_that("factory RLM mirai workers preserve explicit cache control", {
+  skip_if_not_installed("callr")
+  skip_if_not_installed("mirai")
+
+  clear_prompt_history()
+  withr::defer(clear_prompt_history())
+  observed <- logical()
+  worker_cache <- list()
+  testthat::local_mocked_bindings(
+    cached_chat_structured = function(
+      llm,
+      prompt,
+      output_type,
+      rollout_id = NULL,
+      .cache = NULL,
+      .observer = NULL
+    ) {
+      observed <<- c(observed, .cache)
+      if (is.function(.observer)) {
+        if (isTRUE(.cache)) {
+          .observer("miss", "cache_miss")
+        } else {
+          .observer("bypass", "disabled")
+        }
+      }
+      fields <- names(output_type@properties)
+      if (identical(fields, c("reasoning", "code"))) {
+        return(list(reasoning = "Inspect before fallback", code = "1 + 1"))
+      }
+      list(answer = "done")
+    },
+    new_dsprrr_mirai_profile = function() "rlm-cache-test",
+    shutdown_dsprrr_mirai_profile = function(...) TRUE,
+    .package = "dsprrr"
+  )
+  testthat::local_mocked_bindings(
+    daemons = function(...) invisible(TRUE),
+    mirai_map = function(.x, .f, .args, ...) {
+      worker_cache[[length(worker_cache) + 1L]] <<- .args$cache
+      lapply(.x, function(input_set) {
+        package_state <- get(".dsprrr_env", envir = asNamespace("dsprrr"))
+        history_before <- package_state$prompt_history
+        generation_before <- package_state$prompt_history_generation
+        worker_args <- .args
+        worker_args$module <- .args$module$deepcopy()
+        worker_args$llm <- .args$llm$clone(deep = TRUE)
+        worker_args$namespace_path <- file.path(
+          tempdir(),
+          "no-source-package"
+        )
+        tryCatch(
+          do.call(.f, c(list(input_set = input_set), worker_args)),
+          finally = {
+            package_state$prompt_history <- history_before
+            package_state$prompt_history_generation <- generation_before
+          }
+        )
+      })
+    },
+    .package = "mirai"
+  )
+  make_module <- function() {
+    rlm_module(
+      "question -> answer: string",
+      interpreter_factory = function() {
+        r_code_runner(timeout = 10, persistent = TRUE)
+      },
+      max_iterations = 1L,
+      max_llm_calls = 0L,
+      chat = factory_test_rlm_chat()
+    )
+  }
+
+  for (cache in c(TRUE, FALSE)) {
+    observed <- logical()
+    result <- suppressWarnings(run_dataset(
+      make_module(),
+      data.frame(question = c("first", "second")),
+      .cache = cache,
+      .concurrency = concurrency_control(
+        backend = "mirai",
+        max_active = 2L
+      ),
+      .progress = FALSE
+    ))
+
+    expect_identical(
+      result$result,
+      list(list(answer = "done"), list(answer = "done"))
+    )
+    expect_identical(observed, rep(cache, 4L))
+  }
+  expect_identical(worker_cache, list(TRUE, FALSE))
+})
+
+test_that("bounded sequential factory traces remain available to evaluation", {
+  skip_if_not_installed("callr")
+
+  clear_prompt_history()
+  withr::defer(clear_prompt_history())
+  withr::local_options(list(dsprrr.rlm_trace_limit = 1L))
+
+  chat <- factory_test_rlm_chat()
+  module <- rlm_module(
+    "question -> answer: string",
+    interpreter_factory = function() {
+      dsprrr::r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L,
+    chat = chat
+  )
+  observed <- list()
+  metric <- metric_with_trace(
+    function(prediction, expected, program_trace) {
+      observed[[length(observed) + 1L]] <<- program_trace
+      as.numeric(identical(prediction$answer, expected$answer[[1L]]))
+    },
+    field = "answer"
+  )
+  data <- tibble::tibble(
+    question = c("first", "second"),
+    answer = c("first", "second")
+  )
+
+  result <- evaluate(
+    module,
+    data,
+    metric,
+    .concurrency = concurrency_control(backend = "sequential"),
+    .progress = FALSE
+  )
+
+  expect_identical(result$scores, c(1, 1))
+  expect_identical(
+    vapply(
+      observed,
+      function(trace) trace$events[[1L]]$output$answer,
+      character(1)
+    ),
+    c("first", "second")
+  )
+  expect_identical(
+    vapply(observed, `[[`, character(1), "status"),
+    c("ok", "ok")
+  )
+  expect_length(module$state$traces, 1L)
+  expect_identical(module$state$traces[[1L]]$output$answer, "second")
+})
+
+test_that("sequential factory RLM batches retain traces across failed rows", {
+  skip_if_not_installed("callr")
+
+  clear_prompt_history()
+  withr::defer(clear_prompt_history())
+
+  chat_class <- R6::R6Class(
+    "FactorySequentialTraceChat",
+    public = list(
+      chat_structured = function(prompt, type, ...) {
+        if (grepl("Preview: bad", prompt, fixed = TRUE)) {
+          stop("scripted action failure", call. = FALSE)
+        }
+        list(
+          reasoning = "Return this row's question",
+          code = "SUBMIT(answer = .context$question)"
+        )
+      },
+      chat = function(prompt, ...) {
+        stop("recursive queries are disabled in this test", call. = FALSE)
+      },
+      get_model = function() "factory-sequential-trace-test"
+    ),
+    cloneable = TRUE
+  )
+  chat <- chat_class$new()
+  class(chat) <- c("Chat", class(chat))
+
+  module <- rlm_module(
+    "question -> answer: string",
+    interpreter_factory = function() {
+      dsprrr::r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L,
+    chat = chat
+  )
+  observed <- list()
+  metric <- metric_with_trace(
+    function(prediction, expected, program_trace) {
+      observed[[length(observed) + 1L]] <<- program_trace
+      as.numeric(identical(prediction$answer, expected$answer[[1L]]))
+    },
+    field = "answer"
+  )
+  data <- tibble::tibble(
+    question = c("good-1", "bad", "good-2"),
+    answer = c("good-1", "bad", "good-2")
+  )
+
+  result <- evaluate(
+    module,
+    data,
+    metric,
+    .concurrency = concurrency_control(backend = "sequential"),
+    .progress = FALSE
+  )
+
+  expect_identical(result$scores, c(1, NA, 1))
+  expect_length(observed, 2L)
+  expect_true(all(vapply(
+    observed,
+    function(trace) length(trace$events) == 1L,
+    logical(1)
+  )))
+  expect_identical(
+    vapply(
+      observed,
+      function(trace) trace$events[[1L]]$output$answer,
+      character(1)
+    ),
+    c("good-1", "good-2")
+  )
+  expect_identical(
+    vapply(
+      module$state$traces,
+      function(trace) trace$metadata$batch_index,
+      integer(1)
+    ),
+    c(1L, 3L)
+  )
 })
 
 test_that("built-in runners become terminal after close", {

--- a/tests/testthat/test-mcp-repl-runner.R
+++ b/tests/testthat/test-mcp-repl-runner.R
@@ -83,7 +83,7 @@ test_that("mcp_repl_runner overwrites persistent context even when empty", {
   expect_length(inputs, 2L)
   expect_match(inputs[[1L]], "sensitive", fixed = TRUE)
   expect_match(inputs[[2L]], "\\.context <-")
-  expect_match(inputs[[2L]], 'fromJSON("[]",', fixed = TRUE)
+  expect_match(inputs[[2L]], "unserializeJSON", fixed = TRUE)
   expect_false(grepl("sensitive", inputs[[2L]], fixed = TRUE))
 })
 
@@ -113,6 +113,41 @@ test_that("mcp_repl_input compresses large requests without changing them", {
   expect_false(exists(".context", envir = .GlobalEnv, inherits = FALSE))
 })
 
+test_that("mcp_repl_input preserves compact structured context", {
+  context <- list(
+    sessions = data.frame(
+      release = c("2.3.9", "2.4.0"),
+      converted = c(TRUE, FALSE),
+      stringsAsFactors = FALSE
+    ),
+    values = c(2L, 4L),
+    replay = list(list(
+      request = list(index = 1L, arguments = list(value = 20L)),
+      success = TRUE,
+      value = 21L,
+      error = NULL
+    ))
+  )
+  code <- paste(
+    "local({",
+    "  value <- .context",
+    "  base::rm(.context, envir = base::globalenv())",
+    "  value",
+    "})",
+    sep = "\n"
+  )
+
+  input <- dsprrr:::mcp_repl_input(code, context)
+  value <- eval(parse(text = input), envir = .GlobalEnv)
+
+  expect_identical(value, context)
+  expect_s3_class(value$sessions, "data.frame")
+  expect_type(value$values, "integer")
+  expect_type(value$replay, "list")
+  expect_type(value$replay[[1L]]$request, "list")
+  expect_false(exists(".context", envir = .GlobalEnv, inherits = FALSE))
+})
+
 test_that("mcp_repl_input preserves fitting high-entropy requests", {
   withr::local_seed(125L)
   alphabet <- strsplit(
@@ -125,8 +160,14 @@ test_that("mcp_repl_input preserves fitting high-entropy requests", {
   )[[1L]]
   payload <- paste(sample(alphabet, 6040L, replace = TRUE), collapse = "")
   code <- paste0("#", payload, "\n1 + 1")
+  context_literal <- encodeString(
+    as.character(jsonlite::serializeJSON(list(), digits = NA)),
+    quote = "\""
+  )
   expected <- paste0(
-    '.context <- jsonlite::fromJSON("[]", simplifyVector = FALSE)\n',
+    ".context <- jsonlite::unserializeJSON(",
+    context_literal,
+    ")\n",
     code,
     "\n"
   )
@@ -684,6 +725,53 @@ test_that("mcp_repl_runner refuses an unverifiable inherited sandbox", {
   )
 })
 
+test_that("mcp-repl predecoded RLM controls carry process-local attestation", {
+  nonce <- "mcp-predecoded-control"
+  envelope <- list(
+    version = 1L,
+    nonce = nonce,
+    kind = "final",
+    payload = list(index = 1L, output = list(answer = "ok"))
+  )
+  json <- jsonlite::toJSON(
+    envelope,
+    auto_unbox = TRUE,
+    null = "null",
+    na = "null",
+    dataframe = "rows",
+    digits = NA
+  )
+  frame <- paste0(
+    dsprrr:::rlm_control_prefix(),
+    gsub(
+      "[[:space:]]",
+      "",
+      jsonlite::base64_enc(charToRaw(as.character(json)))
+    )
+  )
+  repl <- function(input, timeout_ms) {
+    list(result = list(content = list(list(type = "text", text = frame))))
+  }
+  runner <- mcp_repl_runner(repl = repl)
+
+  result <- runner$execute(
+    "invisible(NULL)",
+    .control_nonce = nonce,
+    .control_protocol = "rlm"
+  )
+  consumed <- dsprrr:::decode_rlm_control(result$result, nonce)
+
+  expect_true(result$success)
+  expect_s3_class(result$result, "rlm_final")
+  expect_s3_class(consumed, "rlm_final")
+  expect_identical(dsprrr:::extract_rlm_final(consumed)$answer, "ok")
+  expect_null(attr(
+    consumed,
+    dsprrr:::rlm_control_attestation_attribute(),
+    exact = TRUE
+  ))
+})
+
 test_that("authenticated RLM traffic fails closed on file previews", {
   previews <- c(
     paste0(
@@ -768,7 +856,7 @@ test_that("Flex normal inline control is decoded before display truncation", {
   expect_identical(result$result$.dsprrr_flex_control, TRUE)
   expect_identical(result$result$nonce, nonce)
   expect_identical(result$result$payload$output$answer, "ok")
-  expect_match(result$stdout, "output truncated by dsprrr", fixed = TRUE)
+  expect_lte(nchar(result$stdout), 20L)
   expect_identical(
     dsprrr:::flex_code_decode_control(list(result$result), nonce),
     result$result
@@ -874,7 +962,7 @@ test_that("Flex recovers one bounded current-step frame from file previews", {
   expect_identical(result$result$.dsprrr_flex_control, TRUE)
   expect_identical(result$result$nonce, nonce)
   expect_identical(result$result$payload$output$answer, "ok")
-  expect_match(result$stdout, "output truncated by dsprrr", fixed = TRUE)
+  expect_lte(nchar(result$stdout), 20L)
 
   rlm_result <- runner$execute(
     "invisible(NULL)",

--- a/tests/testthat/test-module-rlm.R
+++ b/tests/testthat/test-module-rlm.R
@@ -4,12 +4,21 @@
 create_mock_rlm_llm <- function(
   code_responses = list(),
   fallback_chat = "fallback answer",
-  fallback_structured = list(answer = fallback_chat)
+  fallback_structured = list(answer = fallback_chat),
+  .state = NULL
 ) {
-  call_count <- 0
+  if (is.null(.state)) {
+    .state <- new.env(parent = emptyenv())
+    .state$call_count <- 0L
+  }
   mock <- list(
     clone = function() {
-      create_mock_rlm_llm(code_responses, fallback_chat, fallback_structured)
+      create_mock_rlm_llm(
+        code_responses,
+        fallback_chat,
+        fallback_structured,
+        .state = .state
+      )
     },
     chat_structured = function(prompt, type, ...) {
       type_fields <- if (
@@ -24,9 +33,9 @@ create_mock_rlm_llm <- function(
       is_code_gen <- all(c("reasoning", "code") %in% type_fields)
 
       if (is_code_gen) {
-        call_count <<- call_count + 1
-        if (call_count <= length(code_responses)) {
-          return(code_responses[[call_count]])
+        .state$call_count <- .state$call_count + 1L
+        if (.state$call_count <= length(code_responses)) {
+          return(code_responses[[.state$call_count]])
         }
 
         # Default: simple SUBMIT
@@ -53,6 +62,250 @@ create_mock_rlm_llm <- function(
 # Factory Function Tests
 # ============================================================================
 
+test_that("rlm forwards structured one-shot results with an explicit runner", {
+  skip_if_not_installed("callr")
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  chat <- create_mock_rlm_llm(list(list(
+    reasoning = "Return the result",
+    code = "SUBMIT(42L)"
+  )))
+
+  result <- rlm(
+    "question -> answer: integer",
+    question = "What is the answer?",
+    .llm = chat,
+    .runner = runner,
+    .max_llm_calls = 0L,
+    .return_format = "structured"
+  )
+
+  expect_s3_class(result, "dsprrr_result")
+  expect_named(result, c("output", "chat", "metadata"))
+  expect_identical(result$output$answer, 42L)
+  expect_identical(result$metadata$runner_lifecycle, "caller-owned")
+})
+
+test_that("run treats every RLM input as one rich context object", {
+  skip_if_not_installed("callr")
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  chat <- create_mock_rlm_llm(list(list(
+    reasoning = "Verify the staged R objects",
+    code = paste(
+      "stopifnot(",
+      "identical(.context$values, c(2L, 4L, 8L)),",
+      "identical(.context$unnamed, list('alpha', 2L)),",
+      "identical(.context$named, list(alpha = 1L, beta = 'two')),",
+      "is.matrix(.context$grid),",
+      "identical(dim(.context$grid), c(2L, 2L)),",
+      "inherits(.context$model, 'lm')",
+      ") ; SUBMIT(42L)"
+    )
+  )))
+
+  result <- run(
+    rlm_module(
+      "values, unnamed, named, grid, model -> answer: integer",
+      runner = runner,
+      max_llm_calls = 0L
+    ),
+    values = c(2L, 4L, 8L),
+    unnamed = list("alpha", 2L),
+    named = list(alpha = 1L, beta = "two"),
+    grid = matrix(1:4, nrow = 2L),
+    model = stats::lm(mpg ~ wt, data = mtcars),
+    .llm = chat
+  )
+
+  expect_identical(result, list(answer = 42L))
+})
+
+test_that("run_dataset batches rich contexts with one owned runner per row", {
+  skip_if_not_installed("callr")
+  lifecycle <- new.env(parent = emptyenv())
+  lifecycle$created <- 0L
+  lifecycle$closed <- 0L
+  factory <- function() {
+    lifecycle$created <- lifecycle$created + 1L
+    inner <- r_code_runner(timeout = 10, persistent = TRUE)
+    list(
+      execute = function(code, context = list(), .control_nonce = NULL) {
+        inner$execute(code, context = context)
+      },
+      prepare_context = function(...) inner$prepare_context(...),
+      policy = function() inner$policy(),
+      shutdown = function() {
+        lifecycle$closed <- lifecycle$closed + 1L
+        inner$shutdown()
+      }
+    )
+  }
+  chat <- create_mock_rlm_llm(list(
+    list(
+      reasoning = "Read the first rich-context value",
+      code = "SUBMIT(.context$records$value[[1L]])"
+    ),
+    list(
+      reasoning = "Read the first rich-context value",
+      code = "SUBMIT(.context$records$value[[1L]])"
+    )
+  ))
+  records <- list(
+    data.frame(value = 10L, label = "first"),
+    data.frame(value = 20L, label = "second")
+  )
+
+  module <- rlm_module(
+    "records, question -> answer: integer",
+    interpreter_factory = factory,
+    max_llm_calls = 0L
+  )
+  result <- run_dataset(
+    module,
+    tibble::tibble(
+      records = records,
+      question = c("first", "second")
+    ),
+    .llm = chat,
+    .progress = FALSE,
+    .return_format = "structured"
+  )
+
+  expect_s3_class(result, "tbl_df")
+  expect_true(all(is.na(result$.error)))
+  expect_identical(
+    result$result,
+    list(list(answer = 10L), list(answer = 20L))
+  )
+  expect_identical(lifecycle$created, 2L)
+  expect_identical(lifecycle$closed, 2L)
+})
+
+test_that("one-row factory RLM datasets keep the simple result shape", {
+  skip_if_not_installed("callr")
+  module <- rlm_module(
+    "question -> answer: integer",
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_llm_calls = 0L
+  )
+  chat <- create_mock_rlm_llm(list(list(
+    reasoning = "Return one value",
+    code = "SUBMIT(7L)"
+  )))
+
+  result <- run_dataset(
+    module,
+    data.frame(question = "one"),
+    .llm = chat,
+    .progress = FALSE
+  )
+
+  expect_identical(result$result, list(7L))
+})
+
+test_that("run_dataset reuses a caller-owned RLM runner sequentially by row", {
+  skip_if_not_installed("callr")
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  chat_class <- R6::R6Class(
+    "RLMCallerOwnedDatasetChat",
+    public = list(
+      chat_structured = function(...) {
+        list(
+          reasoning = "Return this row",
+          code = "SUBMIT(.context$question)"
+        )
+      },
+      chat = function(...) {
+        stop("recursive queries are disabled", call. = FALSE)
+      },
+      get_model = function() "caller-owned-dataset-test"
+    ),
+    cloneable = TRUE
+  )
+  chat <- chat_class$new()
+  class(chat) <- c("Chat", class(chat))
+  module <- rlm_module(
+    "question -> answer: string",
+    runner = runner,
+    max_llm_calls = 0L
+  )
+
+  result <- run_dataset(
+    module,
+    data.frame(question = c("first", "second")),
+    .llm = chat,
+    .progress = FALSE
+  )
+
+  expect_identical(result$result, list("first", "second"))
+  expect_error(
+    run_dataset(
+      module,
+      data.frame(question = c("first", "second")),
+      .llm = chat,
+      .concurrency = concurrency_control(backend = "mirai", max_active = 2L),
+      .progress = FALSE
+    ),
+    class = "dsprrr_batch_unsupported_module"
+  )
+})
+
+test_that("rlm rejects conflicting execution ownership", {
+  skip_if_not_installed("callr")
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
+
+  expect_error(
+    rlm(
+      "question -> answer",
+      question = "unused",
+      .runner = runner,
+      .interpreter_factory = function() r_code_runner(persistent = TRUE)
+    ),
+    class = "dsprrr_interpreter_binding_error"
+  )
+})
+
+test_that("rlm constructs its managed default lazily and forwards run controls", {
+  captured <- new.env(parent = emptyenv())
+  testthat::local_mocked_bindings(
+    rlm_module = function(...) {
+      captured$module <- list(...)
+      structure(list(), class = "mock_rlm_module")
+    },
+    run = function(module, ...) {
+      captured$run <- list(module = module, arguments = list(...))
+      "result"
+    },
+    mcp_repl_runner = function(...) {
+      captured$mcp <- list(...)
+      "managed runner"
+    },
+    .package = "dsprrr"
+  )
+
+  result <- rlm(
+    "question -> answer",
+    question = "inspect",
+    .llm = "chat",
+    .timeout = 17,
+    .max_output_chars = 321L,
+    .return_format = "structured"
+  )
+
+  expect_identical(result, "result")
+  expect_null(captured$module$runner)
+  expect_null(captured$mcp)
+  expect_identical(captured$run$arguments$question, "inspect")
+  expect_identical(captured$run$arguments$.return_format, "structured")
+  expect_identical(captured$module$interpreter_factory(), "managed runner")
+  expect_identical(captured$mcp, list(timeout = 17, max_output_chars = 321L))
+})
+
 test_that("rlm_module requires runner", {
   expect_error(
     rlm_module("question -> answer"),
@@ -70,7 +323,8 @@ test_that("rlm_module validates runner type", {
 test_that("rlm_module creates RLMModule", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module("question -> answer", runner = runner)
 
   expect_s3_class(rlm, "RLMModule")
@@ -80,16 +334,49 @@ test_that("rlm_module creates RLMModule", {
 test_that("rlm_module accepts string signature", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module("document, question -> answer", runner = runner)
 
   expect_equal(length(rlm$signature@inputs), 2)
 })
 
+test_that("rlm_module rejects opaque JSON Schema outputs before execution", {
+  schema_type <- ellmer::TypeJsonSchema(
+    json = list(
+      type = "object",
+      properties = list(n = list(type = "integer")),
+      required = list("n"),
+      additionalProperties = FALSE
+    )
+  )
+  sig <- signature(
+    inputs = list(input("question")),
+    output_type = schema_type
+  )
+  runner <- list(
+    execute = function(...) stop("must not execute"),
+    policy = function() {
+      list(
+        backend = "test",
+        trust = "test-only",
+        sandboxed = TRUE,
+        persistent = TRUE
+      )
+    }
+  )
+
+  expect_error(
+    rlm_module(sig, runner = runner),
+    class = "dsprrr_rlm_json_schema_unsupported"
+  )
+})
+
 test_that("rlm_module accepts Signature object", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   sig <- signature("question -> answer")
   rlm <- rlm_module(sig, runner = runner)
 
@@ -99,9 +386,10 @@ test_that("rlm_module accepts Signature object", {
 test_that("rlm_module respects max_iterations", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
-    "question -> answer",
+    "question -> answer: integer",
     runner = runner,
     max_iterations = 10
   )
@@ -111,7 +399,8 @@ test_that("rlm_module respects max_iterations", {
 
 test_that("rlm_module accepts the DSPy 3.3 max_iters alias", {
   skip_if_not_installed("callr")
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
 
   rlm <- rlm_module("question -> answer", runner = runner, max_iters = 7L)
 
@@ -130,7 +419,8 @@ test_that("rlm_module accepts the DSPy 3.3 max_iters alias", {
 test_that("rlm_module preserves pre-alias positional argument order", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner,
@@ -147,7 +437,8 @@ test_that("rlm_module preserves pre-alias positional argument order", {
 test_that("rlm_module respects max_llm_calls", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner,
@@ -160,7 +451,8 @@ test_that("rlm_module respects max_llm_calls", {
 test_that("rlm_module validates tools parameter", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
 
   # Must be a list
   expect_error(
@@ -182,7 +474,8 @@ test_that("rlm_module validates tools parameter", {
 test_that("rlm_module validates all tools are functions", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
 
   # Non-function in tools list
   expect_error(
@@ -208,7 +501,8 @@ test_that("rlm_module validates all tools are functions", {
 test_that("rlm_module validates tool names", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
 
   expect_error(
     rlm_module(
@@ -294,7 +588,8 @@ test_that("rlm_module validates tool names", {
 
 test_that("RLMModule constructor also enforces tool and signature contracts", {
   skip_if_not_installed("callr")
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
 
   expect_error(
     signature("question, question -> answer"),
@@ -316,7 +611,8 @@ test_that("RLMModule constructor also enforces tool and signature contracts", {
 test_that("rlm_module validates max_iterations bounds", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
 
   expect_error(
     rlm_module("question -> answer", runner = runner, max_iterations = 0),
@@ -340,7 +636,8 @@ test_that("rlm_module validates max_iterations bounds", {
 test_that("rlm_module validates max_llm_calls bounds", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
 
   expect_error(
     rlm_module("question -> answer", runner = runner, max_llm_calls = -1),
@@ -360,7 +657,8 @@ test_that("rlm_module validates max_llm_calls bounds", {
 
 test_that("rlm_module validates output bounds at both construction layers", {
   skip_if_not_installed("callr")
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
 
   expect_error(
     rlm_module("question -> answer", runner = runner, max_output_chars = 0),
@@ -383,7 +681,8 @@ test_that("rlm_module validates output bounds at both construction layers", {
 test_that("RLMModule has correct fields", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module("question -> answer", runner = runner)
 
   expect_true(!is.null(rlm$runner))
@@ -398,7 +697,8 @@ test_that("RLMModule has correct fields", {
 test_that("RLMModule get_repl_history returns list", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module("question -> answer", runner = runner)
 
   history <- rlm$get_repl_history()
@@ -410,7 +710,8 @@ test_that("RLMModule get_repl_history returns list", {
 test_that("RLMModule reset_copy creates fresh module", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner,
@@ -427,7 +728,8 @@ test_that("RLMModule reset_copy creates fresh module", {
 test_that("RLMModule print works", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module("question -> answer", runner = runner)
 
   expect_invisible(print(rlm))
@@ -440,9 +742,10 @@ test_that("RLMModule print works", {
 test_that("RLMModule terminates on SUBMIT call", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
-    "question -> answer",
+    "question -> answer: integer",
     runner = runner
   )
 
@@ -467,8 +770,9 @@ test_that("RLMModule terminates on SUBMIT call", {
 
 test_that("RLMModule rejects unexpected invocation inputs", {
   skip_if_not_installed("callr")
-  runner <- r_code_runner(timeout = 5)
-  rlm <- rlm_module("question -> answer", runner = runner)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
+  rlm <- rlm_module("question -> answer: integer", runner = runner)
 
   expect_error(
     rlm$forward(list(question = "q", ignored = "unsafe")),
@@ -484,7 +788,9 @@ test_that("RLMModule accepts an instruction-only zero-input signature", {
     output_type = ellmer::type_object(answer = ellmer::type_string()),
     instructions = "Return a greeting."
   )
-  rlm <- rlm_module(sig, runner = r_code_runner(timeout = 5))
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
+  rlm <- rlm_module(sig, runner = runner)
   result <- rlm$forward(
     list(),
     .llm = create_mock_rlm_llm(list(list(
@@ -499,7 +805,8 @@ test_that("RLMModule accepts an instruction-only zero-input signature", {
 test_that("RLMModule SUBMIT returns correct value", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner
@@ -524,9 +831,18 @@ test_that("RLMModule SUBMIT returns correct value", {
 test_that("RLMModule SUBMIT works with complex values", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
-    "question -> answer",
+    signature(
+      inputs = list(input("question")),
+      output_type = ellmer::type_object(
+        answer = ellmer::type_object(
+          value = ellmer::type_number(),
+          unit = ellmer::type_string()
+        )
+      )
+    ),
     runner = runner
   )
 
@@ -549,8 +865,9 @@ test_that("RLMModule SUBMIT works with complex values", {
 test_that("RLMModule strips markdown code fences before execution", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
-  rlm <- rlm_module("question -> answer", runner = runner)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  rlm <- rlm_module("question -> answer: integer", runner = runner)
 
   mock_llm <- create_mock_rlm_llm(list(
     list(
@@ -570,7 +887,8 @@ test_that("RLMModule strips markdown code fences before execution", {
 test_that("RLMModule supports multi-output SUBMIT with named arguments", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer, confidence: number",
     runner = runner
@@ -595,7 +913,8 @@ test_that("RLMModule supports multi-output SUBMIT with named arguments", {
 test_that("RLMModule supports multi-output SUBMIT with positional arguments", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer, confidence: number",
     runner = runner
@@ -620,7 +939,8 @@ test_that("RLMModule supports multi-output SUBMIT with positional arguments", {
 test_that("RLMModule retries after invalid multi-output SUBMIT payload", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer, confidence: number",
     runner = runner,
@@ -655,7 +975,8 @@ test_that("RLMModule retries after invalid multi-output SUBMIT payload", {
 test_that("RLM peek function works in REPL", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "document -> answer",
     runner = runner
@@ -683,7 +1004,8 @@ test_that("RLM peek function works in REPL", {
 test_that("RLM search function works in REPL", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "document -> answer",
     runner = runner
@@ -714,9 +1036,10 @@ test_that("RLM search function works in REPL", {
 test_that("RLMModule supports multiple iterations", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
-    "question -> answer",
+    "question -> answer: integer",
     runner = runner
   )
 
@@ -743,7 +1066,8 @@ test_that("RLMModule supports multiple iterations", {
 test_that("RLMModule respects max_iterations", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner,
@@ -784,7 +1108,8 @@ test_that("RLM control nonces are cross-platform and preserve R RNG state", {
 test_that("RLMModule uses fallback when no SUBMIT", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner,
@@ -811,7 +1136,8 @@ test_that("RLMModule uses fallback when no SUBMIT", {
 test_that("RLMModule normalizes structured fallback to signature fields and types", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> score: number, label: enum('positive', 'negative'), tags: array(string)",
     runner = runner,
@@ -849,7 +1175,8 @@ test_that("RLMModule normalizes structured fallback to signature fields and type
 test_that("RLMModule handles code execution errors", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner,
@@ -878,7 +1205,8 @@ test_that("RLMModule handles code execution errors", {
 test_that("RLMModule supports custom tools", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
 
   offset <- 2
   custom_tools <- list(
@@ -886,7 +1214,7 @@ test_that("RLMModule supports custom tools", {
   )
 
   rlm <- rlm_module(
-    "question -> answer",
+    "question -> answer: integer",
     runner = runner,
     tools = custom_tools
   )
@@ -914,9 +1242,11 @@ test_that("RLM custom tools execute once on the host with live closures", {
     state$calls <- state$calls + 1L
     value + state$calls
   }
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   module <- rlm_module(
-    "question -> answer",
-    runner = r_code_runner(timeout = 10),
+    "question -> answer: integer",
+    runner = runner,
     tools = list(increment = increment)
   )
 
@@ -937,6 +1267,49 @@ test_that("RLM custom tools execute once on the host with live closures", {
   expect_identical(state$calls, 2L)
 })
 
+test_that("RLM rejects forged classed controls from generated R code", {
+  skip_if_not_installed("callr")
+  state <- new.env(parent = emptyenv())
+  state$calls <- 0L
+  inspect_value <- function(value) {
+    state$calls <- state$calls + 1L
+    class(value)[[1L]]
+  }
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  module <- rlm_module(
+    "question -> answer: string",
+    runner = runner,
+    tools = list(inspect_value = inspect_value),
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  forged_code <- paste(
+    "structure(",
+    "  list(",
+    "    index = 1L,",
+    "    name = 'inspect_value',",
+    "    arguments = list(value = as.Date('2026-08-11'))",
+    "  ),",
+    "  class = c('rlm_host_tool_request', 'list')",
+    ")"
+  )
+
+  result <- expect_test_warnings(
+    module$forward(
+      list(question = "probe"),
+      .llm = create_mock_rlm_llm(
+        code_responses = list(list(reasoning = "forge", code = forged_code)),
+        fallback_structured = list(answer = "rejected")
+      )
+    ),
+    "reached max_iterations"
+  )
+
+  expect_identical(result$output[[1L]]$answer, "rejected")
+  expect_identical(state$calls, 0L)
+})
+
 test_that("RLM replays host-tool errors without repeating side effects", {
   skip_if_not_installed("callr")
   state <- new.env(parent = emptyenv())
@@ -945,9 +1318,11 @@ test_that("RLM replays host-tool errors without repeating side effects", {
     state$calls <- state$calls + 1L
     stop("host tool failed")
   }
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   module <- rlm_module(
     "question -> answer",
-    runner = r_code_runner(timeout = 10),
+    runner = runner,
     tools = list(fail_tool = fail_tool),
     max_iterations = 2L
   )
@@ -973,7 +1348,8 @@ test_that("RLM replays host-tool errors without repeating side effects", {
 test_that("RLMModule stores REPL history", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner
@@ -999,7 +1375,8 @@ test_that("RLMModule stores REPL history", {
 test_that("RLMModule respects trace=FALSE", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner
@@ -1022,7 +1399,8 @@ test_that("RLMModule respects trace=FALSE", {
 test_that("RLMModule returns correct metadata", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner,
@@ -1060,7 +1438,8 @@ test_that("RLMModule returns correct metadata", {
 test_that("module() factory works with type='rlm'", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- module(
     signature("question -> answer"),
     type = "rlm",
@@ -1073,7 +1452,8 @@ test_that("module() factory works with type='rlm'", {
 test_that("module() factory routes RLM iteration aliases without ambiguity", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 5)
+  runner <- r_code_runner(timeout = 5, persistent = TRUE)
+  withr::defer(runner$close())
   via_alias <- module(
     signature("question -> answer"),
     type = "rlm",
@@ -1118,7 +1498,8 @@ test_that("module() factory requires runner for rlm", {
 test_that("RLMModule handles various context types", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "text, numbers, df -> answer",
     runner = runner
@@ -1178,7 +1559,7 @@ test_that("create_rlm_prelude includes peek function", {
     custom_tools = list()
   )
 
-  expect_true(grepl("peek <- function", prelude, fixed = TRUE))
+  expect_true(grepl("peek <- base::local", prelude, fixed = TRUE))
 })
 
 test_that("create_rlm_prelude includes search function", {
@@ -1227,7 +1608,7 @@ test_that("create_rlm_prelude requests host tools without deparsing them", {
     custom_tools = custom_tools
   )
 
-  expect_match(prelude, "Authenticated host-tool replay bridge", fixed = TRUE)
+  expect_match(prelude, "Non-local host-tool replay bridge", fixed = TRUE)
   expect_match(prelude, ".name <- \"my_tool\"", fixed = TRUE)
   expect_match(prelude, ".name <- \"another_tool\"", fixed = TRUE)
   expect_false(grepl("function(x) x * 2", prelude, fixed = TRUE))
@@ -1236,7 +1617,8 @@ test_that("create_rlm_prelude requests host tools without deparsing them", {
 test_that("create_rlm_prelude enforces multi-output SUBMIT shape", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   control_nonce <- "submit-shape-test"
   prelude <- dsprrr:::create_rlm_prelude(
     max_llm_calls = 50,
@@ -1250,8 +1632,8 @@ test_that("create_rlm_prelude enforces multi-output SUBMIT shape", {
     paste0(prelude, "\nSUBMIT('ok', 0.9)"),
     context = list()
   )
-  expect_true(ok$success)
-  decoded <- dsprrr:::decode_rlm_control(ok$result, control_nonce)
+  expect_false(ok$success)
+  decoded <- dsprrr:::decode_rlm_control(ok$error, control_nonce)
   expect_true(dsprrr:::is_rlm_final(decoded))
   expect_equal(
     names(dsprrr:::extract_rlm_final(decoded)),
@@ -1284,16 +1666,12 @@ test_that("long authenticated control frames round-trip without whitespace", {
     control_nonce = nonce,
     control_frame_limit = 20000
   )
-  result <- r_code_runner(timeout = 10)$execute(
+  result <- r_code_runner(timeout = 10, persistent = TRUE)$execute(
     paste0(prelude, "\nSUBMIT(base::strrep('x', 5000L))")
   )
-  control <- dsprrr:::normalize_rlm_control_value(
-    result$result,
-    result$stdout,
-    control_nonce = nonce
-  )
+  control <- dsprrr:::decode_rlm_control(result$error, nonce)
 
-  expect_true(result$success)
+  expect_false(result$success)
   expect_true(dsprrr:::is_rlm_final(control))
   expect_identical(
     dsprrr:::extract_rlm_final(control)$answer,
@@ -1303,7 +1681,8 @@ test_that("long authenticated control frames round-trip without whitespace", {
 
 test_that("RLM control frames preserve long multiline unicode payloads", {
   skip_if_not_installed("callr")
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   control_nonce <- "long-payload-test"
   prelude <- dsprrr:::create_rlm_prelude(
     has_sub_lm = FALSE,
@@ -1318,23 +1697,24 @@ test_that("RLM control frames preserve long multiline unicode payloads", {
     paste0(prelude, "\nSUBMIT(", encodeString(answer, quote = "\""), ")"),
     context = list()
   )
-  decoded <- dsprrr:::decode_rlm_control(result$result, control_nonce)
+  decoded <- dsprrr:::decode_rlm_control(result$error, control_nonce)
 
-  expect_true(result$success)
+  expect_false(result$success)
   expect_true(dsprrr:::is_rlm_final(decoded))
   expect_identical(dsprrr:::extract_rlm_final(decoded)$answer, answer)
 })
 
 test_that("RLM control frames authenticate and fail closed", {
   skip_if_not_installed("callr")
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   prelude <- dsprrr:::create_rlm_prelude(
     control_nonce = "one-invocation"
   )
   encoded <- runner$execute(
     paste0(prelude, "\nSUBMIT('ok')"),
     context = list()
-  )$result
+  )$error
 
   expect_null(dsprrr:::decode_rlm_control(encoded, "another-invocation"))
 
@@ -1344,7 +1724,7 @@ test_that("RLM control frames authenticate and fail closed", {
   old_encoded <- runner$execute(
     paste0(old_prelude, "\nSUBMIT('stale')"),
     context = list()
-  )$result
+  )$error
   selected <- dsprrr:::decode_rlm_control(
     paste(old_encoded, encoded, sep = "\n"),
     "one-invocation"
@@ -1404,7 +1784,7 @@ test_that("RLM never accepts control values from failed execution", {
     program <- rlm_module(
       "question -> answer",
       runner = runner,
-      sub_lm = list()
+      sub_lm = list(chat = function(prompt) "unused")
     )
     call_counter <- new.env(parent = emptyenv())
     call_counter$count <- 0L
@@ -1414,7 +1794,10 @@ test_that("RLM never accepts control values from failed execution", {
       inputs = list(question = "test"),
       call_counter = call_counter,
       runner = runner,
-      runner_policy = runner$policy()
+      runner_policy = runner$policy(),
+      sub_lm = program$sub_lm,
+      context_prepared = FALSE,
+      session_state_id = paste0("failed-control-", kind)
     )
 
     expect_false(result$success, info = kind)
@@ -1476,7 +1859,8 @@ test_that("extract_rlm_final removes rlm_final class", {
 test_that("RLMModule warns when max_iterations reached without SUBMIT", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner,
@@ -1498,7 +1882,8 @@ test_that("RLMModule warns when max_iterations reached without SUBMIT", {
 test_that("RLMModule handles LLM response with missing code", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner
@@ -1523,7 +1908,8 @@ test_that("RLMModule handles LLM response with missing code", {
 test_that("RLMModule handles LLM response with non-string code", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner
@@ -1585,7 +1971,8 @@ test_that("is_rlm_query_request detects query requests", {
 test_that("rlm_query_batch generates batch request marker", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   control_nonce <- "query-batch-test"
 
   # Execute prelude in subprocess to test rlm_query_batch
@@ -1601,8 +1988,8 @@ test_that("rlm_query_batch generates batch request marker", {
     context = list()
   )
 
-  expect_true(result$success)
-  request <- dsprrr:::decode_rlm_control(result$result, control_nonce)
+  expect_false(result$success)
+  request <- dsprrr:::decode_rlm_control(result$error, control_nonce)
   expect_s3_class(request, "rlm_query_request")
   expect_true(request$batch)
   expect_equal(request$queries, c("q1", "q2"))
@@ -1611,7 +1998,8 @@ test_that("rlm_query_batch generates batch request marker", {
 test_that("rlm_query_batch preserves one-query arrays", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   control_nonce <- "query-singleton-test"
   prelude <- dsprrr:::create_rlm_prelude(
     max_llm_calls = 50,
@@ -1628,8 +2016,8 @@ test_that("rlm_query_batch preserves one-query arrays", {
     context = list()
   )
 
-  expect_identical(result$success, TRUE)
-  request <- dsprrr:::decode_rlm_control(result$result, control_nonce)
+  expect_identical(result$success, FALSE)
+  request <- dsprrr:::decode_rlm_control(result$error, control_nonce)
   expect_s3_class(request, "rlm_query_request")
   expect_identical(request$queries, "q1")
   expect_identical(request$slices, "context")
@@ -1648,7 +2036,8 @@ test_that("rlm_query_batch preserves one-query arrays", {
   call_counter$count <- 0L
   processed <- rlm$.__enclos_env__$private$process_rlm_query_batch(
     request,
-    call_counter
+    call_counter,
+    sub_lm
   )
 
   expect_identical(
@@ -1661,7 +2050,8 @@ test_that("rlm_query_batch preserves one-query arrays", {
 test_that("rlm_query_batch rejects non-scalar context slices", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   control_nonce <- "query-slice-shape-test"
   prelude <- dsprrr:::create_rlm_prelude(
     has_sub_lm = TRUE,
@@ -1712,7 +2102,8 @@ test_that("rlm_query_batch rejects non-scalar context slices", {
 
 test_that("rlm_query_batch preserves empty batches and rejects missing queries", {
   skip_if_not_installed("callr")
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   control_nonce <- "query-cardinality-test"
   prelude <- dsprrr:::create_rlm_prelude(
     has_sub_lm = TRUE,
@@ -1723,7 +2114,7 @@ test_that("rlm_query_batch preserves empty batches and rejects missing queries",
     paste0(prelude, "\nllm_query_batched(character())"),
     context = list()
   )
-  request <- dsprrr:::decode_rlm_control(empty$result, control_nonce)
+  request <- dsprrr:::decode_rlm_control(empty$error, control_nonce)
   expect_s3_class(request, "rlm_query_request")
   expect_identical(request$queries, character())
 
@@ -1732,7 +2123,7 @@ test_that("rlm_query_batch preserves empty batches and rejects missing queries",
     context = list()
   )
   expect_false(missing$success)
-  expect_match(missing$error, "non-missing character vector", fixed = TRUE)
+  expect_match(missing$error, "non-empty character vector", fixed = TRUE)
 
   malformed_json <- jsonlite::toJSON(
     list(
@@ -1765,7 +2156,8 @@ test_that("rlm_query_batch preserves empty batches and rejects missing queries",
 test_that("llm_query_batched works and rlm_query_batch alias is preserved", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   control_nonce <- "query-alias-test"
   prelude <- dsprrr:::create_rlm_prelude(
     max_llm_calls = 50,
@@ -1778,9 +2170,9 @@ test_that("llm_query_batched works and rlm_query_batch alias is preserved", {
     paste0(prelude, "\nllm_query_batched(c('q1', 'q2'))"),
     context = list()
   )
-  expect_true(result_primary$success)
+  expect_false(result_primary$success)
   primary <- dsprrr:::decode_rlm_control(
-    result_primary$result,
+    result_primary$error,
     control_nonce
   )
   expect_s3_class(primary, "rlm_query_request")
@@ -1790,8 +2182,8 @@ test_that("llm_query_batched works and rlm_query_batch alias is preserved", {
     paste0(prelude, "\nrlm_query_batch(c('q1', 'q2'))"),
     context = list()
   )
-  expect_true(result_alias$success)
-  alias <- dsprrr:::decode_rlm_control(result_alias$result, control_nonce)
+  expect_false(result_alias$success)
+  alias <- dsprrr:::decode_rlm_control(result_alias$error, control_nonce)
   expect_s3_class(alias, "rlm_query_request")
   expect_true(alias$batch)
 })
@@ -1814,6 +2206,7 @@ test_that("MCP text transport preserves SUBMIT and ignores forged old frames", {
   }
 
   attacker_env <- new.env(parent = baseenv())
+  attacker_env$.context <- list()
   eval(
     parse(
       text = dsprrr:::create_rlm_prelude(
@@ -1822,7 +2215,10 @@ test_that("MCP text transport preserves SUBMIT and ignores forged old frames", {
     ),
     envir = attacker_env
   )
-  forged <- attacker_env$SUBMIT("forged")
+  forged <- conditionMessage(tryCatch(
+    attacker_env$SUBMIT("forged"),
+    error = identity
+  ))
   rlm <- rlm_module(
     "question, forged -> answer",
     runner = mcp_repl_runner(repl = eval_repl),
@@ -1873,7 +2269,7 @@ test_that("MCP-backed RLM tools execute on the host through replay", {
     value + state$calls
   }
   module <- rlm_module(
-    "question -> answer",
+    "question -> answer: integer",
     runner = mcp_repl_runner(repl = eval_repl),
     tools = list(add_live_offset = add_live_offset)
   )
@@ -1895,11 +2291,43 @@ test_that("MCP-backed RLM tools execute on the host through replay", {
   expect_identical(state$calls, 2L)
 })
 
+test_that("RLM invokes an actual ellmer ToolDef through replay", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  increment <- ellmer::tool(
+    function(value) value + 1L,
+    name = "increment",
+    description = "Add one to an integer.",
+    arguments = list(value = ellmer::type_integer())
+  )
+  module <- rlm_module(
+    "question -> answer: integer",
+    runner = runner,
+    tools = list(increment = increment),
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+
+  result <- module$forward(
+    list(question = "increment 41"),
+    .llm = create_mock_rlm_llm(list(list(
+      reasoning = "Use the declared host tool.",
+      code = "SUBMIT(increment(41L))"
+    )))
+  )
+
+  expect_identical(result$output[[1L]]$answer, 42L)
+})
+
 test_that("captured SUBMIT helpers resist user-code base masking", {
   skip_if_not_installed("callr")
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
-    runner = r_code_runner(timeout = 10)
+    runner = runner
   )
   llm <- create_mock_rlm_llm(list(list(
     reasoning = "Mask common names after prelude creation",
@@ -1920,7 +2348,8 @@ test_that("captured SUBMIT helpers resist user-code base masking", {
 test_that("rlm_query_batch validates queries is character", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
 
   prelude <- dsprrr:::create_rlm_prelude(
     max_llm_calls = 50,
@@ -1940,7 +2369,8 @@ test_that("rlm_query_batch validates queries is character", {
 test_that("rlm_query_batch validates slices length", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
 
   prelude <- dsprrr:::create_rlm_prelude(
     max_llm_calls = 50,
@@ -1957,14 +2387,220 @@ test_that("rlm_query_batch validates slices length", {
   expect_true(grepl("same length", result$error, fixed = TRUE))
 })
 
+test_that("recursive queries count every provider assistant turn", {
+  make_chat <- function(initial_turns = list()) {
+    turns <- initial_turns
+    chat <- NULL
+    chat <- list(
+      clone = function(...) make_chat(turns),
+      set_turns = function(value) {
+        turns <<- value
+        invisible(NULL)
+      },
+      get_turns = function(...) turns,
+      chat = function(prompt, ...) {
+        turns <<- c(
+          turns,
+          list(
+            ellmer::UserTurn(prompt),
+            ellmer::AssistantTurn(
+              contents = list(ellmer::ContentText("tool request")),
+              tokens = c(10L, 1L, 0L),
+              cost = 0.11,
+              duration = 0.4
+            ),
+            ellmer::AssistantTurn(
+              contents = list(ellmer::ContentText("final")),
+              tokens = c(20L, 2L, 0L),
+              cost = 0.22,
+              duration = 0.6
+            )
+          )
+        )
+        "final"
+      }
+    )
+    chat
+  }
+  sub_lm <- make_chat(list(ellmer::UserTurn("private prior turn")))
+  rlm <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() stop("not used"),
+    sub_lm = sub_lm
+  )
+  call_counter <- new.env(parent = emptyenv())
+  call_counter$count <- 0L
+
+  result <- rlm$.__enclos_env__$private$process_rlm_query(
+    list(query = "question", context = NULL, batch = FALSE),
+    call_counter,
+    sub_lm
+  )
+
+  expect_identical(result$value, "final")
+  expect_identical(call_counter$count, 1L)
+  expect_identical(call_counter$provider_calls, 2L)
+  expect_identical(call_counter$provider_calls_known, TRUE)
+  expect_identical(call_counter$usage[[1L]]$input_tokens, 30L)
+  expect_identical(call_counter$usage[[1L]]$output_tokens, 3L)
+  expect_identical(call_counter$usage[[1L]]$total_tokens, 33L)
+  expect_equal(call_counter$usage[[1L]]$cost, 0.33)
+})
+
+test_that("recursive provider errors leave call and usage accounting unknown", {
+  turns <- list()
+  failed <- NULL
+  failed <- list(
+    clone = function(...) failed,
+    set_turns = function(value) {
+      turns <<- value
+      invisible(NULL)
+    },
+    get_turns = function(...) turns,
+    chat = function(prompt, ...) {
+      turns <<- c(
+        turns,
+        list(ellmer::AssistantTurn(
+          contents = list(ellmer::ContentText("partial")),
+          tokens = c(10L, 1L, 0L),
+          cost = 0.1
+        ))
+      )
+      error <- simpleError("provider stopped")
+      class(error) <- c("dsprrr_rlm_provider_error", class(error))
+      stop(error)
+    }
+  )
+  rlm <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() stop("not used"),
+    sub_lm = failed
+  )
+  call_counter <- new.env(parent = emptyenv())
+  call_counter$count <- 0L
+
+  result <- suppressWarnings(
+    rlm$.__enclos_env__$private$process_rlm_query(
+      list(query = "question", context = NULL, batch = FALSE),
+      call_counter,
+      failed
+    )
+  )
+
+  expect_false(result$success)
+  expect_identical(call_counter$count, 1L)
+  expect_identical(call_counter$provider_calls, 0L)
+  expect_identical(call_counter$provider_calls_known, FALSE)
+  expect_true(is.na(call_counter$usage[[1L]]$provider_calls))
+  expect_true(is.na(call_counter$usage[[1L]]$total_tokens))
+  expect_true(is.na(call_counter$usage[[1L]]$cost))
+})
+
+test_that("parallel recursive accounting uses the cleared batch baseline", {
+  original_turns <- list(ellmer::UserTurn("private prior turn"))
+  make_template <- function(turns = list()) {
+    chat <- NULL
+    chat <- list(
+      clone = function(...) make_template(turns),
+      set_turns = function(value) {
+        turns <<- value
+        invisible(NULL)
+      },
+      get_turns = function(...) turns,
+      chat = function(prompt, ...) "unused"
+    )
+    chat
+  }
+  sub_lm <- make_template(original_turns)
+  make_result <- function(text, usage) {
+    turns <- c(
+      list(ellmer::UserTurn("current")),
+      lapply(seq_along(usage), function(i) {
+        item <- usage[[i]]
+        ellmer::AssistantTurn(
+          contents = list(ellmer::ContentText(
+            if (i == length(usage)) text else "tool request"
+          )),
+          tokens = item$tokens,
+          cost = item$cost,
+          duration = item$duration
+        )
+      })
+    )
+    list(
+      get_turns = function(...) turns,
+      last_turn = function(...) turns[[length(turns)]]
+    )
+  }
+  rlm <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() stop("not used"),
+    sub_lm = sub_lm
+  )
+  call_counter <- new.env(parent = emptyenv())
+  call_counter$count <- 0L
+  captured <- new.env(parent = emptyenv())
+
+  result <- with_mock_parallel_chat(
+    function(
+      chat,
+      prompts,
+      max_active = 10,
+      rpm = 500,
+      on_error = c("return", "continue", "stop")
+    ) {
+      captured$baseline <- chat$get_turns()
+      list(
+        make_result(
+          "first",
+          list(
+            list(tokens = c(10L, 1L, 0L), cost = 0.11, duration = 0.4),
+            list(tokens = c(20L, 2L, 0L), cost = 0.22, duration = 0.6)
+          )
+        ),
+        make_result(
+          "second",
+          list(
+            list(tokens = c(5L, 1L, 0L), cost = 0.05, duration = 0.2)
+          )
+        )
+      )
+    },
+    rlm$.__enclos_env__$private$process_rlm_query_batch(
+      list(
+        queries = c("q1", "q2"),
+        slices = NULL,
+        batch = TRUE
+      ),
+      call_counter,
+      sub_lm
+    )
+  )
+
+  expect_identical(captured$baseline, list())
+  expect_identical(result$value, c("first", "second"))
+  expect_identical(call_counter$count, 2L)
+  expect_identical(call_counter$provider_calls, 3L)
+  expect_identical(call_counter$provider_calls_known, TRUE)
+  expect_identical(
+    vapply(call_counter$usage, `[[`, integer(1), "provider_calls"),
+    c(2L, 1L)
+  )
+  expect_identical(
+    vapply(call_counter$usage, `[[`, integer(1), "total_tokens"),
+    c(33L, 6L)
+  )
+})
+
 test_that("process_rlm_query_batch uses bounded parallelism and preserves order", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   rlm <- rlm_module(
     "question -> answer",
     runner = runner,
-    sub_lm = list()
+    sub_lm = list(chat = function(prompt) "unused")
   )
 
   call_counter <- new.env(parent = emptyenv())
@@ -1975,6 +2611,10 @@ test_that("process_rlm_query_batch uses bounded parallelism and preserves order"
   make_fake_chat <- function(text) {
     list(last_turn = function() list(text = text))
   }
+  provider_error <- structure(
+    simpleError("boom"),
+    class = c("dsprrr_rlm_provider_error", class(simpleError("boom")))
+  )
 
   withr::local_options(list(dsprrr.rlm_batch_max_active = 2L))
   warning_message <- NULL
@@ -1992,11 +2632,15 @@ test_that("process_rlm_query_batch uses bounded parallelism and preserves order"
         captured$on_error <- on_error
         list(
           make_fake_chat("first"),
-          simpleError("boom"),
+          provider_error,
           make_fake_chat("third")
         )
       },
-      rlm$.__enclos_env__$private$process_rlm_query_batch(request, call_counter)
+      rlm$.__enclos_env__$private$process_rlm_query_batch(
+        request,
+        call_counter,
+        rlm$sub_lm
+      )
     ),
     warning = function(w) {
       warning_message <<- conditionMessage(w)
@@ -2005,29 +2649,40 @@ test_that("process_rlm_query_batch uses bounded parallelism and preserves order"
   )
 
   expect_equal(call_counter$count, 3L)
+  expect_equal(call_counter$provider_calls, 0L)
+  expect_false(call_counter$provider_calls_known)
   expect_equal(captured$max_active, 2L)
   expect_equal(captured$prompts, as.list(c("q1", "q2", "q3")))
-  expect_equal(captured$on_error, "return")
+  expect_equal(captured$on_error, "continue")
   expect_match(warning_message, "Some batch queries failed")
 
-  expect_false(result$success)
-  expect_match(result$error, "Query 2: boom")
+  expect_true(result$success)
+  expect_null(result$error)
+  expect_identical(result$value, c("first", "[ERROR] boom", "third"))
+  expect_match(result$errors, "Query 2: boom")
   expect_match(result$formatted_output, "Query 1 result: first")
-  expect_match(result$formatted_output, "Query 2 result: \\[Error: boom\\]")
+  expect_match(
+    result$formatted_output,
+    "Query 2 result: [ERROR] boom",
+    fixed = TRUE
+  )
   expect_match(result$formatted_output, "Query 3 result: third")
 
   pos1 <- regexpr("Query 1 result: first", result$formatted_output)[1]
-  pos2 <- regexpr("Query 2 result: \\[Error: boom\\]", result$formatted_output)[
-    1
-  ]
+  pos2 <- regexpr(
+    "Query 2 result: [ERROR] boom",
+    result$formatted_output,
+    fixed = TRUE
+  )[1]
   pos3 <- regexpr("Query 3 result: third", result$formatted_output)[1]
   expect_true(pos1 < pos2 && pos2 < pos3)
 })
 
-test_that("process_rlm_query_batch does not retry sequentially after parallel infrastructure failure", {
+test_that("process_rlm_query_batch propagates parallel infrastructure failure", {
   skip_if_not_installed("callr")
 
-  runner <- r_code_runner(timeout = 10)
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
   chat_calls <- 0L
   sub_lm <- list(
     chat = function(prompt, ...) {
@@ -2050,8 +2705,8 @@ test_that("process_rlm_query_batch does not retry sequentially after parallel in
     batch = TRUE
   )
 
-  expect_warning(
-    result <- with_mock_parallel_chat(
+  expect_error(
+    with_mock_parallel_chat(
       function(
         chat,
         prompts,
@@ -2061,27 +2716,19 @@ test_that("process_rlm_query_batch does not retry sequentially after parallel in
       ) {
         stop("parallel unavailable")
       },
-      rlm$.__enclos_env__$private$process_rlm_query_batch(request, call_counter)
+      rlm$.__enclos_env__$private$process_rlm_query_batch(
+        request,
+        call_counter,
+        sub_lm
+      )
     ),
-    "Some batch queries failed"
+    class = "dsprrr_rlm_batch_transport_error"
   )
 
   expect_equal(call_counter$count, 3L)
+  expect_equal(call_counter$provider_calls, 0L)
+  expect_true(call_counter$provider_calls_known)
   expect_equal(chat_calls, 0L)
-  expect_false(result$success)
-  expect_match(result$error, "queries not retried")
-  expect_match(
-    result$formatted_output,
-    "Query 1 result: \\[Error: Parallel batch infrastructure error"
-  )
-  expect_match(
-    result$formatted_output,
-    "Query 2 result: \\[Error: Parallel batch infrastructure error"
-  )
-  expect_match(
-    result$formatted_output,
-    "Query 3 result: \\[Error: Parallel batch infrastructure error"
-  )
 })
 
 test_that("RLM sub-LM responses must contain one non-empty text value", {

--- a/tests/testthat/test-module-rlm.R
+++ b/tests/testthat/test-module-rlm.R
@@ -88,7 +88,9 @@ test_that("rlm forwards structured one-shot results with an explicit runner", {
 
 test_that("run treats every RLM input as one rich context object", {
   skip_if_not_installed("callr")
-  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  # Instrumented coverage runs can spend more than ten seconds starting the
+  # persistent callr session before this rich context is staged.
+  runner <- r_code_runner(timeout = 60, persistent = TRUE)
   withr::defer(runner$close())
   chat <- create_mock_rlm_llm(list(list(
     reasoning = "Verify the staged R objects",

--- a/tests/testthat/test-orchestration.R
+++ b/tests/testthat/test-orchestration.R
@@ -46,7 +46,7 @@ test_that("pin_module_config saves correct structure", {
   config <- pins::pin_read(board, "test-module")
 
   expect_identical(config$format, "dsprrr-program")
-  expect_identical(config$format_version, 4L)
+  expect_identical(config$format_version, 5L)
   expect_named(
     config,
     c(

--- a/tests/testthat/test-r-code-runner.R
+++ b/tests/testthat/test-r-code-runner.R
@@ -8,6 +8,7 @@ test_that("r_code_runner creates RCodeRunner object", {
   expect_s3_class(runner, "RCodeRunner")
   expect_equal(runner$timeout, 5)
   expect_equal(runner$max_output_chars, 100000L)
+  expect_false(runner$persistent)
 })
 
 test_that("RCodeRunner exposes its trust boundary", {
@@ -22,6 +23,7 @@ test_that("RCodeRunner exposes its trust boundary", {
   expect_identical(policy$filesystem_access, "host-user")
   expect_identical(policy$network_access, "host-user")
   expect_identical(policy$pattern_scan, "defense-in-depth")
+  expect_false(policy$persistent)
 })
 
 test_that("code runner protocol supports external sandbox backends", {
@@ -559,4 +561,209 @@ test_that("RCodeRunner isolation - variables don't persist", {
   result2 <- runner$execute("exists('test_var')")
   expect_true(result2$success)
   expect_false(result2$result)
+})
+
+test_that("persistent RCodeRunner preserves execution state", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+
+  expect_true(runner$policy()$persistent)
+  first_pid <- runner$execute("Sys.getpid()")$result
+  first <- runner$execute("counter <- 41L; counter")
+  second <- runner$execute("counter <- counter + 1L; counter")
+  second_pid <- runner$execute("Sys.getpid()")$result
+
+  expect_identical(second_pid, first_pid)
+  expect_true(first$success)
+  expect_identical(first$result, 41L)
+  expect_true(second$success)
+  expect_identical(second$result, 42L)
+
+  guest_error <- runner$execute("counter <- counter + 1L; stop('repair me')")
+  recovered <- runner$execute("counter")
+  expect_false(guest_error$success)
+  expect_identical(guest_error$error_type, "execution")
+  expect_true(guest_error$retryable)
+  expect_true(recovered$success)
+  expect_identical(recovered$result, 43L)
+})
+
+test_that("persistent RCodeRunner preserves structured output capture", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  result <- runner$execute(
+    "cat('out'); cat('err', file = stderr()); message('note'); warning('careful'); 42L"
+  )
+
+  expect_true(result$success)
+  expect_identical(result$result, 42L)
+  expect_identical(result$stdout, "out")
+  expect_identical(result$stderr, "err")
+  expect_match(result$messages, "note")
+  expect_match(result$warnings, "careful")
+})
+
+test_that("persistent RCodeRunner stages base context and overlays dynamic fields", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  marker <- new.env(parent = emptyenv())
+  marker$count <- 0L
+  large_data <- data.frame(
+    id = seq_len(25000L),
+    group = factor(rep(c("a", "b"), length.out = 25000L))
+  )
+
+  prepared <- withVisible(runner$prepare_context(list(
+    data = large_data,
+    label = "base",
+    marker = marker
+  )))
+  expect_true(prepared$value)
+  expect_false(prepared$visible)
+  first <- runner$execute(
+    paste(
+      ".context$marker$count <- .context$marker$count + 1L",
+      "list(",
+      "  is_data_frame = is.data.frame(.context$data),",
+      "  rows = nrow(.context$data),",
+      "  groups = levels(.context$data$group),",
+      "  label = .context$label,",
+      "  step = .context$step,",
+      "  marker_count = .context$marker$count",
+      ")",
+      sep = "\n"
+    ),
+    context = list(label = "dynamic", step = 7L)
+  )
+  second <- runner$execute(
+    "list(label = .context$label, has_step = 'step' %in% names(.context), marker_count = .context$marker$count)"
+  )
+
+  expect_true(first$success)
+  expect_true(first$result$is_data_frame)
+  expect_identical(first$result$rows, 25000L)
+  expect_identical(first$result$groups, c("a", "b"))
+  expect_identical(first$result$label, "dynamic")
+  expect_identical(first$result$step, 7L)
+  expect_identical(first$result$marker_count, 1L)
+  expect_true(second$success)
+  expect_identical(second$result$label, "base")
+  expect_false(second$result$has_step)
+  expect_identical(second$result$marker_count, 1L)
+  expect_identical(marker$count, 0L)
+})
+
+test_that("persistent RCodeRunner reset clears state and staged context", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(
+    timeout = 10,
+    prelude = "from_prelude <- 11L",
+    persistent = TRUE
+  )
+  withr::defer(runner$close())
+  runner$prepare_context(list(base_value = 7L))
+  before <- runner$execute(
+    "transient <- 9L; c(from_prelude, .context$base_value, transient)"
+  )
+
+  expect_true(before$success)
+  expect_identical(before$result, c(11L, 7L, 9L))
+  expect_invisible(runner$reset())
+
+  after <- runner$execute(
+    "list(has_transient = exists('transient', inherits = FALSE), from_prelude = from_prelude, context_length = length(.context))"
+  )
+  expect_true(after$success)
+  expect_false(after$result$has_transient)
+  expect_identical(after$result$from_prelude, 11L)
+  expect_identical(after$result$context_length, 0L)
+})
+
+test_that("persistent RCodeRunner timeout terminalizes and stops its session", {
+  skip_if_not_installed("callr")
+  skip_on_cran()
+
+  runner <- r_code_runner(timeout = 1, persistent = TRUE)
+  withr::defer(runner$close())
+  runner$start()
+  session <- runner$.__enclos_env__$private$session
+  expect_true(session$is_alive())
+
+  result <- runner$execute("Sys.sleep(10); 'done'")
+
+  expect_false(result$success)
+  expect_identical(result$error_type, "interpreter")
+  expect_false(result$retryable)
+  expect_match(result$error, "timed out", ignore.case = TRUE)
+  expect_true(runner$terminal)
+  expect_false(session$is_alive())
+  expect_error(
+    runner$execute("1 + 1"),
+    class = "dsprrr_interpreter_terminal_error"
+  )
+  expect_invisible(runner$close())
+  expect_invisible(runner$close())
+})
+
+test_that("persistent RCodeRunner terminalizes when its subprocess crashes", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  runner$start()
+  session <- runner$.__enclos_env__$private$session
+  crash_code <- paste0(
+    "base::get(\"q\", baseenv())(",
+    "save = \"no\", status = 1, runLast = FALSE)"
+  )
+
+  result <- runner$execute(crash_code)
+
+  expect_false(result$success)
+  expect_identical(result$error_type, "interpreter")
+  expect_false(result$retryable)
+  expect_true(runner$terminal)
+  expect_false(session$is_alive())
+})
+
+test_that("persistent RCodeRunner close tears down its session", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  runner$start()
+  session <- runner$.__enclos_env__$private$session
+  expect_true(session$is_alive())
+
+  expect_invisible(runner$close())
+  expect_true(runner$closed)
+  expect_false(session$is_alive())
+  expect_invisible(runner$close())
+  expect_error(
+    runner$execute("1 + 1"),
+    class = "dsprrr_interpreter_closed_error"
+  )
+})
+
+test_that("prepare_context requires persistent mode and named fields", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10)
+  expect_error(
+    runner$prepare_context(list(value = 1)),
+    class = "dsprrr_r_code_runner_context_error"
+  )
+
+  persistent_runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(persistent_runner$close())
+  expect_error(
+    persistent_runner$prepare_context(list(1)),
+    class = "dsprrr_r_code_runner_context_error"
+  )
 })

--- a/tests/testthat/test-rlm-parity.R
+++ b/tests/testthat/test-rlm-parity.R
@@ -1,0 +1,1116 @@
+# Deterministic end-to-end regressions for the public RLM contract.
+
+new_rlm_parity_chat <- function(
+  actions,
+  query_values = list(),
+  fallback = list(answer = "fallback"),
+  fallback_error = NULL,
+  .state = NULL
+) {
+  if (is.null(.state)) {
+    .state <- new.env(parent = emptyenv())
+    .state$action_index <- 0L
+    .state$query_index <- 0L
+    .state$fallback_calls <- 0L
+    .state$action_prompts <- character()
+    .state$query_prompts <- character()
+    .state$fallback_prompts <- character()
+  }
+  turns <- list()
+
+  record_turns <- function(prompt, response) {
+    turns <<- c(
+      turns,
+      list(
+        ellmer::UserTurn(as.character(prompt)),
+        ellmer::AssistantTurn(
+          contents = list(ellmer::ContentText(as.character(response))),
+          tokens = c(1L, 1L, 0L),
+          cost = 0,
+          duration = 0
+        )
+      )
+    )
+    invisible(NULL)
+  }
+
+  chat <- list(
+    clone = function() {
+      new_rlm_parity_chat(
+        actions = actions,
+        query_values = query_values,
+        fallback = fallback,
+        fallback_error = fallback_error,
+        .state = .state
+      )
+    },
+    chat_structured = function(prompt, type, ...) {
+      fields <- if (
+        inherits(type, "ellmer::TypeObject") &&
+          methods::.hasSlot(type, "properties")
+      ) {
+        names(type@properties)
+      } else {
+        character()
+      }
+
+      if (all(c("reasoning", "code") %in% fields)) {
+        .state$action_index <- .state$action_index + 1L
+        .state$action_prompts <- c(.state$action_prompts, prompt)
+        if (.state$action_index > length(actions)) {
+          stop("No scripted RLM action remains", call. = FALSE)
+        }
+        value <- actions[[.state$action_index]]
+        record_turns(prompt, "action")
+        return(value)
+      }
+
+      .state$fallback_calls <- .state$fallback_calls + 1L
+      .state$fallback_prompts <- c(.state$fallback_prompts, prompt)
+      if (!is.null(fallback_error)) {
+        stop(fallback_error, call. = FALSE)
+      }
+      if (is.function(fallback)) {
+        value <- fallback(prompt, type)
+        record_turns(prompt, "fallback")
+        return(value)
+      }
+      record_turns(prompt, "fallback")
+      fallback
+    },
+    chat = function(prompt, ...) {
+      .state$query_index <- .state$query_index + 1L
+      .state$query_prompts <- c(.state$query_prompts, prompt)
+      if (.state$query_index > length(query_values)) {
+        stop("No scripted recursive-query response remains", call. = FALSE)
+      }
+      value <- query_values[[.state$query_index]]
+      if (inherits(value, "condition")) {
+        stop(value)
+      }
+      record_turns(prompt, value)
+      value
+    },
+    get_turns = function(...) turns,
+    set_turns = function(value) {
+      turns <<- value
+      invisible(NULL)
+    },
+    last_turn = function(role = c("assistant", "user"), ...) {
+      role <- match.arg(role)
+      matching <- Filter(function(turn) identical(turn@role, role), turns)
+      if (length(matching) == 0L) NULL else matching[[length(matching)]]
+    },
+    get_model = function() "rlm-parity-test"
+  )
+  chat$parity_state <- .state
+  chat
+}
+
+capture_rlm_parity_error <- function(expr) {
+  captured <- NULL
+  withCallingHandlers(
+    tryCatch(
+      force(expr),
+      error = function(error) {
+        captured <<- error
+        NULL
+      }
+    ),
+    warning = function(warning) invokeRestart("muffleWarning")
+  )
+  captured
+}
+
+test_that("persistent R runners preserve variables across RLM iterations", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  chat <- new_rlm_parity_chat(list(
+    list(reasoning = "Create a reusable value", code = "seed <- 40L; seed"),
+    list(reasoning = "Use the prior value", code = "SUBMIT(seed + 2L)")
+  ))
+  module <- rlm_module(
+    "question -> answer: integer",
+    runner = runner,
+    max_iterations = 2L,
+    max_llm_calls = 0L
+  )
+
+  result <- module$forward(list(question = "What is the answer?"), .llm = chat)
+
+  expect_identical(result$output[[1L]]$answer, 42L)
+  expect_identical(result$metadata[[1L]]$iterations, 2L)
+  expect_match(result$metadata[[1L]]$repl_history[[1L]]$output, "40")
+  expect_true(result$metadata[[1L]]$repl_history[[2L]]$is_final)
+})
+
+test_that("RLM rejects runners without an explicit persistent capability", {
+  skip_if_not_installed("callr")
+
+  module <- rlm_module(
+    "question -> answer",
+    runner = r_code_runner(persistent = FALSE),
+    max_llm_calls = 0L
+  )
+  chat <- new_rlm_parity_chat(list(list(
+    reasoning = "Should not run",
+    code = "SUBMIT('no')"
+  )))
+
+  expect_error(
+    module$forward(list(question = "test"), .llm = chat),
+    class = "dsprrr_rlm_persistent_runner_error"
+  )
+  expect_identical(chat$parity_state$action_index, 0L)
+})
+
+test_that("caller-owned persistent runners release context and bridge state", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  preexisting <- runner$execute(paste(
+    "search <- 'PREEXISTING-SEARCH'",
+    "domain_lookup <- 'PREEXISTING-TOOL'",
+    sep = "\n"
+  ))
+  expect_true(preexisting$success)
+  secret <- paste0("INVOCATION-SECRET-", strrep("x", 100L))
+  module <- rlm_module(
+    "document -> answer",
+    runner = runner,
+    max_iterations = 1L,
+    max_llm_calls = 0L,
+    tools = list(domain_lookup = function(value) value)
+  )
+  chat <- new_rlm_parity_chat(list(list(
+    reasoning = "Read the staged value",
+    code = "SUBMIT(nchar(.context$document))"
+  )))
+
+  result <- module$forward(list(document = secret), .llm = chat)
+  audit <- runner$execute(paste(
+    "list(",
+    "  state = ls(pattern = '^\\\\.dsprrr_rlm_state_', all.names = TRUE),",
+    "  context = .context,",
+    "  bridge = intersect(",
+    "    c('SUBMIT', 'peek', 'llm_query', 'llm_query_batched',",
+    "      'rlm_query', 'rlm_query_batch', '.rlm_host_tool_call'),",
+    "    ls(all.names = TRUE)",
+    "  ),",
+    "  transient = ls(pattern = '^\\\\.rlm_', all.names = TRUE),",
+    "  preserved = c(search, domain_lookup)",
+    ")",
+    sep = "\n"
+  ))
+
+  expect_identical(result$output[[1L]]$answer, as.character(nchar(secret)))
+  expect_true(audit$success)
+  expect_length(audit$result$state, 0L)
+  expect_length(audit$result$context, 0L)
+  expect_length(audit$result$bridge, 0L)
+  expect_length(audit$result$transient, 0L)
+  expect_identical(
+    unname(audit$result$preserved),
+    c("PREEXISTING-SEARCH", "PREEXISTING-TOOL")
+  )
+  expect_false(grepl(
+    secret,
+    paste(capture.output(str(audit$result)), collapse = "\n"),
+    fixed = TRUE
+  ))
+})
+
+test_that("the outer LM supplies composable recursive-query values", {
+  skip_if_not_installed("callr")
+
+  chat <- new_rlm_parity_chat(
+    actions = list(list(
+      reasoning = "Ask two focused questions and combine their answers",
+      code = paste(
+        "first <- llm_query('first question')",
+        "second <- llm_query('second question')",
+        "combined <- paste(first, second, sep = ' + ')",
+        "SUBMIT(combined)",
+        sep = "\n"
+      )
+    )),
+    query_values = list("alpha", "beta")
+  )
+  module <- rlm_module(
+    "question -> answer: string",
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    sub_lm = NULL,
+    max_iterations = 1L,
+    max_llm_calls = 2L
+  )
+
+  result <- module$forward(list(question = "Combine two answers"), .llm = chat)
+
+  expect_identical(result$output[[1L]]$answer, "alpha + beta")
+  expect_identical(result$metadata[[1L]]$llm_calls, 2L)
+  expect_identical(result$metadata[[1L]]$provider_calls, 3L)
+  expect_identical(chat$parity_state$query_index, 2L)
+  expect_identical(
+    chat$parity_state$query_prompts,
+    c("first question", "second question")
+  )
+  expect_identical(chat$parity_state$action_index, 1L)
+})
+
+test_that("recursive values stay complete while displayed evidence is bounded", {
+  skip_if_not_installed("callr")
+
+  recursive_value <- paste0("HEAD-", strrep("x", 200L), "-TAIL")
+  chat <- new_rlm_parity_chat(
+    actions = list(list(
+      reasoning = "Use the complete recursive result",
+      code = paste(
+        "value <- llm_query('return the evidence')",
+        "SUBMIT(nchar(value))",
+        sep = "\n"
+      )
+    )),
+    query_values = list(recursive_value)
+  )
+  module <- rlm_module(
+    "question -> answer: integer",
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 1L,
+    max_output_chars = 40L
+  )
+
+  result <- module$forward(list(question = "measure"), .llm = chat)
+
+  expect_identical(result$output[[1L]]$answer, nchar(recursive_value))
+  expect_identical(result$metadata[[1L]]$output_source, "submit")
+})
+
+test_that("typed SUBMIT failures are repairable on the next turn", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  cases <- list(
+    integer = list(
+      type = ellmer::type_integer(),
+      invalid = "SUBMIT(value = 1.5)",
+      valid = "SUBMIT(value = 2L)",
+      expected = 2L
+    ),
+    structural_integer = list(
+      type = ellmer::type_integer(),
+      invalid = "SUBMIT(value = list('2'))",
+      valid = "SUBMIT(value = 2L)",
+      expected = 2L
+    ),
+    boolean = list(
+      type = ellmer::type_boolean(),
+      invalid = "SUBMIT(value = 'maybe')",
+      valid = "SUBMIT(value = TRUE)",
+      expected = TRUE
+    ),
+    enum = list(
+      type = ellmer::type_enum(c("yes", "no")),
+      invalid = "SUBMIT(value = 'unknown')",
+      valid = "SUBMIT(value = 'yes')",
+      expected = "yes"
+    ),
+    array = list(
+      type = ellmer::type_array(ellmer::type_integer()),
+      invalid = "SUBMIT(value = list(1L, 'bad'))",
+      valid = "SUBMIT(value = c(1L, 2L))",
+      expected = c(1L, 2L)
+    ),
+    object = list(
+      type = ellmer::type_object(
+        code = ellmer::type_string(),
+        score = ellmer::type_number()
+      ),
+      invalid = "SUBMIT(value = list(code = 'ok'))",
+      valid = "SUBMIT(value = list(code = 'ok', score = 0.5))",
+      expected = list(code = "ok", score = 0.5)
+    )
+  )
+
+  for (case_name in names(cases)) {
+    case <- cases[[case_name]]
+    sig <- signature(
+      inputs = list(input("question")),
+      output_type = ellmer::type_object(value = case$type),
+      instructions = "Return one typed value."
+    )
+    chat <- new_rlm_parity_chat(list(
+      list(reasoning = "Try an invalid value", code = case$invalid),
+      list(reasoning = "Repair the value", code = case$valid)
+    ))
+    module <- rlm_module(
+      sig,
+      runner = runner,
+      max_iterations = 2L,
+      max_llm_calls = 0L
+    )
+
+    result <- module$forward(list(question = case_name), .llm = chat)
+    history <- result$metadata[[1L]]$repl_history
+
+    expect_identical(length(history), 2L, info = case_name)
+    expect_false(history[[1L]]$success, info = case_name)
+    expect_false(history[[1L]]$is_final, info = case_name)
+    expect_match(history[[1L]]$output, "wrong type", info = case_name)
+    expect_match(
+      chat$parity_state$action_prompts[[2L]],
+      "wrong type",
+      info = case_name
+    )
+    expect_true(history[[2L]]$success, info = case_name)
+    expect_true(history[[2L]]$is_final, info = case_name)
+    expect_identical(
+      result$output[[1L]]$value,
+      case$expected,
+      info = case_name
+    )
+  }
+})
+
+test_that("optional inputs, outputs, and ignored fields follow the signature", {
+  skip_if_not_installed("callr")
+
+  sig <- signature(
+    inputs = list(
+      input("question"),
+      input("context_note", type = ellmer::type_string(required = FALSE))
+    ),
+    output_type = ellmer::type_object(
+      answer = ellmer::type_string(),
+      note = ellmer::type_string(required = FALSE),
+      hidden = ellmer::type_ignore()
+    )
+  )
+  module <- rlm_module(
+    sig,
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  chat <- new_rlm_parity_chat(list(list(
+    reasoning = "Only the required result is needed",
+    code = "SUBMIT(answer = 'ok')"
+  )))
+
+  result <- run(
+    module,
+    question = "test",
+    .llm = chat,
+    .return_format = "structured"
+  )
+
+  expect_identical(result$output, list(answer = "ok"))
+  prompt <- chat$parity_state$action_prompts[[1L]]
+  expect_match(prompt, "note.*optional")
+  expect_false(grepl("hidden", prompt, fixed = TRUE))
+})
+
+test_that("all-optional and nested ignored outputs may be omitted", {
+  skip_if_not_installed("callr")
+
+  optional <- rlm_module(
+    signature(
+      inputs = list(input("question")),
+      output_type = ellmer::type_object(
+        note = ellmer::type_string(required = FALSE)
+      )
+    ),
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  empty_result <- optional$forward(
+    list(question = "none"),
+    .llm = new_rlm_parity_chat(list(list(
+      reasoning = "No output is needed",
+      code = "SUBMIT()"
+    )))
+  )
+  expect_identical(empty_result$output[[1L]], list())
+
+  nested <- rlm_module(
+    signature(
+      inputs = list(input("question")),
+      output_type = ellmer::type_object(
+        answer = ellmer::type_object(
+          value = ellmer::type_string(),
+          hidden = ellmer::type_ignore()
+        )
+      )
+    ),
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  nested_result <- nested$forward(
+    list(question = "nested"),
+    .llm = new_rlm_parity_chat(list(list(
+      reasoning = "Return the visible field",
+      code = "SUBMIT(answer = list(value = 'ok'))"
+    )))
+  )
+  expect_identical(nested_result$output[[1L]]$answer, list(value = "ok"))
+})
+
+test_that("SUBMIT prevents later guest and host-tool effects", {
+  skip_if_not_installed("callr")
+
+  calls <- 0L
+  increment_counter <- function() {
+    calls <<- calls + 1L
+    calls
+  }
+  module <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    tools = list(increment_counter = increment_counter),
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  result <- module$forward(
+    list(question = "stop"),
+    .llm = new_rlm_parity_chat(list(list(
+      reasoning = "Submit immediately",
+      code = paste(
+        "frame <- try(SUBMIT('ok'), silent = TRUE)",
+        "increment_counter()",
+        "frame",
+        sep = "; "
+      )
+    )))
+  )
+
+  expect_identical(result$output[[1L]]$answer, "ok")
+  expect_identical(calls, 0L)
+})
+
+test_that("one ordered replay ledger rejects cross-kind divergence", {
+  skip_if_not_installed("callr")
+
+  host_calls <- 0L
+  query_calls <- 0L
+  ping <- function() {
+    host_calls <<- host_calls + 1L
+    "pong"
+  }
+  sub_lm <- list(
+    clone = function(deep = FALSE) sub_lm,
+    set_turns = function(turns) invisible(NULL),
+    chat = function(prompt) {
+      query_calls <<- query_calls + 1L
+      "unexpected"
+    }
+  )
+  branch_option <- paste0("dsprrr.rlm.replay.", sample.int(1e8, 1L))
+  code <- paste0(
+    "if (is.null(getOption('",
+    branch_option,
+    "'))) { options(",
+    branch_option,
+    " = TRUE); ping() } else { llm_query('must not run') }"
+  )
+  module <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    sub_lm = sub_lm,
+    tools = list(ping = ping),
+    max_iterations = 2L,
+    max_llm_calls = 1L
+  )
+  chat <- new_rlm_parity_chat(list(
+    list(reasoning = "Take a replay-unstable branch", code = code),
+    list(reasoning = "Recover", code = "SUBMIT('recovered')")
+  ))
+
+  result <- module$forward(list(question = "test"), .llm = chat)
+
+  expect_identical(result$output[[1L]]$answer, "recovered")
+  expect_identical(host_calls, 1L)
+  expect_identical(query_calls, 0L)
+  expect_match(
+    result$metadata[[1L]]$repl_history[[1L]]$output,
+    "replay state"
+  )
+})
+
+test_that("tool contracts never reveal function default expressions", {
+  skip_if_not_installed("callr")
+
+  secret <- "TOOL-DEFAULT-SECRET"
+  lookup <- eval(bquote(function(key, token = .(secret)) key))
+  module <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    tools = list(lookup = lookup),
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  chat <- new_rlm_parity_chat(list(list(
+    reasoning = "No tool needed",
+    code = "SUBMIT('ok')"
+  )))
+  module$forward(list(question = "test"), .llm = chat)
+
+  prompt <- chat$parity_state$action_prompts[[1L]]
+  expect_false(grepl(secret, prompt, fixed = TRUE))
+  expect_match(prompt, "token = <default>", fixed = TRUE)
+})
+
+test_that("typed SUBMIT accepts an explicitly empty array", {
+  skip_if_not_installed("callr")
+
+  module <- rlm_module(
+    signature(
+      inputs = list(input("question")),
+      output_type = ellmer::type_object(
+        values = ellmer::type_array(ellmer::type_integer())
+      )
+    ),
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  chat <- new_rlm_parity_chat(list(list(
+    reasoning = "The collection is empty",
+    code = "SUBMIT(values = integer())"
+  )))
+
+  result <- module$forward(list(question = "none"), .llm = chat)
+
+  expect_length(result$output[[1L]]$values, 0L)
+  expect_identical(result$metadata[[1L]]$output_source, "submit")
+})
+
+test_that("fallback provider and output failures are terminal", {
+  skip_if_not_installed("callr")
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+
+  provider_chat <- new_rlm_parity_chat(
+    actions = list(list(reasoning = "Inspect", code = "1 + 1")),
+    fallback_error = "structured extraction unavailable"
+  )
+  provider_module <- rlm_module(
+    "question -> answer: integer",
+    runner = runner,
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  provider_error <- capture_rlm_parity_error(
+    provider_module$forward(list(question = "test"), .llm = provider_chat)
+  )
+
+  expect_s3_class(provider_error, "dsprrr_rlm_fallback_error")
+  expect_match(conditionMessage(provider_error), "fallback extraction failed")
+  expect_identical(provider_chat$parity_state$action_index, 1L)
+  expect_identical(provider_chat$parity_state$fallback_calls, 1L)
+
+  invalid_chat <- new_rlm_parity_chat(
+    actions = list(list(reasoning = "Inspect", code = "1 + 1")),
+    fallback = list(answer = "not an integer")
+  )
+  invalid_module <- rlm_module(
+    "question -> answer: integer",
+    runner = runner,
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  invalid_error <- capture_rlm_parity_error(
+    invalid_module$forward(list(question = "test"), .llm = invalid_chat)
+  )
+
+  expect_s3_class(invalid_error, "dsprrr_rlm_output_validation_error")
+  expect_match(conditionMessage(invalid_error), "wrong type")
+  expect_identical(invalid_chat$parity_state$action_index, 1L)
+  expect_identical(invalid_chat$parity_state$fallback_calls, 1L)
+})
+
+test_that("direct forward rejects multi-row data frames before leasing a runner", {
+  factory_calls <- 0L
+  module <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() {
+      factory_calls <<- factory_calls + 1L
+      stop("factory should not run", call. = FALSE)
+    }
+  )
+
+  error <- capture_rlm_parity_error(module$forward(data.frame(
+    question = c("first", "second")
+  )))
+
+  expect_s3_class(error, "dsprrr_rlm_batch_error")
+  expect_match(conditionMessage(error), "exactly one data-frame row")
+  expect_identical(factory_calls, 0L)
+})
+
+test_that("RLM predictors are visible through named_modules", {
+  module <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() r_code_runner(persistent = TRUE)
+  )
+
+  children <- named_modules(module, include_root = FALSE)
+
+  expect_setequal(
+    names(children),
+    c("$/generate_action", "$/extract")
+  )
+  expect_identical(children[["$/generate_action"]], module$generate_action)
+  expect_identical(children[["$/extract"]], module$extract)
+})
+
+test_that("RLM prompts carry the task, output contract, and bounded head and tail", {
+  skip_if_not_installed("callr")
+
+  sig <- signature(
+    "question -> answer: string, confidence: number",
+    instructions = "PARITY_TASK_INSTRUCTION: preserve exact evidence."
+  )
+  chat <- new_rlm_parity_chat(list(
+    list(
+      reasoning = "Produce deliberately long output",
+      code = paste0(
+        "cat(paste0('HEAD-SIGNAL-', strrep('m', 800), ",
+        " '-TAIL-SIGNAL'))"
+      )
+    ),
+    list(
+      reasoning = "Submit the bounded result",
+      code = "SUBMIT(answer = 'ok', confidence = 1)"
+    )
+  ))
+  module <- rlm_module(
+    sig,
+    interpreter_factory = function() {
+      r_code_runner(
+        timeout = 10,
+        max_output_chars = 5000L,
+        persistent = TRUE
+      )
+    },
+    max_iterations = 2L,
+    max_llm_calls = 0L,
+    max_output_chars = 240L
+  )
+
+  result <- module$forward(list(question = "Inspect output"), .llm = chat)
+  first_prompt <- chat$parity_state$action_prompts[[1L]]
+  second_prompt <- chat$parity_state$action_prompts[[2L]]
+
+  expect_identical(result$output[[1L]]$answer, "ok")
+  expect_true(grepl("PARITY_TASK_INSTRUCTION", first_prompt, fixed = TRUE))
+  expect_true(grepl("`answer`: string", first_prompt, fixed = TRUE))
+  expect_true(grepl("`confidence`: number", first_prompt, fixed = TRUE))
+  expect_true(grepl("HEAD-SIGNAL-", second_prompt, fixed = TRUE))
+  expect_true(grepl("-TAIL-SIGNAL", second_prompt, fixed = TRUE))
+  expect_true(grepl("characters omitted; total", second_prompt, fixed = TRUE))
+})
+
+
+test_that("RLM fallback preserves task instructions and the configured output bound", {
+  skip_if_not_installed("callr")
+
+  decisive_tail <- "DECISIVE-TAIL-EVIDENCE"
+  chat <- new_rlm_parity_chat(
+    actions = list(list(
+      reasoning = "Produce evidence for fallback extraction",
+      code = paste0(
+        "marker <- paste0('DECISIVE', '-TAIL-EVIDENCE'); ",
+        "cat(paste0('HEAD-', strrep('x', 3000L), '-', marker))"
+      )
+    )),
+    fallback = function(prompt, type) {
+      list(
+        answer = if (
+          grepl(decisive_tail, prompt, fixed = TRUE) &&
+            grepl("FALLBACK-TASK-MARKER", prompt, fixed = TRUE)
+        ) {
+          "evidence retained"
+        } else {
+          "evidence missing"
+        }
+      )
+    }
+  )
+  module <- rlm_module(
+    signature(
+      "question, records -> answer: string",
+      instructions = "FALLBACK-TASK-MARKER: use the decisive tail."
+    ),
+    interpreter_factory = function() {
+      r_code_runner(
+        timeout = 10,
+        max_output_chars = 5000L,
+        persistent = TRUE
+      )
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L,
+    max_output_chars = 4000L
+  )
+
+  result <- suppressWarnings(module$forward(
+    list(
+      question = "Inspect the evidence",
+      records = data.frame(
+        ordinary = 1L,
+        decisive_column = "available"
+      )
+    ),
+    .llm = chat
+  ))
+  fallback_prompt <- chat$parity_state$fallback_prompts[[1L]]
+
+  expect_identical(result$output[[1L]]$answer, "evidence retained")
+  expect_match(fallback_prompt, "FALLBACK-TASK-MARKER", fixed = TRUE)
+  expect_match(fallback_prompt, decisive_tail, fixed = TRUE)
+  expect_match(fallback_prompt, "decisive_column", fixed = TRUE)
+  expect_gt(regexpr(decisive_tail, fallback_prompt, fixed = TRUE)[[1L]], 2000L)
+})
+
+
+test_that("RLM excerpts honor very small output bounds", {
+  module <- rlm_module(
+    "question -> answer",
+    runner = r_code_runner(),
+    max_output_chars = 40L
+  )
+  excerpt <- module$.__enclos_env__$private$format_excerpt(strrep("x", 100000L))
+
+  expect_lte(nchar(excerpt), 40L)
+  expect_identical(excerpt, strrep("x", 40L))
+})
+
+test_that("RLM bounds rendered data frames before retaining trajectory output", {
+  module <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() stop("not used"),
+    max_output_chars = 300L
+  )
+  large <- data.frame(
+    id = seq_len(40000L),
+    value = sprintf("row-%05d", seq_len(40000L))
+  )
+  formatted <- module$.__enclos_env__$private$format_execution_output(list(
+    stdout = "",
+    messages = "",
+    warnings = "",
+    result = large
+  ))
+
+  expect_lte(nchar(formatted), 300L)
+  expect_match(formatted, "39980 data-frame rows omitted", fixed = TRUE)
+  expect_false(grepl("row-20000", formatted, fixed = TRUE))
+})
+
+test_that("RLM usage totals include recursive calls and fail closed on gaps", {
+  module <- rlm_module(
+    "question -> answer",
+    interpreter_factory = function() stop("not used")
+  )
+  action <- list(
+    input_tokens = 2L,
+    cached_input_tokens = 0L,
+    output_tokens = 3L,
+    total_tokens = 5L,
+    cost = 0.01
+  )
+  recursive <- list(
+    input_tokens = 7L,
+    cached_input_tokens = 1L,
+    output_tokens = 11L,
+    total_tokens = 18L,
+    cost = 0.02
+  )
+  known <- module$.__enclos_env__$private$summarize_action_usage(
+    list(list(action_metadata = action)),
+    recursive_metadata = list(recursive)
+  )
+  unknown <- module$.__enclos_env__$private$summarize_action_usage(
+    list(list(action_metadata = action)),
+    recursive_metadata = list(canonical_usage_metadata())
+  )
+
+  expect_identical(known$total_tokens, 23L)
+  expect_equal(known$cost, 0.03)
+  expect_true(is.na(unknown$total_tokens))
+  expect_true(is.na(unknown$cost))
+})
+
+test_that("RLM chat clones clear pre-existing conversation turns", {
+  state <- new.env(parent = emptyenv())
+  state$turns <- list("private prior turn")
+  cloned <- list(set_turns = function(turns) state$turns <- turns)
+  chat <- list(clone = function(deep = TRUE) cloned)
+
+  result <- dsprrr:::clone_rlm_chat(chat)
+
+  expect_identical(result, cloned)
+  expect_identical(state$turns, list())
+})
+
+test_that("RLM traces retain input hashes and sizes, not source values", {
+  skip_if_not_installed("callr")
+
+  secret <- paste0("TRACE-SECRET-", strrep("do-not-retain-", 200L))
+  chat <- new_rlm_parity_chat(list(list(
+    reasoning = "Return a fixed answer",
+    code = "SUBMIT('done')"
+  )))
+  module <- rlm_module(
+    "document -> answer: string",
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+
+  module$forward(list(document = secret), .llm = chat, trace = TRUE)
+  history_summary <- module$get_repl_history()[[1L]]$inputs$document
+  trace_summary <- module$state$traces[[1L]]$inputs$document
+  retained <- paste(
+    utils::capture.output(str(list(history_summary, trace_summary))),
+    collapse = "\n"
+  )
+
+  expect_identical(
+    history_summary$sha256,
+    digest::digest(secret, algo = "sha256")
+  )
+  expect_identical(history_summary$length, 1L)
+  expect_gt(history_summary$bytes, 0)
+  expect_identical(trace_summary, history_summary)
+  expect_false("value" %in% names(history_summary))
+  expect_false(grepl("TRACE-SECRET", retained, fixed = TRUE))
+})
+
+test_that("bounded RLM traces still expose newly appended events", {
+  skip_if_not_installed("callr")
+  withr::local_options(list(dsprrr.rlm_trace_limit = 2L))
+
+  module <- rlm_module(
+    "question -> answer: string",
+    interpreter_factory = function() {
+      r_code_runner(timeout = 10, persistent = TRUE)
+    },
+    max_iterations = 1L,
+    max_llm_calls = 0L
+  )
+  run_once <- function(answer) {
+    chat <- new_rlm_parity_chat(list(list(
+      reasoning = "Submit",
+      code = paste0("SUBMIT('", answer, "')")
+    )))
+    module$forward(list(question = answer), .llm = chat, trace = TRUE)
+  }
+
+  run_once("first")
+  run_once("second")
+  cursor <- dsprrr:::evaluation_trace_cursor(module)
+  run_once("third")
+  events <- dsprrr:::new_evaluation_trace_events(module, cursor)
+
+  expect_length(module$state$traces, 2L)
+  expect_identical(module$state$trace_sequence, 3)
+  expect_length(events, 1L)
+  expect_identical(events[[1L]]$output$answer, "third")
+})
+
+test_that("the 40k release investigation is exact and keeps the table external", {
+  skip_if_not_installed("callr")
+
+  n <- 5000L
+  sessions <- expand.grid(
+    release = c("2.3.9", "2.4.0"),
+    platform = c("desktop", "mobile"),
+    plan = c("free", "pro"),
+    within_group = seq_len(n),
+    KEEP.OUT.ATTRS = FALSE,
+    stringsAsFactors = FALSE
+  )
+  base_rate <- c(
+    "desktop.free" = 0.88,
+    "mobile.free" = 0.84,
+    "desktop.pro" = 0.94,
+    "mobile.pro" = 0.92
+  )
+  cohort_key <- paste(sessions$platform, sessions$plan, sep = ".")
+  conversion_rate <- unname(base_rate[cohort_key])
+  conversion_rate[
+    sessions$release == "2.4.0" & cohort_key == "mobile.pro"
+  ] <- 0.61
+  sessions$converted <- sessions$within_group <= n * conversion_rate
+  sessions$audit_marker <- ""
+  full_table_sentinel <- "FULL-TABLE-SENTINEL-ROW-40000"
+  sessions$audit_marker[[nrow(sessions)]] <- full_table_sentinel
+
+  changes <- data.frame(
+    change_id = sprintf("CHG-%04d", 1701:1900),
+    release = rep(c("2.3.9", "2.4.0"), each = 100),
+    component = "miscellaneous",
+    note = "Routine maintenance with no expected checkout impact."
+  )
+  target <- which(changes$change_id == "CHG-1842")
+  changes$component[[target]] <- "checkout-auth"
+  changes$note[[target]] <- paste(
+    "Mobile Pro token refresh:",
+    "retry budget changed from 3 to 0 and timeout from 8 s to 800 ms."
+  )
+  question <- paste(
+    "Checkout conversion fell after release 2.4.0.",
+    "Find the finest low-cardinality categorical cohort with the largest",
+    "before/after drop; do not stop at a marginal roll-up that dilutes the",
+    "change. Identify its dimensions and values, quantify the rates, and cite",
+    "the change-log record that is the strongest candidate explanation."
+  )
+  sig <- signature(
+    paste(
+      "sessions, changes, question ->",
+      "release: string, cohort: string,",
+      "before_rate: number, after_rate: number,",
+      "drop_pp: number, change_id: string, evidence: string"
+    ),
+    instructions = paste(
+      "Inspect the schema and low-cardinality categorical fields; exclude the",
+      "release, outcome, and row-index fields from candidate cohort dimensions.",
+      "Find the finest low-cardinality cohort with the largest before/after",
+      "drop; do not stop at a marginal roll-up that dilutes the change.",
+      "Quantify it and cite the strongest matching change record.",
+      "Format cohort in source-column order as '<dimension>=<value> / ...'.",
+      "Copy the selected change note verbatim into evidence. Treat that record",
+      "as evidence, not proof of causation."
+    )
+  )
+  chat <- new_rlm_parity_chat(list(
+    list(
+      reasoning = "Inspect shape and schema without printing rows",
+      code = paste(
+        "schema <- list(",
+        "  session_dim = dim(.context$sessions),",
+        "  session_fields = names(.context$sessions),",
+        "  releases = table(.context$sessions$release),",
+        "  change_fields = names(.context$changes)",
+        ")",
+        "schema",
+        sep = "\n"
+      )
+    ),
+    list(
+      reasoning = "Calculate each cohort's before and after rates",
+      code = paste(
+        "rates <- aggregate(",
+        "  converted ~ release + platform + plan,",
+        "  data = .context$sessions,",
+        "  FUN = mean",
+        ")",
+        "before <- subset(rates, release == '2.3.9')",
+        "after <- subset(rates, release == '2.4.0')",
+        "deltas <- merge(",
+        "  before, after,",
+        "  by = c('platform', 'plan'),",
+        "  suffixes = c('_before', '_after')",
+        ")",
+        "deltas$drop_pp <- 100 * (",
+        "  deltas$converted_before - deltas$converted_after",
+        ")",
+        "deltas[order(-deltas$drop_pp), ]",
+        sep = "\n"
+      )
+    ),
+    list(
+      reasoning = "Inspect only the matching change record",
+      code = paste(
+        "candidate <- subset(",
+        "  .context$changes,",
+        "  release == '2.4.0' &",
+        "    grepl('token|retry', paste(component, note), ignore.case = TRUE)",
+        ")",
+        "candidate",
+        sep = "\n"
+      )
+    ),
+    list(
+      reasoning = "Submit the computed incident evidence",
+      code = paste(
+        "winner <- deltas[which.max(deltas$drop_pp), ]",
+        "SUBMIT(",
+        "  release = after$release[[1L]],",
+        paste0(
+          "  cohort = paste0('platform=', winner$platform, ",
+          " ' / plan=', winner$plan),"
+        ),
+        "  before_rate = winner$converted_before,",
+        "  after_rate = winner$converted_after,",
+        "  drop_pp = winner$drop_pp,",
+        "  change_id = candidate$change_id[[1L]],",
+        "  evidence = candidate$note[[1L]]",
+        ")",
+        sep = "\n"
+      )
+    )
+  ))
+  investigator <- rlm_module(
+    sig,
+    interpreter_factory = function() {
+      r_code_runner(timeout = 20, persistent = TRUE)
+    },
+    max_iterations = 4L,
+    max_llm_calls = 0L,
+    max_output_chars = 10000L
+  )
+
+  result <- run(
+    investigator,
+    sessions = sessions,
+    changes = changes,
+    question = question,
+    .llm = chat,
+    .return_format = "structured"
+  )
+  output <- result$output
+  prompts <- chat$parity_state$action_prompts
+
+  expect_identical(nrow(sessions), 40000L)
+  expect_identical(output$release, "2.4.0")
+  expect_identical(output$cohort, "platform=mobile / plan=pro")
+  expect_equal(output$before_rate, 0.92)
+  expect_equal(output$after_rate, 0.61)
+  expect_equal(output$drop_pp, 31)
+  expect_identical(output$change_id, "CHG-1842")
+  expect_identical(output$evidence, changes$note[[target]])
+  expect_identical(result$metadata$iterations, 4L)
+  expect_identical(length(prompts), 4L)
+  expect_true(grepl("40000 rows x 6 cols", prompts[[1L]], fixed = TRUE))
+  expect_false(any(grepl(full_table_sentinel, prompts, fixed = TRUE)))
+  expect_lt(max(nchar(prompts)), as.numeric(utils::object.size(sessions)))
+})

--- a/tests/testthat/test-rlm-predictor-contract.R
+++ b/tests/testthat/test-rlm-predictor-contract.R
@@ -1,0 +1,290 @@
+rlm_contract_runner <- function() {
+  list(
+    execute = function(code, context = list()) {
+      list(success = TRUE, result = NULL)
+    },
+    policy = function() {
+      list(
+        backend = "test",
+        trust = "test",
+        sandboxed = TRUE,
+        persistent = TRUE
+      )
+    }
+  )
+}
+
+
+rlm_contract_output <- function(
+  answer_required = TRUE,
+  ignore_required = TRUE,
+  descriptions = "original"
+) {
+  ellmer::type_object(
+    .description = paste(descriptions, "root"),
+    answer = ellmer::type_string(
+      description = paste(descriptions, "answer"),
+      required = answer_required
+    ),
+    details = ellmer::type_object(
+      .description = paste(descriptions, "details"),
+      count = ellmer::type_integer(
+        description = paste(descriptions, "count"),
+        required = FALSE
+      ),
+      internal = ellmer::TypeIgnore(required = ignore_required)
+    )
+  )
+}
+
+
+rlm_contract_signature <- function(output_type = rlm_contract_output()) {
+  signature(
+    inputs = list(input("question", type = ellmer::type_string())),
+    output_type = output_type
+  )
+}
+
+
+rlm_contract_action <- function(
+  state_type = ellmer::type_string(),
+  output_type = ellmer::type_object(
+    reasoning = ellmer::type_string(),
+    code = ellmer::type_string()
+  ),
+  extra_inputs = list()
+) {
+  PredictModule$new(
+    signature = signature(
+      inputs = c(
+        list(input(
+          "state",
+          type = state_type,
+          description = "A replaceable state description"
+        )),
+        extra_inputs
+      ),
+      output_type = output_type
+    )
+  )
+}
+
+
+rlm_contract_extract <- function(output_type) {
+  PredictModule$new(
+    signature = signature(
+      inputs = list(input(
+        "state",
+        type = ellmer::type_string(description = "Different description")
+      )),
+      output_type = output_type
+    )
+  )
+}
+
+
+test_that("RLM predictor contracts accept defaults and ignore descriptions", {
+  runner <- rlm_contract_runner()
+  root_signature <- rlm_contract_signature()
+
+  defaults <- RLMModule$new(signature = root_signature, runner = runner)
+  expect_s3_class(defaults$generate_action, "Module")
+  expect_s3_class(defaults$extract, "Module")
+
+  custom <- RLMModule$new(
+    signature = root_signature,
+    runner = runner,
+    generate_action = rlm_contract_action(
+      state_type = ellmer::type_string(description = "Custom state"),
+      output_type = ellmer::type_object(
+        .description = "Custom action",
+        reasoning = ellmer::type_string(description = "Custom reasoning"),
+        code = ellmer::type_string(description = "Custom code")
+      )
+    ),
+    extract = rlm_contract_extract(
+      rlm_contract_output(descriptions = "replacement")
+    )
+  )
+
+  expect_s3_class(custom, "RLMModule")
+})
+
+
+test_that("RLM constructor rejects incompatible generate_action contracts", {
+  runner <- rlm_contract_runner()
+  root_signature <- rlm_contract_signature()
+  extract <- rlm_contract_extract(root_signature@output_type)
+  invalid <- list(
+    optional_state = rlm_contract_action(
+      state_type = ellmer::type_string(required = FALSE)
+    ),
+    extra_input = rlm_contract_action(
+      extra_inputs = list(input("other", type = ellmer::type_string()))
+    ),
+    wrong_field_type = rlm_contract_action(
+      output_type = ellmer::type_object(
+        reasoning = ellmer::type_number(),
+        code = ellmer::type_string()
+      )
+    ),
+    optional_code = rlm_contract_action(
+      output_type = ellmer::type_object(
+        reasoning = ellmer::type_string(),
+        code = ellmer::type_string(required = FALSE)
+      )
+    ),
+    extra_output = rlm_contract_action(
+      output_type = ellmer::type_object(
+        reasoning = ellmer::type_string(),
+        code = ellmer::type_string(),
+        confidence = ellmer::type_number()
+      )
+    ),
+    open_output = rlm_contract_action(
+      output_type = ellmer::TypeObject(
+        properties = list(
+          reasoning = ellmer::type_string(),
+          code = ellmer::type_string()
+        ),
+        additional_properties = TRUE
+      )
+    )
+  )
+
+  for (name in names(invalid)) {
+    expect_error(
+      RLMModule$new(
+        signature = root_signature,
+        runner = runner,
+        generate_action = invalid[[name]],
+        extract = extract
+      ),
+      class = "dsprrr_rlm_generate_action_contract_error",
+      info = name
+    )
+  }
+})
+
+
+test_that("RLM constructor matches the complete extract output contract", {
+  runner <- rlm_contract_runner()
+  root_signature <- rlm_contract_signature()
+  action <- rlm_contract_action()
+
+  expect_error(
+    RLMModule$new(
+      signature = root_signature,
+      runner = runner,
+      generate_action = action,
+      extract = rlm_contract_extract(
+        rlm_contract_output(answer_required = FALSE)
+      )
+    ),
+    class = "dsprrr_rlm_extract_contract_error"
+  )
+
+  expect_error(
+    RLMModule$new(
+      signature = root_signature,
+      runner = runner,
+      generate_action = action,
+      extract = rlm_contract_extract(
+        rlm_contract_output(ignore_required = FALSE)
+      )
+    ),
+    class = "dsprrr_rlm_extract_contract_error"
+  )
+
+  missing_ignore <- ellmer::type_object(
+    answer = ellmer::type_string(),
+    details = ellmer::type_object(
+      count = ellmer::type_integer(required = FALSE)
+    )
+  )
+  expect_error(
+    RLMModule$new(
+      signature = root_signature,
+      runner = runner,
+      generate_action = action,
+      extract = rlm_contract_extract(missing_ignore)
+    ),
+    class = "dsprrr_rlm_extract_contract_error"
+  )
+})
+
+
+test_that("RLM graph child replacement validates atomically", {
+  module <- RLMModule$new(
+    signature = rlm_contract_signature(),
+    runner = rlm_contract_runner()
+  )
+  original_action <- module$generate_action
+  original_extract <- module$extract
+
+  invalid_action <- rlm_contract_action(
+    state_type = ellmer::type_number()
+  )
+  expect_error(
+    module$set_graph_children(list(
+      generate_action = invalid_action,
+      extract = original_extract
+    )),
+    class = "dsprrr_rlm_generate_action_contract_error"
+  )
+  expect_identical(module$generate_action, original_action)
+  expect_identical(module$extract, original_extract)
+
+  invalid_extract <- rlm_contract_extract(
+    rlm_contract_output(answer_required = FALSE)
+  )
+  expect_error(
+    module$set_graph_children(list(
+      generate_action = original_action,
+      extract = invalid_extract
+    )),
+    class = "dsprrr_rlm_extract_contract_error"
+  )
+  expect_identical(module$generate_action, original_action)
+  expect_identical(module$extract, original_extract)
+})
+
+
+test_that("RLM artifact restoration rejects incompatible predictor contracts", {
+  runner <- rlm_contract_runner()
+  artifact <- program_artifact(
+    RLMModule$new(
+      signature = rlm_contract_signature(),
+      runner = runner
+    ),
+    registry = list(runner = runner)
+  )
+  restore_condition <- function(value) {
+    value$integrity <- dsprrr:::artifact_integrity(value)
+    rlang::catch_cnd(restore_module_config(
+      value,
+      registry = list(runner = runner)
+    ))
+  }
+
+  invalid_action <- artifact
+  invalid_action$graph$nodes[[
+    "$/generate_action"
+  ]]$signature$output_type$properties$code$required <- FALSE
+  condition <- restore_condition(invalid_action)
+
+  expect_s3_class(condition, "dsprrr_artifact_malformed")
+  expect_s3_class(
+    condition$parent,
+    "dsprrr_rlm_generate_action_contract_error"
+  )
+
+  invalid_extract <- artifact
+  invalid_extract$graph$nodes[[
+    "$/extract"
+  ]]$signature$output_type$properties$answer$required <- FALSE
+  condition <- restore_condition(invalid_extract)
+
+  expect_s3_class(condition, "dsprrr_artifact_malformed")
+  expect_s3_class(condition$parent, "dsprrr_rlm_extract_contract_error")
+})

--- a/tests/testthat/test-rlm-tools.R
+++ b/tests/testthat/test-rlm-tools.R
@@ -1,0 +1,345 @@
+capture_rlm_tools_error <- function(expr) {
+  tryCatch(force(expr), error = function(error) error)
+}
+
+
+eval_rlm_guest <- function(
+  code,
+  replay = list(),
+  nonce = "rlm-tools-test-nonce",
+  has_sub_lm = TRUE,
+  custom_tools = list()
+) {
+  replay <- lapply(replay, function(record) {
+    if (!is.list(record)) {
+      return(record)
+    }
+    record$kind <- record$kind %||% "query"
+    record[c("kind", setdiff(names(record), "kind"))]
+  })
+  context <- list()
+  context[[rlm_control_replay_field()]] <- replay
+  env <- new.env(parent = baseenv())
+  env$.context <- context
+  prelude <- create_rlm_prelude(
+    has_sub_lm = has_sub_lm,
+    custom_tools = custom_tools,
+    control_nonce = nonce
+  )
+  eval(parse(text = paste(prelude, code, sep = "\n\n")), envir = env)
+}
+
+
+query_request_from_error <- function(error, nonce = "rlm-tools-test-nonce") {
+  decode_rlm_control(conditionMessage(error), nonce)
+}
+
+
+encode_rlm_tools_frame <- function(payload, nonce) {
+  envelope <- list(
+    version = 1L,
+    nonce = nonce,
+    kind = "query",
+    payload = payload
+  )
+  json <- jsonlite::toJSON(
+    envelope,
+    auto_unbox = TRUE,
+    null = "null",
+    na = "null",
+    digits = NA
+  )
+  paste0(
+    rlm_control_prefix(),
+    gsub(
+      "[[:space:]]",
+      "",
+      jsonlite::base64_enc(charToRaw(as.character(json)))
+    )
+  )
+}
+
+
+test_that("recursive queries replay as ordinary R values", {
+  code <- paste(
+    "answer <- llm_query('What is the answer?', 'relevant context')",
+    "paste0('answer=', toupper(answer))",
+    sep = "\n"
+  )
+  first <- capture_rlm_tools_error(eval_rlm_guest(code))
+  request <- query_request_from_error(first)
+
+  expect_s3_class(first, "error")
+  expect_s3_class(request, "rlm_query_request")
+  expect_identical(request$index, 1L)
+  expect_identical(request$query, "What is the answer?")
+  expect_identical(request$context, "relevant context")
+  expect_identical(request$batch, FALSE)
+
+  replay <- list(list(
+    request = unclass(request),
+    success = TRUE,
+    value = "forty-two",
+    error = NULL
+  ))
+
+  expect_identical(eval_rlm_guest(code, replay), "answer=FORTY-TWO")
+})
+
+
+test_that("recursive query indices advance across replayed calls", {
+  code <- paste(
+    "first <- llm_query('first')",
+    "second <- rlm_query('second')",
+    "paste(first, second, sep = ':')",
+    sep = "\n"
+  )
+  first_error <- capture_rlm_tools_error(eval_rlm_guest(code))
+  first_request <- query_request_from_error(first_error)
+  first_replay <- list(list(
+    request = unclass(first_request),
+    success = TRUE,
+    value = "one",
+    error = NULL
+  ))
+
+  second_error <- capture_rlm_tools_error(eval_rlm_guest(code, first_replay))
+  second_request <- query_request_from_error(second_error)
+
+  expect_identical(first_request$index, 1L)
+  expect_identical(second_request$index, 2L)
+  expect_identical(second_request$query, "second")
+
+  replay <- append(
+    first_replay,
+    list(list(
+      request = unclass(second_request),
+      success = TRUE,
+      value = "two",
+      error = NULL
+    ))
+  )
+  expect_identical(eval_rlm_guest(code, replay), "one:two")
+})
+
+
+test_that("batched recursive queries preserve singleton array shape", {
+  code <- paste(
+    "answers <- rlm_query_batch('only', slices = 'context')",
+    "list(length = length(answers), value = answers)",
+    sep = "\n"
+  )
+  error <- capture_rlm_tools_error(eval_rlm_guest(code))
+  request <- query_request_from_error(error)
+
+  expect_s3_class(request, "rlm_query_request")
+  expect_identical(request$index, 1L)
+  expect_identical(request$batch, TRUE)
+  expect_identical(request$queries, "only")
+  expect_identical(request$slices, "context")
+
+  replay <- list(list(
+    request = unclass(request),
+    success = TRUE,
+    value = "response",
+    error = NULL
+  ))
+  expect_identical(
+    eval_rlm_guest(code, replay),
+    list(length = 1L, value = "response")
+  )
+})
+
+
+test_that("recursive query replay rejects divergence and malformed records", {
+  code <- "llm_query('original')"
+  request_error <- capture_rlm_tools_error(eval_rlm_guest(code))
+  request <- query_request_from_error(request_error)
+
+  divergent_request <- unclass(request)
+  divergent_request$query <- "different"
+  divergent <- capture_rlm_tools_error(eval_rlm_guest(
+    code,
+    list(list(
+      request = divergent_request,
+      success = TRUE,
+      value = "answer",
+      error = NULL
+    ))
+  ))
+  expect_s3_class(divergent, "error")
+  expect_match(
+    conditionMessage(divergent),
+    "control replay diverged from its recorded request",
+    fixed = TRUE
+  )
+
+  malformed <- capture_rlm_tools_error(eval_rlm_guest(
+    code,
+    list(list(
+      request = unclass(request),
+      success = "yes",
+      value = "answer"
+    ))
+  ))
+  expect_s3_class(malformed, "error")
+  expect_identical(
+    conditionMessage(malformed),
+    "Malformed RLM control replay state"
+  )
+
+  missing_value <- capture_rlm_tools_error(eval_rlm_guest(
+    code,
+    list(list(request = unclass(request), success = TRUE))
+  ))
+  expect_identical(
+    conditionMessage(missing_value),
+    "Malformed RLM control replay state"
+  )
+
+  malformed_container <- capture_rlm_tools_error(eval_rlm_guest(
+    code,
+    replay = "not a list"
+  ))
+  expect_match(
+    conditionMessage(malformed_container),
+    "Malformed RLM control replay state",
+    fixed = TRUE
+  )
+})
+
+
+test_that("recursive query replay reproduces host failures", {
+  code <- "llm_query('fails')"
+  request_error <- capture_rlm_tools_error(eval_rlm_guest(code))
+  request <- query_request_from_error(request_error)
+  replay <- list(list(
+    request = unclass(request),
+    success = FALSE,
+    value = NULL,
+    error = "sub-LM unavailable"
+  ))
+
+  replay_error <- capture_rlm_tools_error(eval_rlm_guest(code, replay))
+
+  expect_s3_class(replay_error, "error")
+  expect_identical(conditionMessage(replay_error), "sub-LM unavailable")
+})
+
+
+test_that("control requests reject lossy non-JSON values", {
+  invalid <- list(
+    "SUBMIT(NA_character_)",
+    "SUBMIT(NaN)",
+    "SUBMIT(Inf)",
+    "SUBMIT(as.Date('2026-08-11'))"
+  )
+
+  for (code in invalid) {
+    error <- capture_rlm_tools_error(eval_rlm_guest(
+      code,
+      has_sub_lm = FALSE
+    ))
+    expect_s3_class(error, "error")
+    expect_match(
+      conditionMessage(error),
+      "JSON-compatible|missing values|NaN or infinite",
+      perl = TRUE
+    )
+    expect_null(query_request_from_error(error))
+  }
+
+  tool_error <- capture_rlm_tools_error(eval_rlm_guest(
+    "classify_missing(NA_character_)",
+    has_sub_lm = FALSE,
+    custom_tools = list(classify_missing = function(value) value)
+  ))
+  expect_match(conditionMessage(tool_error), "missing values", fixed = TRUE)
+  expect_null(query_request_from_error(tool_error))
+})
+
+
+test_that("query control frames authenticate and validate their index", {
+  nonce <- "current-query-frame"
+  request_error <- capture_rlm_tools_error(eval_rlm_guest(
+    "llm_query('current')",
+    nonce = nonce
+  ))
+  frame <- conditionMessage(request_error)
+
+  expect_null(decode_rlm_control(frame, "stale-query-frame"))
+  expect_identical(decode_rlm_control(frame, nonce)$index, 1L)
+
+  invalid_payloads <- list(
+    list(query = "missing", context = NULL, batch = FALSE),
+    list(index = 0L, query = "zero", context = NULL, batch = FALSE),
+    list(index = 1.5, query = "fractional", context = NULL, batch = FALSE),
+    list(
+      index = 1L,
+      query = "bad context",
+      context = I(c("one", "two")),
+      batch = FALSE
+    ),
+    list(
+      index = .Machine$integer.max + 1,
+      query = "overflow",
+      context = NULL,
+      batch = FALSE
+    )
+  )
+  for (payload in invalid_payloads) {
+    malformed <- encode_rlm_tools_frame(payload, nonce)
+    error <- capture_rlm_tools_error(decode_rlm_control(malformed, nonce))
+    expect_s3_class(error, "dsprrr_rlm_control_error")
+    expect_match(
+      conditionMessage(error),
+      "Malformed RLM query control frame",
+      fixed = TRUE
+    )
+  }
+})
+
+
+test_that("peek handles scalar and vector boundaries without reverse slices", {
+  env <- new.env(parent = baseenv())
+  env$.context <- list()
+  eval(
+    parse(
+      text = create_rlm_prelude(
+        has_sub_lm = FALSE,
+        control_nonce = "peek-test"
+      )
+    ),
+    envir = env
+  )
+
+  expect_identical(env$peek(c("a", "b", "c"), 2, 3), c("b", "c"))
+  expect_identical(env$peek(c("a", "b", "c"), 4, 7), character())
+  expect_identical(env$peek(c("a", "b", "c"), 3, 2), character())
+  expect_identical(env$peek(c("a", "b", "c"), -2, 2), c("a", "b"))
+  expect_identical(env$peek("abcdef", 2, 4), "bcd")
+  expect_identical(env$peek("abcdef", 8, 10), "")
+  expect_identical(env$peek("abcdef", 4, 2), "")
+  expect_identical(env$peek(character(), 1, 2), character())
+  expect_identical(env$peek(NA_character_, 1, 2), NA_character_)
+
+  invalid_bounds <- list(
+    function() env$peek("abcdef", NA_real_, 2),
+    function() env$peek("abcdef", 1.5, 2),
+    function() env$peek("abcdef", c(1, 2), 3),
+    function() env$peek("abcdef", 1, Inf)
+  )
+  for (call in invalid_bounds) {
+    error <- capture_rlm_tools_error(call())
+    expect_s3_class(error, "error")
+    expect_match(conditionMessage(error), "finite whole number", fixed = TRUE)
+  }
+})
+
+
+test_that("query replay uses a reserved context field", {
+  expect_identical(
+    rlm_control_replay_field(),
+    ".dsprrr_rlm_control_replay"
+  )
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -768,6 +768,41 @@ test_that("process_batch_item returns correct format for structured mode", {
   expect_equal(result$metadata$cost, 0.001)
 })
 
+test_that("chat usage aggregates every verified assistant turn", {
+  prior <- ellmer::UserTurn("prior")
+  turns <- list(
+    prior,
+    ellmer::UserTurn("current"),
+    ellmer::AssistantTurn(
+      contents = list(ellmer::ContentText("tool request")),
+      tokens = c(10L, 1L, 2L),
+      cost = 0.11,
+      duration = 0.4
+    ),
+    ellmer::AssistantTurn(
+      contents = list(ellmer::ContentText("final")),
+      tokens = c(20L, 2L, 3L),
+      cost = 0.22,
+      duration = 0.6
+    )
+  )
+  chat <- list(get_turns = function() turns)
+
+  usage <- dsprrr:::chat_usage_metadata(chat, turns_before = list(prior))
+
+  expect_identical(usage$provider_calls, 2L)
+  expect_identical(usage$input_tokens, 30L)
+  expect_identical(usage$output_tokens, 3L)
+  expect_identical(usage$cached_input_tokens, 5L)
+  expect_identical(usage$total_tokens, 33L)
+  expect_equal(usage$cost, 0.33)
+  expect_equal(usage$duration_s, 1)
+
+  unknown <- dsprrr:::chat_usage_metadata(chat, turns_before = list("wrong"))
+  expect_true(is.na(unknown$provider_calls))
+  expect_true(is.na(unknown$total_tokens))
+})
+
 test_that("extract_simple_output extracts single-field objects", {
   # Create real TypeObject with single property
   single_field_type <- ellmer::type_object(answer = ellmer::type_string())
@@ -1995,4 +2030,46 @@ test_that("print.dsprrr_batch_result reports success when there are no errors", 
   )
   out <- cli::cli_fmt(print(result))
   expect_true(any(grepl("All items completed successfully", out, fixed = TRUE)))
+})
+
+
+test_that("run_dataset accepts omitted and provided optional inputs", {
+  seen <- list()
+  program <- module_fn(
+    signature(
+      inputs = list(
+        input("question"),
+        input("context_note", type = ellmer::type_string(required = FALSE))
+      ),
+      output_type = ellmer::type_object(answer = ellmer::type_string())
+    ),
+    function(question, context_note = NULL, ...) {
+      seen[[length(seen) + 1L]] <<- context_note %||% "<missing>"
+      list(answer = paste(question, context_note %||% "none", sep = ":"))
+    }
+  )
+
+  omitted <- run_dataset(
+    program,
+    data.frame(question = c("a", "b")),
+    .progress = FALSE
+  )
+  provided <- run_dataset(
+    program,
+    data.frame(
+      question = c("c", "d"),
+      context_note = c("first", "second")
+    ),
+    .progress = FALSE
+  )
+
+  expect_identical(
+    unlist(omitted$result, use.names = FALSE),
+    c("a:none", "b:none")
+  )
+  expect_identical(
+    unlist(provided$result, use.names = FALSE),
+    c("c:first", "d:second")
+  )
+  expect_identical(seen, list("<missing>", "<missing>", "first", "second"))
 })

--- a/tests/testthat/test-teleprompter-bootstrap-rs.R
+++ b/tests/testthat/test-teleprompter-bootstrap-rs.R
@@ -109,6 +109,76 @@ test_that("BootstrapFewShotWithRandomSearch requires metric", {
   )
 })
 
+test_that("BootstrapFewShotWithRandomSearch rejects RLM before candidates", {
+  runner <- list(
+    execute = function(code, context = list(), ...) {
+      list(success = TRUE, result = NULL)
+    },
+    policy = function() {
+      list(
+        backend = "test",
+        trust = "test-only",
+        sandboxed = TRUE,
+        persistent = TRUE
+      )
+    }
+  )
+  program <- rlm_module("question -> answer", runner = runner)
+  optimizer <- BootstrapFewShotWithRandomSearch(
+    metric = function(prediction, expected) 1,
+    num_candidate_programs = 3L
+  )
+
+  error <- tryCatch(
+    compile(
+      optimizer,
+      program,
+      data.frame(question = "train", answer = "train"),
+      valset = data.frame(question = "val", answer = "val")
+    ),
+    error = identity
+  )
+
+  expect_s3_class(error, "dsprrr_bootstrap_graph_unsupported")
+  expect_match(
+    conditionMessage(error),
+    "BootstrapFewShotWithRandomSearch",
+    fixed = TRUE
+  )
+  expect_identical(error$paths, "$")
+})
+
+test_that("BootstrapFewShotWithRandomSearch rejects wrapped Flex", {
+  flex_program <- suppressWarnings(flex("question -> answer"))
+  program <- best_of_n(
+    flex_program,
+    N = 2L,
+    reward_fn = function(...) 1
+  )
+  optimizer <- BootstrapFewShotWithRandomSearch(
+    metric = function(prediction, expected) 1,
+    num_candidate_programs = 3L
+  )
+
+  error <- tryCatch(
+    compile(
+      optimizer,
+      program,
+      data.frame(question = "train", answer = "train"),
+      valset = data.frame(question = "val", answer = "val")
+    ),
+    error = identity
+  )
+
+  expect_s3_class(error, "dsprrr_flex_demo_unsupported_error")
+  expect_match(
+    conditionMessage(error),
+    "BootstrapFewShotWithRandomSearch",
+    fixed = TRUE
+  )
+  expect_identical(error$paths, "$/module")
+})
+
 test_that("BootstrapFewShotWithRandomSearch requires valset", {
   sig <- Signature(
     inputs = list(input(name = "question", class = S7::class_character)),

--- a/tests/testthat/test-teleprompter-bootstrap.R
+++ b/tests/testthat/test-teleprompter-bootstrap.R
@@ -93,6 +93,11 @@ test_that("BootstrapFewShot rejects Flex instead of assigning unused demos", {
   flex_program <- suppressWarnings(flex("question -> draft"))
   pipeline_program <- flex_program %>>%
     module(signature("draft -> answer"), type = "predict")
+  wrapped_program <- best_of_n(
+    flex_program,
+    N = 2L,
+    reward_fn = function(...) 1
+  )
   trainset <- data.frame(question = "q", answer = "a")
   optimizer <- BootstrapFewShot(
     metric = function(prediction, expected) 1,
@@ -108,11 +113,51 @@ test_that("BootstrapFewShot rejects Flex instead of assigning unused demos", {
     compile(optimizer, pipeline_program, trainset),
     error = identity
   )
+  wrapped_error <- tryCatch(
+    compile(optimizer, wrapped_program, trainset),
+    error = identity
+  )
 
   expect_s3_class(direct_error, "dsprrr_flex_demo_unsupported_error")
   expect_identical(direct_error$paths, "$")
   expect_s3_class(nested_error, "dsprrr_flex_demo_unsupported_error")
   expect_identical(nested_error$paths, "$/steps/1")
+  expect_s3_class(wrapped_error, "dsprrr_flex_demo_unsupported_error")
+  expect_identical(wrapped_error$paths, "$/module")
+})
+
+test_that("BootstrapFewShot rejects RLM without predictor-local evidence", {
+  runner <- list(
+    execute = function(code, context = list(), ...) {
+      list(success = TRUE, result = NULL)
+    },
+    policy = function() {
+      list(
+        backend = "test",
+        trust = "test-only",
+        sandboxed = TRUE,
+        persistent = TRUE
+      )
+    }
+  )
+  program <- rlm_module("question -> answer", runner = runner)
+  trainset <- data.frame(question = "q", answer = "a")
+  optimizer <- BootstrapFewShot(
+    metric = function(prediction, expected) 1,
+    max_labeled_demos = 1L,
+    max_bootstrapped_demos = 0L
+  )
+
+  error <- tryCatch(
+    compile(optimizer, program, trainset),
+    error = identity
+  )
+
+  expect_s3_class(error, "dsprrr_bootstrap_graph_unsupported")
+  expect_s3_class(error, "dsprrr_optimizer_ineligible_error")
+  expect_identical(error$paths, "$")
+  expect_length(program$generate_action$demos, 0L)
+  expect_length(program$extract$demos, 0L)
 })
 
 test_that("BootstrapFewShot compile returns unmodified program for empty trainset", {

--- a/tests/testthat/test-teleprompter-gepa.R
+++ b/tests/testthat/test-teleprompter-gepa.R
@@ -551,3 +551,113 @@ test_that("GEPA restores the caller RNG state", {
 
   expect_identical(get(".Random.seed", envir = globalenv()), before)
 })
+
+test_that("GEPA tunes both graph-visible RLM predictors", {
+  skip_if_not_installed("callr")
+  local_reset_cache()
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  expect_identical(runner$policy()$persistent, TRUE)
+  program <- make_rlm_optimizer_program(runner)
+  chat <- make_rlm_optimizer_chat()
+  original_action <- program$generate_action$signature@instructions
+  original_extract <- program$extract$signature@instructions
+
+  run <- capture_rlm_optimizer_warnings(
+    compile(
+      GEPA(
+        metric = rlm_optimizer_accuracy,
+        population_size = 2L,
+        generations = 1L,
+        mutation_rate = 1,
+        crossover_rate = 0,
+        component_selector = "all",
+        use_merge = FALSE,
+        seed = 17L,
+        verbose = FALSE
+      ),
+      program,
+      data.frame(question = "inspect", answer = "yes"),
+      .llm = chat
+    )
+  )
+  compiled <- expect_only_rlm_fallback_warnings(run)
+
+  expect_identical(
+    compiled$config$optimizer$component_ids,
+    c(
+      "instructions::$/generate_action",
+      "instructions::$/extract"
+    )
+  )
+  expect_identical(
+    compiled$generate_action$signature@instructions,
+    "ACTION-TUNED"
+  )
+  expect_identical(
+    compiled$extract$signature@instructions,
+    "EXTRACT-TUNED"
+  )
+  expect_identical(
+    program$generate_action$signature@instructions,
+    original_action
+  )
+  expect_identical(program$extract$signature@instructions, original_extract)
+  expect_equal(compiled$config$optimizer$best_scores[["quality"]], 1)
+  expect_length(chat$optimizer_state$reflection_prompts, 2L)
+})
+
+test_that("GEPA reflection receives feedback from bounded RLM trajectories", {
+  skip_if_not_installed("callr")
+  local_reset_cache()
+
+  runner <- r_code_runner(timeout = 10, persistent = TRUE)
+  withr::defer(runner$close())
+  expect_identical(runner$policy()$persistent, TRUE)
+  program <- make_rlm_optimizer_program(runner, max_output_chars = 96L)
+  chat <- make_rlm_optimizer_chat()
+  observed_outputs <- character()
+  trace_metric <- metric_with_trace(
+    function(prediction, expected, program_trace) {
+      event <- program_trace$events[[length(program_trace$events)]]
+      output <- event$history[[1L]]$output
+      observed_outputs <<- c(observed_outputs, output)
+      list(
+        score = 0,
+        feedback = paste0("BOUNDED-RLM-TRACE: ", output)
+      )
+    },
+    field = "answer"
+  )
+
+  run <- capture_rlm_optimizer_warnings(
+    compile(
+      GEPA(
+        metric = trace_metric,
+        population_size = 2L,
+        generations = 2L,
+        mutation_rate = 1,
+        crossover_rate = 0,
+        component_selector = "round_robin",
+        use_merge = FALSE,
+        seed = 23L,
+        verbose = FALSE
+      ),
+      program,
+      data.frame(question = "inspect", answer = "yes"),
+      .llm = chat
+    )
+  )
+  expect_only_rlm_fallback_warnings(run)
+
+  expect_gt(length(observed_outputs), 0L)
+  expect_true(all(nchar(observed_outputs) <= program$max_output_chars))
+  expect_true(all(grepl("TRACE_HEAD", observed_outputs, fixed = TRUE)))
+  expect_true(all(grepl("TRACE_TAIL", observed_outputs, fixed = TRUE)))
+  expect_true(any(grepl(
+    "BOUNDED-RLM-TRACE:",
+    chat$optimizer_state$reflection_prompts,
+    fixed = TRUE
+  )))
+})

--- a/tests/testthat/test-teleprompter-harness.R
+++ b/tests/testthat/test-teleprompter-harness.R
@@ -235,6 +235,91 @@ test_that("MetaHarness can optimize multiple pipeline components jointly", {
   expect_equal(compiled$config$optimizer$best_score, 1)
 })
 
+test_that("agentic harnesses materialize both RLM predictor leaves", {
+  skip_if_not_installed("callr")
+  local_reset_cache()
+
+  proposal <- list(
+    name = "tune both RLM predictors",
+    rationale = "Action selection and typed extraction must improve together.",
+    edits = list(
+      list(
+        path = "$/generate_action",
+        instructions = "ACTION-HARNESS"
+      ),
+      list(
+        path = "$/extract",
+        instructions = "EXTRACT-HARNESS"
+      )
+    )
+  )
+  response <- list(
+    action = "propose",
+    rationale = "Tune both graph-visible predictors.",
+    candidates = list(proposal)
+  )
+  cases <- list(
+    AutoResearch = list(
+      teleprompter = AutoResearch(
+        metric = rlm_optimizer_accuracy,
+        max_iterations = 1L,
+        verbose = FALSE
+      ),
+      agent = make_harness_agent(list(response))
+    ),
+    MetaHarness = list(
+      teleprompter = MetaHarness(
+        metric = rlm_optimizer_accuracy,
+        max_iterations = 1L,
+        max_candidates_per_iteration = 1L,
+        verbose = FALSE
+      ),
+      agent = make_harness_agent_factory(list(response))
+    )
+  )
+
+  for (name in names(cases)) {
+    runner <- r_code_runner(timeout = 10, persistent = TRUE)
+    withr::defer(runner$close())
+    expect_identical(runner$policy()$persistent, TRUE)
+    program <- make_rlm_optimizer_program(runner)
+    chat <- make_rlm_optimizer_chat()
+    case <- cases[[name]]
+
+    run <- capture_rlm_optimizer_warnings(
+      compile(
+        case$teleprompter,
+        program,
+        data.frame(question = "inspect", answer = "yes"),
+        .llm = chat,
+        .agent_llm = case$agent,
+        runner = make_harness_runner()$runner,
+        control = optimizer_control(
+          checkpoint_registry = list(rlm_runner = runner)
+        ),
+        .cache = FALSE
+      )
+    )
+    compiled <- expect_only_rlm_fallback_warnings(run)
+
+    expect_identical(compiled$config$teleprompter, name)
+    expect_identical(
+      compiled$generate_action$signature@instructions,
+      "ACTION-HARNESS"
+    )
+    expect_identical(
+      compiled$extract$signature@instructions,
+      "EXTRACT-HARNESS"
+    )
+    expect_identical(compiled$config$optimizer$baseline_score, 0)
+    expect_identical(compiled$config$optimizer$best_score, 1)
+    expect_setequal(
+      names(named_parameters(compiled, boundaries = "cross")),
+      c("$/generate_action", "$/extract")
+    )
+  }
+})
+
 test_that("MetaHarness deduplicates candidates by canonical snapshot", {
   sandbox <- make_harness_runner()
   proposal <- candidate_proposal("perfect")

--- a/tests/testthat/test-teleprompter-mipro.R
+++ b/tests/testthat/test-teleprompter-mipro.R
@@ -105,6 +105,160 @@ test_that("MIPROv2 runs end-to-end with auto=light", {
   expect_true(file.exists(file.path(log_dir, "trials.jsonl")))
 })
 
+test_that("MIPROv2 tunes nested predictor instructions as graph components", {
+  runner <- list(
+    execute = function(code, context = list(), ...) {
+      list(success = TRUE, result = NULL)
+    },
+    policy = function() {
+      list(
+        backend = "test",
+        trust = "test-only",
+        sandboxed = TRUE,
+        persistent = TRUE
+      )
+    }
+  )
+  program <- rlm_module("question -> answer", runner = runner)
+  action_demos <- list(list(
+    inputs = list(state = "prior action state"),
+    output = list(reasoning = "inspect", code = "1 + 1")
+  ))
+  extract_demos <- list(list(
+    inputs = list(state = "prior extract state"),
+    output = "prior answer"
+  ))
+  program$generate_action$demos <- action_demos
+  program$extract$demos <- extract_demos
+  original_action <- program$generate_action$signature@instructions
+  original_extract <- program$extract$signature@instructions
+  trainset <- data.frame(question = "What is 2 + 2?", answer = "4")
+  evaluated <- list()
+
+  testthat::local_mocked_bindings(
+    resolve_mipro_settings = function(...) {
+      list(
+        trials = 4L,
+        minibatch_size = 1L,
+        full_eval_every = 1L,
+        demo_candidates = 1L,
+        instruction_candidates = 2L
+      )
+    },
+    optimizer_eval_program = function(
+      compiled,
+      budget,
+      stage,
+      unit_id,
+      ...
+    ) {
+      predictors <- dsprrr:::mipro_named_predictors(
+        compiled,
+        boundaries = "cross"
+      )
+      tuned <- vapply(
+        predictors,
+        function(predictor) {
+          grepl(
+            "Dataset summary:",
+            predictor$signature@instructions,
+            fixed = TRUE
+          )
+        },
+        logical(1)
+      )
+      evaluated[[length(evaluated) + 1L]] <<- tuned
+      dsprrr:::record_optimizer_outcome(budget, TRUE, stage)
+      dsprrr:::optimizer_budget_count_trial(budget, stage, unit_id)
+      dsprrr:::optimizer_budget_complete_unit(budget, unit_id)
+      dsprrr:::EvalResult(
+        mean_score = mean(tuned),
+        std_error = 0,
+        n_evaluated = 1L,
+        n_errors = 0L
+      )
+    },
+    .package = "dsprrr"
+  )
+
+  compiled <- compile(
+    MIPROv2(
+      metric = function(...) 1,
+      auto = NULL,
+      num_candidates = 2L,
+      max_bootstrapped_demos = 0L,
+      seed = 41L
+    ),
+    program,
+    trainset
+  )
+
+  expect_length(evaluated, 4L)
+  expect_setequal(
+    vapply(evaluated, paste, character(1), collapse = "/"),
+    c("FALSE/FALSE", "TRUE/FALSE", "FALSE/TRUE", "TRUE/TRUE")
+  )
+  expect_true(any(vapply(evaluated, all, logical(1))))
+  expect_match(
+    compiled$generate_action$signature@instructions,
+    "Dataset summary:",
+    fixed = TRUE
+  )
+  expect_match(
+    compiled$extract$signature@instructions,
+    "Dataset summary:",
+    fixed = TRUE
+  )
+  expect_identical(
+    program$generate_action$signature@instructions,
+    original_action
+  )
+  expect_identical(program$extract$signature@instructions, original_extract)
+  expect_identical(
+    compiled$signature@instructions,
+    program$signature@instructions
+  )
+  expect_identical(compiled$generate_action$demos, action_demos)
+  expect_identical(compiled$extract$demos, extract_demos)
+  expect_identical(
+    compiled$config$optimizer$candidate_scope,
+    "predictor_components"
+  )
+  expect_identical(compiled$config$optimizer$demo_mode, "preserved")
+  expect_identical(compiled$config$optimizer$effective_labeled_demos, 0L)
+  expect_identical(compiled$config$optimizer$effective_bootstrapped_demos, 0L)
+})
+
+test_that("MIPROv2 fails explicitly without nested predictor evidence", {
+  runner <- list(
+    execute = function(code, context = list(), ...) {
+      list(success = TRUE, result = NULL)
+    },
+    policy = function() {
+      list(
+        backend = "test",
+        trust = "test-only",
+        sandboxed = TRUE,
+        persistent = TRUE
+      )
+    }
+  )
+  program <- rlm_module("question -> answer", runner = runner)
+  trainset <- data.frame(question = "What is 2 + 2?", answer = "4")
+
+  expect_error(
+    compile(
+      MIPROv2(
+        metric = function(...) 1,
+        max_bootstrapped_demos = 1L
+      ),
+      program,
+      trainset
+    ),
+    class = "dsprrr_mipro_graph_bootstrap_unsupported"
+  )
+})
+
 test_that("MIPROv2 requires metric for compilation", {
   sig <- Signature(
     inputs = list(input(name = "question", class = S7::class_character)),

--- a/tests/testthat/test-teleprompter.R
+++ b/tests/testthat/test-teleprompter.R
@@ -106,6 +106,26 @@ test_that("LabeledFewShot compile works", {
   expect_equal(optimized_no_sample$demos[[2]]$inputs$text, "world")
 })
 
+test_that("LabeledFewShot rejects root labels for nested predictors", {
+  runner <- list(
+    execute = function(code, context = list(), ...) {
+      list(success = TRUE, result = NULL)
+    },
+    policy = function() {
+      list(backend = "test", trust = "test-only", sandboxed = TRUE)
+    }
+  )
+  program <- rlm_module("question -> answer", runner = runner)
+  trainset <- data.frame(question = "What is 2 + 2?", answer = "4")
+
+  expect_error(
+    compile(LabeledFewShot(k = 1L), program, trainset),
+    class = "dsprrr_labeled_graph_unsupported"
+  )
+  expect_length(program$generate_action$demos, 0L)
+  expect_length(program$extract$demos, 0L)
+})
+
 test_that("GridSearchTeleprompter can be created", {
   variants <- data.frame(
     id = c("v1", "v2"),

--- a/vignettes/advanced-modules.Rmd
+++ b/vignettes/advanced-modules.Rmd
@@ -36,7 +36,7 @@ library(ellmer)
 
 ## Overview
 
-dsprrr provides advanced module types inspired by [DSPy](https://dspy.ai/) that implement sophisticated reasoning patterns. These modules go beyond simple prompt-response to enable:
+Choose a module by the work it needs to do:
 
 - **Step-by-step reasoning** with ChainOfThought
 - **Multiple attempts** with BestOfN
@@ -44,16 +44,21 @@ dsprrr provides advanced module types inspired by [DSPy](https://dspy.ai/) that 
 - **Ensemble reasoning** with MultiChainComparison
 - **Exact computation** with ProgramOfThought (code generation)
 - **Hybrid agents** with CodeAct (tools + code execution)
+- **Adaptive investigation** of large or awkward R objects with RLM
+- **Implementation search** across predictors, R logic, and tools with Flex
 
-Each pattern addresses different challenges in LLM reliability and output quality.
+The sections below show each execution pattern and its tradeoffs.
 
 ## ChainOfThought
 
-ChainOfThought (CoT) is the foundational advanced reasoning pattern. It prompts the model to "show its work" by generating step-by-step reasoning before the final answer.
+ChainOfThought (CoT) asks the model for a reasoning field before the final
+answer.
 
 ### Why Use ChainOfThought?
 
-Research shows that asking models to reason step-by-step improves accuracy on complex tasks like math, logic, and multi-step reasoning. The model's intermediate reasoning also provides transparency into how it arrived at an answer.
+Use it when intermediate reasoning is useful to the task or evaluator. It adds
+tokens and does not make the reasoning inherently faithful, so evaluate the
+final output against a task-specific metric.
 
 ### Basic Usage
 
@@ -338,16 +343,15 @@ refined$get_feedback_history(all = TRUE)
 
 ## MultiChainComparison
 
-MultiChainComparison (MCC) implements ensemble reasoning by running multiple independent reasoning chains and synthesizing the best answer.
+MultiChainComparison (MCC) runs several independent reasoning chains and asks a
+final model call to synthesize one answer.
 
 ### Why Use MultiChainComparison?
 
-Different reasoning paths can lead to different insights. MCC:
+MCC:
 - Generates M diverse reasoning attempts (using temperature for variation)
 - Compares all attempts in a synthesis step
-- Produces a final answer that leverages the best reasoning
-
-This is particularly effective for complex reasoning tasks where there's no single "right" approach.
+- Produces one answer from the compared attempts
 
 ### Basic Usage
 
@@ -469,10 +473,9 @@ runner <- r_code_runner(
 ```
 
 **Security note**: `r_code_runner()` provides subprocess isolation but is not a
-security sandbox. For untrusted inputs, supply `mcp_repl_runner()` or another
-runner with verified OS-level sandboxing. mcp-repl is persistent: reset it
-between logically isolated jobs and do not share one runner across concurrent
-invocations.
+security sandbox. For untrusted generated code, use a fresh managed
+`mcp_repl_runner()` from an interpreter factory or another runner with verified
+OS-level sandboxing.
 
 ProgramOfThought, CodeAct, and RLM accept exactly one execution binding. Pass
 `runner` to retain a caller-owned runner object that dsprrr reuses and never
@@ -490,9 +493,9 @@ pot <- program_of_thought(
 )
 ```
 
-The factory form is the safer default when state must not cross invocation
-boundaries. The direct-runner form is useful for object reuse or intentional
-REPL persistence; never share a stateful runner across concurrent calls.
+The factory form prevents state from crossing invocation boundaries. A direct
+runner is caller-owned and sequential; never share a stateful runner across
+concurrent calls.
 Supplying both forms is an error.
 Factory-backed ProgramOfThought, CodeAct, and RLM support `run_async()` and
 isolated mirai batch execution because every invocation owns a fresh runner.
@@ -562,7 +565,9 @@ result <- run(
 
 ## CodeAct
 
-CodeAct combines the best of both worlds: it can use external tools AND execute R code. This makes it ideal for complex agentic tasks that require both information retrieval and computation.
+CodeAct combines declared host tools with generated R execution. Use it when a
+task needs both an external action and computation inside one bounded agent
+loop.
 
 ### Why Use CodeAct?
 
@@ -660,6 +665,135 @@ agent <- code_act(
 )
 ```
 
+## Recursive Language Model (experimental)
+
+Use an RLM when the answer is inside an R object but the useful slice and
+calculation are not known in advance. The model proposes one R operation,
+observes bounded output, and chooses the next operation. The full object does
+not enter every model prompt.
+
+That is a different job from the other code-oriented modules:
+
+| Need | Module |
+|---|---|
+| Execute a calculation whose steps are already known | `program_of_thought()` |
+| Discover an exploration path for this invocation | `rlm_module()` |
+| Learn a reusable implementation from labeled examples | `flex()` with GEPA |
+
+### Investigate a large R object
+
+The release-regression tutorial uses 40,000 session rows and 200 change
+records. A persistent callr runner stages those rich R objects once and keeps
+derived values between iterations:
+
+```{r rlm-rich-context, eval=FALSE}
+incident <- rlm_module(
+  paste(
+    "sessions, changes, question ->",
+    "release: string, cohort: string, before_rate: number,",
+    "after_rate: number, drop_pp: number, change_id: string, evidence: string"
+  ),
+  interpreter_factory = function() {
+    r_code_runner(timeout = 30, persistent = TRUE)
+  },
+  max_iters = 8,
+  max_llm_calls = 0L,
+  max_output_chars = 10000
+)
+
+result <- run(
+  incident,
+  sessions = sessions,
+  changes = changes,
+  question = "Which cohort regressed, and which change best explains it?",
+  .llm = chat_openai(),
+  .return_format = "structured"
+)
+```
+
+This configuration is appropriate only when the fixture and generated code are
+trusted. `persistent = TRUE` preserves one callr process, but that process has
+the host user's file, network, and environment permissions.
+
+The default `max_output_chars = 10000` keeps a head-and-tail excerpt from each
+execution in the next prompt. It bounds model-visible evidence; it does not
+increase a runner's transport limit.
+
+### Recursive queries return values
+
+`sub_lm = NULL` inherits the outer model passed to `run()`. Generated code can
+therefore assign and use the result of a focused query:
+
+```r
+candidate <- subset(.context$changes, component == "checkout-auth")
+interpretation <- llm_query(
+  "Which change could reduce successful token refreshes?",
+  paste(candidate$note, collapse = "\n")
+)
+SUBMIT(answer = interpretation)
+```
+
+The guest emits a nonce-bound, schema-checked request, dsprrr calls the model in
+the host, then replays the same code evaluation with the returned value. One
+ordered ledger prevents query/tool replay from changing operation kind. It
+cannot roll back an
+external side effect performed directly by generated code before the query, so
+RLM code should keep pre-query work read-only.
+
+`SUBMIT()` is checked against the signature. Missing required, extra, or
+incompatible fields become a repairable observation so the next iteration can
+correct the submission; optional fields may be omitted. If the iteration
+budget ends first, the extraction predictor attempts to produce the best typed
+answer supported by the trajectory; provider or type-validation failure remains
+terminal.
+
+The action and fallback extraction steps are graph-visible child predictors:
+
+```{r rlm-children, eval=FALSE}
+names(incident$graph_children())
+#> [1] "generate_action" "extract"
+```
+
+Structured results report whether the answer came from `SUBMIT()` or fallback,
+and retain the bounded trajectory:
+
+```{r rlm-metadata, eval=FALSE}
+result$output
+result$metadata$output_source
+result$metadata$repl_history
+result$metadata$runner_policy
+```
+
+### Choose the execution boundary
+
+The one-call helper creates a fresh managed MCP sandbox by default:
+
+```{r rlm-safe-default, eval=FALSE}
+answer <- rlm(
+  "document, question -> answer",
+  document = "Owner: team-a\nCommitment: rotate signing keys quarterly",
+  question = "Which commitments have no owner?",
+  .llm = chat_openai(),
+  .max_iterations = 4L,
+  .max_llm_calls = 0L
+)
+```
+
+Managed `mcp-repl` requires the suggested R package `mcptools` plus the external
+`mcp-repl` executable. It disables network access and applies an OS sandbox,
+but workspace writes remain allowed. Requests have a 7 KB wire bound and RLM
+control frames have a 3,000-byte encoded bound. When a raw request is too large,
+dsprrr first tries a gzip/base64 wrapper; the final JSON-RPC request must still
+fit the wire bound. Oversized output may be rejected by the runner before the
+module's 10,000-character head-and-tail formatter.
+Host tools run outside that sandbox with host permissions. Use explicit
+persistent `r_code_runner()` for trusted large data frames and fitted models;
+it is not a sandbox.
+
+See [Investigate a Release Regression with an
+RLM](tutorial-rlm-dsprrr.html) for the deterministic demo and [How the RLM
+Works](how-rlm-works.html) for the complete execution contract.
+
 ## Flex (experimental)
 
 Use `flex()` when the implementation strategy is the search problem. GEPA can
@@ -678,7 +812,7 @@ router accuracy while removing unnecessary model calls.
 
 ## Combining Modules
 
-These modules can be composed for sophisticated pipelines:
+These modules can be composed when one execution pattern is not enough:
 
 ```{r combining, eval=FALSE}
 # ChainOfThought inside BestOfN
@@ -696,7 +830,21 @@ refined_cot <- refine(cot_with_feedback, N = 3, reward_fn = quality_score)
 
 ## Optimization Support
 
-All advanced modules integrate with dsprrr's optimization:
+Wrapper modules retain their underlying optimizable predictors. RLM exposes
+separate `generate_action` and `extract` children, but optimizer support is
+deliberately explicit:
+
+| Optimizer | RLM support |
+|---|---|
+| `GEPA()` | Tunes both child predictors with end-to-end feedback; `metric_with_trace()` can derive feedback from the bounded RLM trajectory |
+| `AutoResearch()` / `MetaHarness()` | Discovers and applies both graph children |
+| `MIPROv2()` | Tunes child instructions only when `max_bootstrapped_demos = 0L` |
+| `BootstrapFewShot()` / `BootstrapFewShotWithRandomSearch()` | Programs containing Flex or an RLM are rejected; use GEPA, or instruction-only MIPROv2 for an RLM graph |
+| `LabeledFewShot()` | Programs containing an RLM are rejected because root examples do not match child signatures |
+
+Nested MIPRO demo bootstrapping fails with an actionable typed error until RLM
+collects predictor-local child evidence. This avoids attaching task-level demos
+to incompatible `state -> ...` predictors.
 
 ```{r optimization, eval=FALSE}
 # Grid search over wrapper parameters
@@ -719,45 +867,40 @@ compiled <- compile(tp, wrapper, trainset)
 
 ### Token Usage
 
-Advanced modules use more tokens than simple prediction:
-
-- **ChainOfThought**: ~1.5-2x tokens (reasoning + answer)
-- **BestOfN(N=3)**: Up to 3x tokens (worst case, no early stopping)
-- **Refine(N=3)**: Up to 3x tokens plus feedback overhead
-- **MCC(M=3)**: ~4x tokens (M chains + 1 comparison)
+Advanced modules trade additional calls for reasoning, retries, comparison, or
+exploration. The actual cost depends on early stopping, provider behavior,
+trajectory length, and recursive queries. Set explicit iteration and call
+budgets, then inspect returned metadata rather than relying on a fixed
+multiplier.
 
 ### Cost Tracking
 
-All modules track costs in metadata:
+Structured results expose the usage and cost metadata available for the module:
 
 ```{r cost-tracking, eval=FALSE}
-result <- run(mcc, question = "Test", .llm = llm)
-result$.metadata[[1]]$total_cost
-result$.metadata[[1]]$total_tokens
-result$.metadata[[1]]$n_llm_calls
+result <- run(
+  mcc,
+  question = "Test",
+  .llm = llm,
+  .return_format = "structured"
+)
+result$metadata$cost
+result$metadata$total_tokens
 ```
-
-### When to Use Each
-
-| Module | Best For | Trade-off |
-|--------|----------|-----------|
-| ChainOfThought | Complex reasoning, math, logic | Slight cost increase |
-| BestOfN | High-variance tasks, critical outputs | N× cost (with early stopping) |
-| Refine | Tasks with clear failure modes | N× cost + feedback gen |
-| MCC | Complex analysis, multiple valid approaches | (M+1)× cost |
 
 ## Summary
 
-dsprrr's advanced modules bring battle-tested patterns from DSPy to R:
+These modules cover distinct execution strategies:
 
 | Module | Best For | Trade-off |
 |--------|----------|-----------|
-| `chain_of_thought()` | Complex reasoning, math, logic | Slight cost increase |
-| `best_of_n()` | High-variance tasks, critical outputs | N× cost (with early stopping) |
-| `refine()` | Tasks with clear failure modes | N× cost + feedback gen |
-| `multi_chain_comparison()` | Complex analysis, multiple valid approaches | (M+1)× cost |
+| `chain_of_thought()` | Complex reasoning, math, logic | Longer model output |
+| `best_of_n()` | High-variance tasks, critical outputs | Additional candidate calls |
+| `refine()` | Tasks with clear failure modes | Iterative feedback calls |
+| `multi_chain_comparison()` | Complex analysis, multiple valid approaches | Candidate and comparison calls |
 | `program_of_thought()` | Exact computation, data analysis | Code execution overhead |
 | `code_act()` | Tasks needing both tools AND computation | Agent loop overhead |
+| `rlm_module()` | Adaptive exploration of large or irregular R objects | Experimental; iterative calls and an explicit execution boundary |
 | `flex()` | Optimizing the choice among predictors, R logic, and tools | Experimental; executable source requires a sandbox |
 
 **Getting started:**
@@ -765,6 +908,7 @@ dsprrr's advanced modules bring battle-tested patterns from DSPy to R:
 - Add **BestOfN** when you need reliability
 - Use **ProgramOfThought** for exact computation (math, statistics)
 - Use **CodeAct** when you need tools AND code execution together
+- Use **RLM** when the exploration path is unknown for this input
 - Use **Flex** when the implementation strategy itself is the experiment
 
 ## Further Reading
@@ -772,6 +916,7 @@ dsprrr's advanced modules bring battle-tested patterns from DSPy to R:
 **Tutorials:**
 - [Improving with Examples](tutorial-improve-with-demos.html) — Learn few-shot prompting
 - [Finding Best Configuration](tutorial-optimize-your-module.html) — Grid search optimization
+- [Investigate a Release Regression with an RLM](tutorial-rlm-dsprrr.html) — Explore a deterministic large object
 
 **How-to Guides:**
 - [Compile & Optimize](compilation-optimization.html) — Full optimization workflow with advanced modules
@@ -780,6 +925,7 @@ dsprrr's advanced modules bring battle-tested patterns from DSPy to R:
 **Concepts:**
 - [Understanding Signatures & Modules](concepts-signatures-modules.html) — S7 vs R6 design choices
 - [How Optimization Works](concepts-optimization-theory.html) — Teleprompter theory
+- [How the RLM Works](how-rlm-works.html) — Lifecycle, replay, typed submission, and runner boundaries
 
 **Reference:**
 - [Quick Reference](cheatsheet.html) — Syntax and patterns at a glance

--- a/vignettes/articles/agentic-optimization-harnesses.Rmd
+++ b/vignettes/articles/agentic-optimization-harnesses.Rmd
@@ -100,7 +100,7 @@ test connection from silently inheriting the trust assigned to a
 dsprrr-managed mcp-repl process.
 
 For RLM submit and recursive-query messages, dsprrr uses a versioned,
-per-invocation authenticated text frame capped at 3,000 encoded bytes. That cap
+per-invocation nonce-bound, schema-checked text frame capped at 3,000 encoded bytes. That cap
 keeps ordinary control messages below mcp-repl's inline-output threshold. If
 user code produces enough additional output to trigger a file preview or
 interactive pager, dsprrr fails the iteration (and attempts to reset the pager)

--- a/vignettes/articles/how-rlm-works.Rmd
+++ b/vignettes/articles/how-rlm-works.Rmd
@@ -1,8 +1,8 @@
 ---
 title: "How the Recursive Language Model (RLM) Works"
 description: >
-  From the research origins to dsprrr's R implementation: what Recursive
-  Language Models are, why they matter, and how the internals work.
+  The RLM execution contract: external context, iterative R code, recursive
+  queries, typed submission, runner ownership, and bounded evidence.
 author: "James H. Wade"
 date: "`r Sys.Date()`"
 output: rmarkdown::html_vignette
@@ -17,392 +17,378 @@ vignette: >
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  # Code blocks in this article are excerpts from the source, not runnable
-  # examples. The companion tutorial (tutorial-rlm-dsprrr) uses VCR cassettes
-  # for evaluated examples.
   eval = FALSE
 )
 ```
 
-## The Problem: Context Rot
+An RLM changes where context lives. A regular predictor serializes its inputs
+into the model request. An RLM keeps the inputs in an R execution environment
+and initially shows the model only their names, types, sizes, and previews. The
+model writes R code to select evidence, observes bounded output, and repeats
+until it can submit the signature's typed outputs.
 
-Modern LLMs accept enormous context windows. GPT-5 handles a million tokens; Gemini stretches to two million. But bigger windows do not solve the fundamental problem.
+That makes RLM an inference strategy for discovery, not a more elaborate way to
+answer every prompt.
 
-As context grows, performance degrades: details get lost and answers go wrong. The MIT researchers who introduced Recursive Language Models call this *context rot*, the empirical observation that output quality deteriorates as prompts grow, even when the relevant information is technically within the window [see @zhang2025rlm]. The model misses what it needs with increasing frequency as input length grows.
+## Decide before you build
 
-And there is no adaptive retrieval. The model cannot decide to re-read section 14 after discovering something relevant in section 42. It processes the entire input in one pass and produces output from whatever signal survived.
+| Need | Prefer |
+|---|---|
+| Short context and a direct answer | `Predict` |
+| Hard reasoning over already selected context | `ChainOfThought` |
+| A known calculation expressed as generated R code | `ProgramOfThought` |
+| External actions or data acquisition through tools | `ReAct` or `CodeAct` |
+| Retrieval from a prepared index | RAG |
+| Adaptive exploration of large or irregular in-memory objects | RLM |
+| Search for a reusable implementation across labeled cases | Flex |
 
-## The Insight: Context as Environment
+Use RLM when the model must discover *how* to inspect the supplied context.
+Skip it when a direct R function, SQL query, retrieval rule, or ordinary module
+already describes the path. Every RLM iteration adds another model call and
+another code execution.
 
-The core idea behind RLMs is simple: *don't put the context in the prompt*. Instead, store it as a variable in a programming environment and let the model write code to explore it.
+The [release-regression tutorial](tutorial-rlm-dsprrr.html) shows the intended
+shape: use R to identify an anomalous cohort, inspect one relevant change
+record, and validate the answer against an independent calculation.
 
-A traditional call looks like this:
+## One invocation, step by step
 
-```r
-llm$chat(paste("Summarize this document:", huge_document))
-```
+An invocation has six observable stages.
 
-An RLM inverts the relationship. The document lives outside the model as a variable in an R session, and the model generates code to interact with it. When you call `run()`, dsprrr provides a REPL: the model writes R code, dsprrr executes it in a subprocess, and the printed output feeds back into the next iteration. A typical exploration might look like this:
+1. `rlm_module()` reads the signature and fixes the iteration, recursive-call,
+   and output budgets.
+2. The runner loads the signature inputs into `.context`. A persistent runner
+   keeps its execution state for the whole invocation.
+3. The outer model receives variable metadata and the trajectory so far, then
+   proposes one R code block.
+4. The runner executes that code. After any stricter runner transport limit,
+   bounded head-and-tail output enters the next model turn; the full source
+   object does not.
+5. A valid `SUBMIT(...)` ends the loop. An invalid typed submission becomes
+   repairable feedback instead.
+6. If the loop spends `max_iters` without a valid submission, a final extraction
+   pass attempts to produce the best typed answer supported by the trajectory;
+   provider or type-validation failure remains terminal.
 
-```r
-# The model generates and executes code like this:
-intro <- peek(.context$document, 1, 2000)
-findings <- search(.context$document, "\\b(conclusion|finding|result)\\b")
-section_42 <- peek(.context$document, 85000, 90000)
-SUBMIT(answer = "The document concludes that...")
-```
+The core interface is small:
 
-The shift is from treating context as *input* to treating it as *environment*. The model reads what it needs, skips what it doesn't, and revisits sections as its picture of the data develops.
-
-In dsprrr's API, the module receives input arguments (e.g., `question`), holds context variables (e.g., `document`) outside the prompt, and exposes `llm_query()` so the model can delegate sub-questions to a secondary model from generated code. In the paper's notation [@zhang2025rlm], these correspond to a query $q$, context $C$, and a recursive tool call $\text{RLM}_M(\hat{q}, \hat{C})$ that spawns an isolated sub-instance with a new query and a transformed slice of the context.
-
-## Origin and Ecosystem
-
-RLMs were introduced by Alex Zhang, Tim Kraska, and Omar Khattab at MIT [@zhang2025rlm]. On BrowseComp-Plus (a benchmark with 6--11 million token inputs), standard models scored 0% while an RLM powered by GPT-5 achieved 91.33%. That comparison is less "RLM beats prompting" than "RLM makes previously intractable tasks tractable"; inputs that large exceed every current model's context window. The fairer apples-to-apples result is that their post-trained RLM-Qwen3-8B outperformed the base Qwen3-8B by 28.3% on average across long-context tasks.
-
-The idea has since spread quickly. DSPy integrated RLMs as a first-class module ([`dspy.RLM`](https://dspy.ai/api/modules/RLM/)) in version 3.1.2+, using a Pyodide WASM sandbox for code execution. Google's Agent Development Kit [re-implemented the pattern](https://medium.com/google-cloud/recursive-language-models-in-adk-d9dc736f0478) with Gemini models. The [official `rlm` Python package](https://github.com/alexzhang13/rlm), a [community implementation](https://github.com/ysz/recursive-llm), and [Prime Intellect's research program](https://www.primeintellect.ai/blog/rlm) round out the ecosystem. The [comparison table below](#how-dsprrrs-rlm-compares) summarizes the key differences.
-
-dsprrr's `rlm_module()` brings the same approach to R, using R as the REPL
-language instead of Python and structured outputs via
-[ellmer](https://ellmer.tidyverse.org/). Execution is delegated to the selected
-runner backend: the built-in `r_code_runner()` uses
-[callr](https://callr.r-lib.org/), while the default managed
-`mcp_repl_runner()` uses an OS-sandboxed persistent session.
-
-## How dsprrr Implements RLM
-
-The rest of this article walks through dsprrr's implementation. For a practical example, see `vignette("tutorial-rlm-dsprrr", package = "dsprrr")`, which uses `rlm_module()` to trace a theming bug across the bslib, shiny, and brand.yml codebases.
-
-### The User-Facing API
-
-Creating an RLM module requires a signature plus exactly one execution binding.
-To reuse a caller-owned runner object, pass `runner`:
-
-```{r}
+```{r basic-module}
 library(dsprrr)
 
-runner <- r_code_runner(timeout = 30)
-
-rlm <- rlm_module(
-  signature = "document, question -> answer",
-  runner = runner
+explorer <- rlm_module(
+  "document, question -> answer, evidence",
+  interpreter_factory = function() {
+    r_code_runner(timeout = 30, persistent = TRUE)
+  },
+  max_iters = 10,
+  max_llm_calls = 6,
+  max_output_chars = 10000
 )
 ```
 
-For tasks that benefit from recursive sub-queries, you can wire up a secondary model:
+All signature inputs are available under `.context`:
 
-```{r}
-rlm <- rlm_module(
-  signature = "document, question -> answer",
-  runner = runner,
-  sub_lm = ellmer::chat_openai(model = "gpt-5-mini"),
-  max_llm_calls = 10
+```r
+nchar(.context$document)
+search(.context$document, "renewal|termination")
+peek(.context$document, start = 12000, end = 15000)
+```
+
+`peek()` and `search()` are conveniences, not a separate query language. The
+generated program can use ordinary R functions appropriate to the value in
+`.context`.
+
+## State belongs to one invocation
+
+RLM code is iterative. A value calculated on one turn should remain available
+on the next, so the runner used for an invocation must provide persistent state.
+
+The recommended lifecycle is a zero-argument factory:
+
+```{r factory-lifecycle}
+explorer <- rlm_module(
+  "records, question -> answer",
+  interpreter_factory = function() mcp_repl_runner(),
+  max_iters = 10
 )
 ```
 
-You can also inject custom R functions as tools available in the REPL. The factory validates these against reserved names (`SUBMIT`, `peek`, `search`, `llm_query`, etc.) to prevent collisions.
+dsprrr creates one runner from the factory, uses it for that invocation, and
+closes it exactly once on success, error, or interrupt. Factory-backed modules
+can create isolated runners for concurrent invocations.
 
-### The REPL Loop
+A directly supplied `runner` is caller-owned. dsprrr neither resets nor closes
+it. RLM attempts to remove staged context and invocation-private variables when
+a call ends. Inspect cleanup warnings and close or reset the runner if cleanup
+fails. No cleanup can undo arbitrary file, option, or network side effects from
+guest code. Reuse a caller-owned runner only sequentially and within one trust
+boundary:
 
-When you call `run(rlm, ...)`, dsprrr dispatches to the module's internal `forward()` method. This is where the REPL loop lives. A `PredictModule`'s `forward()` makes a single call; the RLM module loops, up to `max_iterations` times (default 20):
-
-```{r}
-# From R/module-rlm.R (error handling, sub-query interception, and
-# fallback extraction omitted -- see those sections below)
-for (iter in seq_len(self$max_iterations)) {
-  # Build prompt including all previous iterations
-  prompt <- private$build_iteration_prompt(system_prompt, history, iter)
-
-  # Ask the model to generate R code
-  response <- private$get_code_response(llm, prompt)
-
-  # Execute code in isolated subprocess with RLM tools injected
-  exec_result <- private$execute_with_rlm_tools(
-    response$code,
-    inputs,
-    call_counter
+```{r caller-owned}
+local({
+  runner <- r_code_runner(timeout = 30, persistent = TRUE)
+  on.exit(runner$close(), add = TRUE)
+  explorer <- rlm_module(
+    "records, question -> answer",
+    runner = runner
   )
-
-  # Record in history -- the model sees this on the next iteration
-  history[[iter]] <- list(
-    iteration = iter,
-    reasoning = response$reasoning,
-    code = response$code,
-    output = exec_result$formatted_output,
-    success = exec_result$success,
-    is_final = exec_result$is_final
-  )
-
-  # SUBMIT() terminates the loop
-  if (exec_result$is_final) {
-    final_answer <- exec_result$final_value
-    break
-  }
-}
+  # Run explorer sequentially inside this scope.
+})
 ```
 
-Each iteration produces a structured response with two fields: `reasoning` (the model's explanation of its plan for that step) and `code` (R code to execute). This uses ellmer's structured output support:
+## Recursive calls happen through the host
 
-```{r}
-# From R/module-rlm.R -- structured code generation
-output_type <- ellmer::type_object(
-  reasoning = ellmer::type_string("Your thought process for this step"),
-  code = ellmer::type_string("R code to execute")
+The outer model is responsible for planning and code. Generated code can ask a
+model to interpret a focused slice:
+
+```r
+candidate <- subset(.context$notes, component == "checkout-auth")
+interpretation <- llm_query(
+  "Which change could reduce successful token refreshes?",
+  paste(candidate$note, collapse = "\n")
 )
-
-result <- llm$chat_structured(prompt, type = output_type)
+SUBMIT(answer = interpretation)
 ```
 
-The accumulated history gives the model a growing record of what it has tried. Failed executions are included. The model sees its own errors and can correct course.
+The replay bridge does not pass model credentials into the recursive call path.
+Guest access to environment variables and other host resources still depends
+on the selected runner: only a verified sandbox enforces that boundary. The
+guest emits a nonce-bound, schema-checked request, dsprrr calls the sub-model in
+the host process, and the code evaluation is replayed with the response.
+Ordinary R assignments are committed only after the replay completes, and
+bridged host tools execute once. Direct file, network, or other external side
+effects before a query cannot be rolled back and may repeat, so keep pre-query
+guest work read-only.
 
-### REPL Tools
+Bridge requests use unclassed JSON-compatible values. Missing values, `NaN`,
+infinities, and classed R objects are rejected instead of being silently
+coerced. A ToolDef schema helps the model form a call; the host function must
+still enforce domain-specific constraints before acting.
 
-Before each execution, dsprrr injects a "prelude" that defines the tools available in the subprocess. These are defined in `R/rlm-tools.R`:
+`sub_lm = NULL` inherits the outer model passed to `run()`. Supply a separate
+chat when narrow interpretation can use a cheaper model:
 
-`peek(var, start, end)` views a slice of a variable. It dispatches on the input type: for a character vector, `start` and `end` are element indices; for a single string, they are character positions:
-
-```{r}
-# From R/rlm-tools.R
-peek <- function(var, start = 1L, end = 1000L) {
-  if (!is.character(var)) {
-    var <- as.character(var)
-  }
-  if (length(var) > 1) {
-    return(var[max(1L, start):min(length(var), end)])
-  }
-  substr(var, max(1L, start), min(nchar(var), end))
-}
-```
-
-`search(var, pattern)` runs a Perl-compatible regex against a variable and returns all matches:
-
-```{r}
-# From R/rlm-tools.R
-search <- function(var, pattern, ignore_case = FALSE) {
-  if (!is.character(var)) {
-    var <- as.character(var)
-  }
-  if (length(var) > 1) {
-    var <- paste(var, collapse = "\n")
-  }
-  matches <- regmatches(
-    var,
-    gregexpr(pattern, var, ignore.case = ignore_case, perl = TRUE)
-  )
-  unlist(matches)
-}
-```
-
-`SUBMIT(...)` terminates the loop and returns the final answer. It validates that the provided values match the signature's output fields, supporting both positional (`SUBMIT("my answer")`) and named (`SUBMIT(answer = "my answer")`) arguments:
-
-```{r}
-# From R/rlm-tools.R -- simplified; see source for full validation logic
-SUBMIT <- function(...) {
-  args <- list(...)
-  arg_names <- names(args)
-  has_any_names <- any(nzchar(arg_names %||% ""))
-
-  if (!has_any_names) {
-    # Positional: match by order against signature output fields
-    names(args) <- .rlm_output_fields
-  } else {
-    # Named: validate that all required fields are present
-    missing <- setdiff(.rlm_output_fields, arg_names)
-    if (length(missing) > 0) {
-      stop("SUBMIT() missing outputs: ", paste(missing, collapse = ", "))
-    }
-  }
-
-  class(args) <- c("rlm_final", class(args))
-  args
-}
-```
-
-The `.rlm_output_fields` variable is not magic. It is injected into the subprocess by the same prelude that defines `peek()`, `search()`, and `SUBMIT()` itself. The prelude reads the signature's output field names and writes them as a character vector at the top of the execution script.
-
-The `rlm_final` class is a sentinel: when the parent process sees it in the subprocess result, it exits the loop and extracts the answer.
-
-### Runner-Selected Isolation
-
-The example in this article uses `RCodeRunner`, so each generated code fragment
-runs in an isolated R subprocess via `callr::r()`. The `RCodeRunner` class in
-`R/r-code-runner.R` handles that backend:
-
-```{r}
-# From R/r-code-runner.R -- subprocess execution (simplified)
-exec_result <- callr::r(
-  func = private$execution_wrapper,
-  args = list(code = code, context = context, ...),
-  timeout = self$timeout,
-  stdout = stdout_file,
-  stderr = stderr_file,
-  user_profile = FALSE
+```{r sub-lm}
+explorer <- rlm_module(
+  "documents, question -> answer",
+  interpreter_factory = function() mcp_repl_runner(),
+  sub_lm = ellmer::chat_openai(),
+  max_llm_calls = 8
 )
 ```
 
-Inside the subprocess, a fresh environment is created with the context available as `.context`. The wrapper overrides `library()` and `require()` to enforce a package allowlist, and a pattern scanner rejects calls to `system()`, `unlink()`, `quit()`, and `download.file()`. Each iteration spawns a new subprocess, so each pays a cold-start cost (typically 200--400ms depending on platform).
+`llm_query_batched()` runs independent focused questions concurrently and
+returns results in input order. A per-request provider failure becomes an
+ordered `[ERROR] ...` slot. An unexpected exception, malformed batch result, or
+transport-level failure terminates the invocation instead of masquerading as a
+model answer. Every requested prompt consumes one unit of `max_llm_calls`. Set
+that budget from the economics of the task, not from the largest number the
+provider permits.
 
-### Recursive Sub-Queries
+## Submission is part of the contract
 
-This is where the "recursive" in RLM comes from. When `sub_lm` is provided, the model can write `llm_query("What does section 3 say?", context_slice)` in its generated code. The function does not execute the sub-call inside the subprocess, which would be a security problem. Instead, it returns a marker object:
+The signature defines both the names and types accepted by `SUBMIT()`:
 
-```{r}
-# From R/rlm-tools.R -- returns a marker, not a result
-llm_query <- function(query, context_slice = NULL) {
-  structure(
-    list(query = query, context = context_slice, batch = FALSE),
-    class = "rlm_query_request"
-  )
-}
+```{r typed-submit}
+typed <- rlm_module(
+  paste(
+    "logs ->",
+    "error_count: integer,",
+    "severity: enum('low', 'high'),",
+    "evidence: array(string)"
+  ),
+  interpreter_factory = function() mcp_repl_runner()
+)
 ```
 
-The parent process intercepts this marker after execution, performs the actual call, and feeds the result back on the next iteration. A batched variant, `llm_query_batched()`, allows multiple sub-questions at once, running concurrently via `ellmer::parallel_chat()` when available.
+Generated code can submit named values:
 
-A shared call counter tracks total calls across all iterations and enforces the `max_llm_calls` budget, preventing runaway recursion.
-
-### Fallback and Output Normalization
-
-If the model exhausts all iterations without calling `SUBMIT()`, the module performs fallback extraction: it feeds the entire exploration trajectory back and asks for a synthesized answer from what was discovered. This uses a two-phase approach, trying structured output via `chat_structured()` first, then unstructured `chat()` if that fails.
-
-The final answer passes through output normalization, which coerces whatever was produced into the signature's declared output fields. This handles named lists, positional lists, scalar values, and case-insensitive enum matching (e.g., `"Positive"` is mapped to `"positive"` if the signature declares `type_enum("positive", "negative")`).
-
-### Observability
-
-Every RLM execution records its full REPL history: reasoning, code, output, success or failure, and timing for each iteration:
-
-```{r}
-history <- rlm$get_repl_history()
-last_run <- history[[length(history)]]
-
-last_run$iterations_used
-#> [1] 5
-last_run$llm_calls_used
-#> [1] 3
+```r
+SUBMIT(
+  error_count = 7L,
+  severity = "high",
+  evidence = c("AUTH-401 increased", "Refresh retries fell to zero")
+)
 ```
 
-You can see what the model tried, where it went wrong, and how it recovered.
+Missing required fields, extra fields, and incompatible values do not silently
+become a final answer. Optional fields may be omitted. The validation message
+joins the trajectory, giving the model a chance to repair its submission.
+Positional submission is supported, but named fields are easier to audit.
 
-## How dsprrr's RLM Compares
+RLM strictly validates explicit ellmer string, number, integer, boolean, enum,
+array, and object types, including nested combinations. It rejects opaque
+`TypeJsonSchema` output nodes at construction because accepting them without a
+JSON Schema validator would make the repair contract misleading. Express the
+output with ellmer's explicit type constructors when using RLM.
 
-The table below summarizes the key implementations:
+If `max_iters` is exhausted, fallback extraction reads the trajectory and
+attempts to return the signature fields. Provider or output-validation failure
+still terminates the invocation. Treat a successful fallback as degraded
+completion: it is useful, but it is evidence that the exploration budget or
+instructions may need work.
 
-| | dsprrr | DSPy | Official `rlm` | Google ADK |
-|---|---|---|---|---|
-| **Language** | R | Python | Python | Python |
-| **REPL** | R via callr | Python via Pyodide/WASM | Python (isolated or not) | Python via ADK |
-| **Sandbox** | Subprocess (callr) | Deno/WASM | Configurable | ADK orchestration |
-| **Structured output** | ellmer types | DSPy signatures | Freeform | ADK tools |
-| **Recursive calls** | `llm_query()` | Built-in | Built-in | Child agents |
-| **Optimization** | Teleprompters, grid search | DSPy optimizers | Manual | Manual |
-| **Batched sub-calls** | `llm_query_batched()` | `llm_query_batched()` | -- | -- |
+## Output is bounded evidence
 
-The "batched sub-calls" row refers specifically to issuing multiple recursive
-sub-queries from one REPL iteration and running them concurrently. Both dsprrr
-and DSPy 3.3 expose that operation. dsprrr dispatches its batch through
-`ellmer::parallel_chat()` while preserving the R runner's lifecycle and call
-budget.
+`max_output_chars` limits how much runner output from each execution enters
+model history. The default 10,000-character module display retains the head and
+tail. A runner may impose a stricter limit first: managed MCP rejects file/pager
+compaction for RLM rather than treating an incomplete preview as evidence. The
+module bound is not permission to return arbitrarily large control payloads.
 
-dsprrr is the only implementation that uses R as the REPL language, which matters when your context *is* R data: data frames, model objects, or package source code. It also inherits dsprrr's full optimization infrastructure (teleprompters, grid search, evaluation metrics), so you can systematically improve RLM performance, not just run it.
+Ask for structured output when the trajectory matters:
 
-## When to Use RLMs (and When Not To)
+```{r structured-result}
+result <- run(
+  explorer,
+  records = records,
+  question = "Which change preceded the failure spike?",
+  .llm = ellmer::chat_openai(),
+  .return_format = "structured"
+)
 
-The hard part of any task here is either *finding* the right context or *reasoning* about it once found. RLMs help with the first problem. If the context is already short and well-scoped, simpler approaches are faster and cheaper.
+result$output
+result$metadata$repl_history
+result$metadata$iterations
+result$metadata$llm_calls
+result$metadata$runner_policy
+```
 
-| Approach | Best for | Latency | Context limit |
-|----------|----------|---------|---------------|
-| `PredictModule` | Short, self-contained tasks | Low | Context window |
-| `chain_of_thought()` | Complex reasoning, known context | Medium | Context window |
-| `rag_module()` | Lookup in large corpora | Medium | Chunk size |
-| `rlm_module()` | Exploration of large, interconnected data | High | Unlimited\* |
+Each trajectory entry records the proposed reasoning, executed code, displayed
+output, success state, and whether a final submission occurred. Prefer the
+returned metadata over mutable module state for async or batch work.
 
-\*Bounded by `max_iterations` and `max_llm_calls`, not by context window size.
+### One investigation or many
 
-**Skip RLMs when the context is short.** If the document fits comfortably in the context window, a `PredictModule` or `chain_of_thought()` will be faster and cheaper. The overhead of multiple REPL round-trips is not justified when one call suffices.
+`run()` always stages each RLM input as one REPL variable. Its R length does not
+imply a batch: an atomic vector, list, matrix, data frame, or fitted model is one
+context object for one investigation. This matches the way generated code reads
+the inputs through `.context` and avoids silently splitting irregular objects.
 
-**Skip RLMs when the task is well-defined.** If you know what you are looking for (extracting a specific field from a known document format, say), a prompt-optimized module will outperform an RLM. RLMs spend iterations discovering a good exploration path. If you already know the path, skip the discovery.
+Use `run_dataset()` for multiple investigations. Each data-frame row is one RLM
+invocation; put rich per-row objects in list-columns. A factory-backed RLM owns
+one fresh runner per row and can use isolated mirai execution. A caller-owned
+runner is reused sequentially and rejects concurrent dataset execution.
 
-**Skip RLMs when cost-per-query matters.** An RLM with 15 iterations makes at least 15 calls, plus any recursive sub-queries. For a production pipeline processing thousands of inputs, that multiplier adds up. If a single-call module with good prompting gets you 80% of the accuracy at 5% of the cost, the economics favor the simpler approach.
+The counters separate workflow steps from paid provider work.
+`action_calls`, `recursive_calls`, and `extraction_calls` count logical RLM
+operations. `provider_calls` sums the verified provider turns behind them, with
+component fields for action, recursive, and extraction calls. A cached action
+or extraction contributes zero provider calls and zero current-run usage. If a
+backend cannot prove every contributing turn, provider, token, and cost totals
+remain `NA` instead of reporting a partial total.
 
-**Skip RLMs when the context contains bad information.** RLMs gather more evidence than simpler approaches, which is usually beneficial. But more evidence also means more surface area for misleading content. If the context contains contradictions, outdated facts, or adversarial content, a `chain_of_thought()` module with curated context gives explicit control over what the model sees.
+## Choose the execution boundary
 
-## Improvement Opportunities
+RLM executes model-generated code. Runner choice is therefore part of the
+program's security and data contract.
 
-dsprrr's RLM implementation is functional but young. The items below are split into design constraints that affect deployment and API improvements that would make the module more ergonomic.
+| Runner path | Strength | Limitation |
+|---|---|---|
+| Managed `mcp_repl_runner()` | OS sandbox, network disabled, fresh factory-owned invocation | Workspace writes remain allowed; bounded transport is intended for compact JSON-compatible context |
+| Persistent `r_code_runner()` | Preserves rich R objects in a long-lived callr process | Not a security sandbox; process retains the host user's permissions |
+| Custom runner | Can provide a remote sandbox or domain-specific resource loading | Must implement and truthfully report the dsprrr runner policy |
 
-### Design Constraints
+The one-call `rlm()` helper chooses a fresh managed MCP runner by default.
+Install the suggested R package and external executable first:
 
-**Choose the runner as a security boundary.** `r_code_runner()` provides a fresh
-callr subprocess and package allowlist, but it retains the host user's
-permissions and is only for trusted code. For model-generated or otherwise
-untrusted code, `mcp_repl_runner()` launches Posit's mcp-repl with an
-OS-enforced workspace-write sandbox and network access disabled. A user-supplied
-`repl` function is reported as unverified and is not accepted where dsprrr
-requires sandboxed execution.
+```sh
+R -q -e 'install.packages("mcptools")'
+uv tool install posit-mcp-repl
+```
 
-**Runner ownership is explicit.** A directly supplied `runner` is caller-owned
-and reused across separate `forward()` calls; dsprrr never closes it. The
-backend determines whether execution state persists and whether `reset()` is
-available. mcp-repl retains variables and loaded packages until you call
-`runner$reset()`. Reset that persistent backend between logically isolated
-jobs and never share it across concurrent invocations.
+Then run a compact investigation:
 
-For isolated invocations, pass `interpreter_factory` instead. It must be a
-zero-argument function returning a valid runner. dsprrr calls it once per
-invocation, owns that fresh runner, and closes it exactly once when the
-invocation ends, including after a failure:
-
-```{r rlm-interpreter-factory, eval=FALSE}
-rlm <- rlm_module(
+```{r safe-convenience}
+answer <- rlm(
   "document, question -> answer",
-  interpreter_factory = function() r_code_runner(timeout = 30)
+  document = "Owner: team-a\nObligation: rotate signing keys quarterly",
+  question = "Which obligations have no owner?",
+  .llm = ellmer::chat_openai(),
+  .max_iterations = 4L,
+  .max_llm_calls = 0L
 )
 ```
 
-`runner` and `interpreter_factory` are mutually exclusive, and one is required.
+The managed default runs model-generated code under an OS sandbox with network
+access disabled; it can still mutate allowed workspace files. The final
+JSON-RPC request must fit the 7 KB wire bound. When the raw request is too
+large, dsprrr first tries a gzip/base64 wrapper and rejects it before execution
+only if that request still does not fit.
+`SUBMIT()` values, recursive-query context slices, and host-tool arguments also
+cross a 3,000-byte encoded control-frame boundary. Replayed query and tool
+results instead count against the next 7 KB raw-or-compressed request. Large
+data frames and fitted models can use an explicit trusted
+`r_code_runner(persistent = TRUE)`. Live external-pointer resources generally
+need a child-side resource loader or a custom runner rather than callr
+serialization.
 
-Factory-backed RLM invocations can also use `run_async()` and isolated mirai
-dataset batches. A caller-owned runner remains sequential-only because dsprrr
-cannot prove that shared interpreter state is safe under overlap. Async
-streaming and finite batch timeout/error-budget controls are not adapted yet
-and fail before runner work.
+The runner boundary is not a privacy guarantee. RLM automatically sends up to
+1,000 characters of a structural preview for each input value to the outer
+model; `str()`-style previews can include sample values. Anything printed into
+the trajectory, passed to `llm_query()`, or returned in the final answer can
+also be sent to the configured provider. Declared host tools run in the dsprrr
+host process, outside the guest sandbox, with the host's permissions.
 
-**Execution and interpreter failures are different.** A submitted R expression
-can fail in a repairable way, allowing the RLM to inspect the error and try a
-new expression. Process, transport, protocol, startup, and shutdown failures
-are terminal: the runner is invalidated and is never retried or reused. If
-execution and teardown both fail, dsprrr preserves the primary execution
-condition and attaches teardown evidence instead of replacing it.
+Action and fallback predictor requests also follow dsprrr's response-cache
+configuration, which can include memory and disk. For sensitive investigations,
+pass `.cache = FALSE` to `run()` or configure a memory-only or disabled cache.
+Recursive `llm_query()` calls and runner execution are not response-cached.
 
-**Custom tools execute on the host.** Guest code emits an authenticated tool
-request, dsprrr invokes the original function and its live closure in the host
-process, and the guest program is replayed with that immutable response. The
-function itself is never deparsed or serialized into generated code. This
-runner-neutral bridge works with both `r_code_runner()` and mcp-repl; arguments
-and results still need to cross the runner's value boundary. A host tool is
-called once even though deterministic guest code before it may be replayed.
+## Repairable and terminal failures
 
-**mcp-repl control results are intentionally bounded.** RLM submit and recursive
-query frames are capped at 3,000 encoded bytes to stay inline. If incidental
-output triggers an mcp-repl file preview or pager, the iteration fails closed
-rather than trusting a partial control frame. Keep `SUBMIT()` values compact;
-use a transport with structured out-of-band results when larger payloads are a
-requirement.
+Ordinary R errors are part of exploration. A malformed regular expression or
+missing column can be shown to the model so it can try a corrected expression.
 
-**Fresh subprocesses have cold-start overhead.** `r_code_runner()` pays process
-startup cost on each iteration in exchange for clean process state. A
-persistent mcp-repl runner avoids that repeated startup, but requires the reset
-and concurrency discipline above.
+Interpreter startup, transport, protocol, and shutdown failures are different.
+They invalidate the execution boundary and terminate the invocation. dsprrr
+does not disguise those failures as an empty observation or reuse a runner whose
+state is uncertain.
 
-### API Improvements
+Three budgets keep the ordinary loop finite:
 
-**`peek()` dual-dispatch API.** `peek()` silently changes meaning depending on whether the input is a single string (character positions) or a character vector (element indices). The model has to infer which form `.context$document` is in, and if it guesses wrong, the slice is nonsensical. Splitting into `peek_chars()` and `peek_lines()` (or adding a `unit` argument) would make the contract explicit.
+| Argument | Bounds |
+|---|---|
+| `max_iters` | Outer model/code/observation turns before fallback |
+| `max_llm_calls` | Host-side recursive model calls; batch items count separately |
+| `max_output_chars` | Head-and-tail execution output retained per turn |
 
-**`search()` returns raw matches, not locations.** The model gets the matched text but not the byte offset or surrounding context, so it often has to follow up with a `peek()` call to figure out *where* the match occurred. Returning match positions or a concordance-style snippet would save an iteration.
+The host bridge also enforces an internal safety ceiling of 1,000 declared tool
+calls in one generated R step. This is a protocol guard, not a recommended
+working budget; generated steps should make a small, auditable number of calls.
 
-## What's Next
+Start small, inspect the returned trajectory, and increase a budget only when
+the trace shows useful unfinished work.
 
-RLMs trade latency for reach. They can explore contexts that no model handles well in a single pass, with subprocess isolation, recursive sub-queries, and full optimization support through dsprrr's teleprompters and grid search.
+## Relationship to DSPy
 
-For a hands-on walkthrough, see `vignette("tutorial-rlm-dsprrr", package = "dsprrr")`, which uses `rlm_module()` to trace a real theming bug across bslib, shiny, and brand.yml: nearly 4 million characters of source, explored in under 15 iterations.
+RLMs were introduced by Zhang, Kraska, and Khattab [@zhang2025rlm]. DSPy makes
+the pattern a module with a per-invocation interpreter, recursive query tools,
+typed final output, and trajectory metadata. dsprrr follows those execution
+contracts while using R and ellmer:
+
+- inputs appear as `.context$name` and generated programs are R;
+- `sub_lm = NULL` inherits the invocation's outer ellmer chat;
+- a factory creates one persistent runner per invocation; a caller-owned
+  persistent runner can be reused sequentially;
+- invalid typed submissions are repairable observations;
+- recursive calls and host tools cross a validated replay boundary; and
+- `run(..., .return_format = "structured")` returns outputs with trajectory and
+  runner evidence.
+
+The R implementation is not a line-by-line port. In particular, runner and
+serialization capabilities determine which R objects can cross into an
+execution environment. Those limits should be visible and testable rather than
+described as unlimited context.
+
+## The practical rule
+
+Use RLM for high-value questions where the useful slice and computation are not
+known beforehand. Inspect its trajectory as seriously as its answer. When the
+same exploration pattern repeats, replace discovery with a deterministic R
+function, a dsprrr pipeline, or an optimized executable program.
+
+For a complete deterministic example, continue to
+[Investigate a Release Regression with an RLM](tutorial-rlm-dsprrr.html).
 
 ## References

--- a/vignettes/articles/tutorial-rlm-dsprrr.Rmd
+++ b/vignettes/articles/tutorial-rlm-dsprrr.Rmd
@@ -1,645 +1,395 @@
 ---
-title: "Recursive Language Models: Exploring Codebases with dsprrr"
+title: "Investigate a Release Regression with an RLM"
+description: >
+  Use an RLM to explore a large R data frame, isolate a conversion regression,
+  and connect it to a relevant change record.
 output: rmarkdown::html_vignette
 vignette: >
-  %\VignetteIndexEntry{Recursive Language Models: Exploring Codebases with dsprrr}
+  %\VignetteIndexEntry{Investigate a Release Regression with an RLM}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r}
-#| include: false
-# Replay recorded HTTP responses (VCR cassettes) during site builds;
-# skip evaluation entirely during R CMD check to avoid API dependencies.
-force_eval <- identical(Sys.getenv("VITALS_SHOULD_EVAL"), "true")
-in_ci <- !force_eval &&
-  (nzchar(Sys.getenv("CI")) || nzchar(Sys.getenv("GITHUB_ACTIONS")))
-in_check <- !force_eval &&
-  (nzchar(Sys.getenv("_R_CHECK_PACKAGE_NAME_")) ||
-    identical(Sys.getenv("NOT_CRAN"), "false"))
-
-should_eval <- !in_ci && !in_check && dsprrr:::eval_vignette()
-
+```{r setup, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
-  eval = should_eval
+  eval = FALSE
+)
+```
+
+An RLM is useful when the answer is buried in a large object and you do not
+know the right exploration path in advance. It keeps the object in an R
+environment, lets the model inspect it with R code, and returns only selected
+results to the model between steps.
+
+This worked example asks an RLM to investigate a checkout regression. The
+deterministic fixture contains 40,000 sessions (about 3.6 MB as row-oriented
+JSON) and 200 change records. The expected finding is fixed and independently
+checkable:
+
+```text
+release:      2.4.0
+cohort:       platform=mobile / plan=pro
+before_rate:  0.92
+after_rate:   0.61
+drop_pp:      31
+change_id:    CHG-1842
+evidence:     Mobile Pro token refresh: retry budget changed from 3 to 0 and timeout from 8 s to 800 ms.
+```
+
+The model must discover which low-cardinality categorical fields define the
+affected cohort, calculate the change, and find the most relevant release
+note. It does not receive the complete session table in its prompt.
+
+## Why use an RLM here?
+
+The task combines three properties:
+
+- the source object is expensive and distracting to serialize into a prompt;
+- the useful grouping is not supplied in the question; and
+- the answer needs both exact aggregation and interpretation of a small piece
+  of text.
+
+A regular `Predict` or `ChainOfThought` module would put the supplied context in
+token space. `ProgramOfThought` is a better fit when the required computation
+is already known. A deterministic R pipeline is best once the investigation
+pattern is stable. RLM occupies the exploratory middle: the model decides what
+to inspect, uses R for exact work, and revises its plan from the results.
+
+## Build the deterministic incident
+
+The fixture uses no random numbers. Every cohort contains exactly 5,000
+sessions per release.
+
+```{r make-sessions}
+n <- 5000L
+
+sessions <- expand.grid(
+  release = c("2.3.9", "2.4.0"),
+  platform = c("desktop", "mobile"),
+  plan = c("free", "pro"),
+  within_group = seq_len(n),
+  KEEP.OUT.ATTRS = FALSE,
+  stringsAsFactors = FALSE
 )
 
-if (should_eval) {
-  if (!is.null(vcr::current_cassette())) {
-    try(vcr::eject_cassette(), silent = TRUE)
-  }
-  vcr::vcr_configure(
-    dir = "_vcr",
-    filter_request_headers = c("Authorization", "x-api-key"),
-    match_requests_on = c("method", "uri")
-  )
-  vcr::setup_knitr()
-}
+base_rate <- c(
+  "desktop.free" = 0.88,
+  "mobile.free" = 0.84,
+  "desktop.pro" = 0.94,
+  "mobile.pro" = 0.92
+)
+
+cohort_key <- paste(sessions$platform, sessions$plan, sep = ".")
+conversion_rate <- unname(base_rate[cohort_key])
+conversion_rate[
+  sessions$release == "2.4.0" & cohort_key == "mobile.pro"
+] <- 0.61
+
+sessions$converted <-
+  sessions$within_group <= n * conversion_rate
 ```
 
-LLM context windows have a hard ceiling. A large codebase either doesn't fit,
-or, if it does, accuracy degrades silently: the model keeps producing confident
-output while dropping details buried in the middle.
+Most change records are irrelevant. One describes a checkout-authentication
+change for the affected release and cohort.
 
-Recursive Language Models (RLMs) take a different approach. Instead of pasting
-context into the prompt, they give the model programmatic tools to explore it.
-The model writes R code to read files, search for patterns, and accumulate
-relevant excerpts iteratively, turning long-context problems into coding
-problems. For the conceptual background (what context rot is, how the ecosystem
-evolved, and how dsprrr's internals work), see
-the [How the RLM Works](how-rlm-works.html) article.
+```{r make-changes}
+changes <- data.frame(
+  change_id = sprintf("CHG-%04d", 1701:1900),
+  release = rep(c("2.3.9", "2.4.0"), each = 100),
+  component = "miscellaneous",
+  note = "Routine maintenance with no expected checkout impact."
+)
 
-```
-Traditional:  [entire document] -> LLM -> answer
-RLM:          [query only]      -> LLM -> code -> [selective reads] -> LLM -> ...
-```
-
-This tutorial uses `rlm_module()` to explore three interconnected R package
-codebases (bslib, shiny, and brand.yml) and investigate a real open issue
-that spans all three. By Step 8, we show that repeated RLM runs converge on
-the same five-phase exploration pattern, a finding you can use to design
-deterministic pipelines.
-
-**Time**: 30--45 minutes
-
-**Topics covered:**
-
-- Setting up an RLM module for codebase exploration
-- Comparing RLM results against a curated-context baseline
-- Tracing a real bug across three interconnected R packages
-- Delegating interpretive work with recursive sub-queries
-- Extracting stable exploration patterns from RLM traces
-
-## The Problem: Contributing to bslib
-
-[bslib issue #1123](https://github.com/rstudio/bslib/issues/1123): setting
-the `primary` color in `bs_theme()` changes the navbar in `page_navbar()` but
-is ignored by `page_sidebar()`. A user reported it with this example:
-
-```r
-# This changes the navbar color:
-page_navbar(theme = bs_theme(preset = "flatly", primary = "#95a5a6"))
-
-# This does NOT:
-page_sidebar(theme = bs_theme(preset = "flatly", primary = "#95a5a6"))
+target <- which(changes$change_id == "CHG-1842")
+changes$component[target] <- "checkout-auth"
+changes$note[target] <- paste(
+  "Mobile Pro token refresh:",
+  "retry budget changed from 3 to 0 and timeout from 8 s to 800 ms."
+)
 ```
 
-Fixing this requires tracing how a brand color flows through three packages:
+The question does not reveal the affected dimensions:
 
-- **brand.yml**: reads `_brand.yml` files and generates Sass variables
-- **bslib**: compiles those variables into Bootstrap CSS
-- **shiny**: renders the themed UI components
+```{r question}
+question <- paste(
+  "Checkout conversion fell after release 2.4.0.",
+  "Find the finest low-cardinality categorical cohort with the largest",
+  "before/after drop; do not stop at a marginal roll-up that dilutes the",
+  "change. Identify its dimensions and values, quantify the rates, and cite",
+  "the change-log record that is the strongest candidate explanation."
+)
+```
 
-The bslib package alone has over 500 R and SCSS files. Adding shiny and
-brand.yml pushes the total context to nearly 4 million characters, well
-beyond what fits in a single prompt.
+## Define the investigation
 
-## Step 1: Setup and Load the Codebases
+The output signature makes the evidence checkable. `SUBMIT()` must provide all
+of these fields with compatible types.
 
-```{r setup}
+```{r define-rlm}
 library(dsprrr)
 library(ellmer)
-```
 
-Create an `RCodeRunner` for executing the code the RLM generates:
-
-```{r runner-setup}
-runner <- r_code_runner(timeout = 30)
-```
-
-This tutorial evaluates code against trusted local package sources, so the
-fresh callr subprocess is appropriate. It is isolation, not a security
-sandbox. For untrusted or adversarial inputs, use `mcp_repl_runner()` and its
-OS-enforced sandbox; reset that persistent runner between logically isolated
-jobs and do not share it across concurrent invocations.
-
-This tutorial reuses the caller-owned `runner` deliberately. For one fresh
-runner per `run()`, omit `runner` from `rlm_module()` and pass the mutually
-exclusive zero-argument factory instead:
-
-```{r runner-factory}
-runner_factory <- function() r_code_runner(timeout = 30)
-investigator <- rlm_module(
-  "document, question -> answer",
-  interpreter_factory = runner_factory
-)
-```
-
-dsprrr owns a factory-created runner and closes it exactly once at the end of
-the invocation, including when evaluation fails.
-
-Pull the source code for all three packages. The `read_package_source()`
-helper below clones a repo, concatenates its R and SCSS files into a single
-string (preserving file paths), and returns the result. Expand the fold to
-see the implementation, or skip ahead; the important thing is what the
-function returns, not how it works.
-
-<details>
-<summary>Definition of <code>read_package_source()</code></summary>
-
-```{r read-package-source, cache = TRUE}
-read_package_source <- function(repo, ref = "main", subdirs = c("R", "inst")) {
-  dir <- tempfile()
-  status <- system2(
-    "git",
-    c(
-      "clone",
-      "--depth=1",
-      "--branch",
-      ref,
-      paste0("https://github.com/", repo, ".git"),
-      dir
-    ),
-    stdout = FALSE,
-    stderr = FALSE
-  )
-  if (status != 0) {
-    stop("git clone failed for ", repo, " (exit code ", status, ")")
-  }
-
-  files <- unlist(lapply(subdirs, function(subdir) {
-    list.files(
-      file.path(dir, subdir),
-      pattern = "\\.(R|r|scss)$",
-      recursive = TRUE,
-      full.names = TRUE
-    )
-  }))
-
-  contents <- vapply(
-    files,
-    function(f) {
-      path <- sub(paste0(dir, "/"), "", f)
-      paste0("--- FILE: ", path, " ---\n", paste(readLines(f), collapse = "\n"))
-    },
-    character(1),
-    USE.NAMES = FALSE
-  )
-
-  paste(contents, collapse = "\n\n")
-}
-```
-
-</details>
-
-```{r load-code, cache = TRUE}
-bslib_source <- read_package_source("rstudio/bslib")
-shiny_source <- read_package_source("rstudio/shiny")
-brandyml_source <- read_package_source(
-  "posit-dev/brand-yml",
-  subdirs = "pkg-r/R"
-)
-```
-
-These three strings sit in programmatic space; none enter the context window
-until the model requests a specific slice:
-
-```{r context-sizes}
-format_size <- function(source, label) {
-  n_files <- length(gregexpr("--- FILE:", source)[[1]])
-  cli::cli_li("{.strong {label}}: {format(nchar(source), big.mark = ',')} characters ({n_files} files)")
-}
-cli::cli_ul()
-format_size(bslib_source, "bslib")
-format_size(shiny_source, "shiny")
-format_size(brandyml_source, "brand.yml")
-cli::cli_end()
-```
-
-Nearly 4 million characters total, well beyond what any model handles
-accurately in a single pass.
-
-## Step 2: Baseline, What a Developer Would Try First
-
-Before reaching for an RLM, a competent developer would grep for the relevant
-functions and feed the results to a model. Let's try that:
-
-```{r baseline}
-#| cassette: true
-# Extract the context a developer would actually assemble:
-# definitions and nearby code for both page functions, plus Sass variable usage
-relevant_lines <- function(source, patterns, context_chars = 3000) {
-  slices <- lapply(patterns, function(pat) {
-    positions <- gregexpr(pat, source, perl = TRUE)[[1]]
-    positions <- positions[positions > 0]
-    if (length(positions) == 0) {
-      return(character(0))
-    }
-    # Take first 3 matches, with surrounding context
-    positions <- head(positions, 3)
-    vapply(
-      positions,
-      function(pos) {
-        start <- max(1, pos - context_chars %/% 2)
-        substr(source, start, start + context_chars)
-      },
-      character(1)
-    )
-  })
-  paste(unlist(slices), collapse = "\n\n---\n\n")
-}
-
-curated_context <- paste(
-  relevant_lines(bslib_source, c("page_navbar", "page_sidebar", "\\$primary")),
-  relevant_lines(shiny_source, c("navbarPage", "navbar")),
-  sep = "\n\n=== shiny ===\n\n"
-)
-
-baseline <- module(
-  signature(
-    "codebase, question -> analysis",
-    instructions = "You are an expert R developer analyzing package source code."
-  )
-)
-
-result <- run(
-  baseline,
-  codebase = curated_context,
-  question = paste(
-    "In bslib, why does setting primary in bs_theme() change the navbar",
-    "in page_navbar() but not in page_sidebar()? Trace the Sass variable",
-    "chain from primary through to the navbar background."
+incident_signature <- signature(
+  paste(
+    "sessions, changes, question ->",
+    "release: string, cohort: string,",
+    "before_rate: number, after_rate: number,",
+    "drop_pp: number, change_id: string, evidence: string"
   ),
-  .llm = chat_openai(model = "gpt-5-mini")
+  instructions = paste(
+    "Inspect the schema and low-cardinality categorical fields; exclude the",
+    "release, outcome, and row-index fields from candidate cohort dimensions.",
+    "Find the finest low-cardinality cohort with the largest before/after",
+    "drop; do not stop at a marginal roll-up that dilutes the change.",
+    "Quantify it and cite the strongest matching change record.",
+    "Format cohort in source-column order as '<dimension>=<value> / ...'.",
+    "Copy the selected change note verbatim into evidence. Treat that record as",
+    "evidence, not proof of causation."
+  )
 )
 
-result$analysis
-```
-
-The model gets targeted context: function definitions for both `page_navbar()`
-and `page_sidebar()`, plus Sass variable references and relevant shiny code.
-Better than stuffing in a random 50K prefix, but still incomplete. The grep
-captures mentions of `$primary` but not the chain of SCSS imports and mixins
-that connect it (or fail to connect it) to `$navbar-bg`. The model can see the
-endpoints but not the plumbing between them.
-
-A coding agent could search files iteratively, but it needs files on disk. An
-RLM works on arbitrary in-memory data: combined source strings from multiple
-repos, API responses, scraped content, anything you can load into a variable.
-And because `rlm_module()` is a dsprrr module, its traces feed into
-`compile()`, `evaluate()`, and the rest of the optimization framework.
-
-## Step 3: Set Up the RLM
-
-```{r rlm-setup}
 investigator <- rlm_module(
-  signature(
-    "bslib_source, shiny_source, brandyml_source, question -> analysis",
-    instructions = paste(
-      "You are an expert R/Sass developer investigating a theming bug across",
-      "three interconnected R packages. Explore the source code systematically",
-      "to trace how Sass variables flow between packages."
-    )
-  ),
-  runner = runner,
-  max_iterations = 15,
-  verbose = TRUE
+  incident_signature,
+  interpreter_factory = function() {
+    r_code_runner(timeout = 30, persistent = TRUE)
+  },
+  max_iters = 8,
+  max_llm_calls = 0L,
+  max_output_chars = 10000
 )
 ```
 
-The module takes three context variables (one per package) plus a question.
-Inside the REPL, these mechanisms are available:
+This example deliberately uses persistent `r_code_runner()` because the input
+is a large, rich R object and the fixture and generated trajectory are assumed
+trusted. A callr subprocess provides process isolation, not an operating-system
+security sandbox. Do not use this configuration for adversarial context or
+untrusted generated code.
 
-| Mechanism | Purpose |
-|-----------|---------|
-| `.context$<var>` | Access a context variable (e.g., `.context$bslib_source`) |
-| `peek(var, start, end)` | View a slice of a variable; dispatches on type (character positions for strings, element indices for vectors). Default: first 1000 chars |
-| `search(var, pattern)` | Perl-compatible regex search; returns all matching substrings |
-| `llm_query(query, context_slice)` | Delegate a sub-question to a secondary model (requires `sub_lm`) |
-| `llm_query_batched(queries, slices)` | Batch multiple sub-questions in parallel (requires `sub_lm`) |
-| `SUBMIT(...)` | Return the final answer and terminate the REPL loop; validates against signature output fields |
+The factory creates one runner for the invocation. State remains available
+between RLM iterations, and dsprrr closes the runner when the invocation ends.
 
-The model writes R code using these mechanisms. Each iteration, the code
-executes and the output feeds back as context for the next step.
+## Run and retain the evidence
 
-## Step 4: Run the Investigation
+Request structured output so the answer and its trajectory travel together:
 
 ```{r run-rlm}
-#| cassette: true
 result <- run(
   investigator,
-  bslib_source = bslib_source,
-  shiny_source = shiny_source,
-  brandyml_source = brandyml_source,
-  question = paste(
-    "In bslib, setting `primary` in bs_theme() changes the navbar color in",
-    "page_navbar() but NOT in page_sidebar(). This is GitHub issue #1123.",
-    "Trace the complete Sass variable chain from `$primary` to the navbar",
-    "background in both page functions. Identify exactly where and why the",
-    "chain breaks for page_sidebar(). Include specific file names and line",
-    "references."
-  ),
-  .llm = chat_openai(model = "gpt-5-mini")
+  sessions = sessions,
+  changes = changes,
+  question = question,
+  .llm = chat_openai(),
+  .return_format = "structured"
 )
 
-cli::cli_h3("Analysis")
-cli::cli_verbatim(result$analysis)
+result$output
 ```
 
-With `verbose = TRUE`, each iteration prints as it runs.
+This article does not claim a recorded model run. Model-generated code and the
+number of iterations can vary. The fixed output at the top is the result that a
+successful run must recover from the deterministic fixture.
 
-## Step 5: Inside the REPL
+## What a successful trajectory looks like
 
-The RLM runs a loop: generate code, execute it, observe results, repeat. It
-does not read everything at once:
+The exact R code may differ, but the useful work should be recognizable in four
+steps.
 
-```{r repl-history}
-history <- investigator$get_repl_history()
-latest <- history[[length(history)]]
+### 1. Orient to the objects
 
-cli::cli_alert_info("Iterations used: {latest$iterations_used} / {investigator$max_iterations}")
-
-# Helper for displaying iteration history
-show_iteration <- function(entry, n, label = NULL) {
-  header <- if (!is.null(label)) {
-    paste0("Iteration ", n, " (", label, ")")
-  } else {
-    paste0("Iteration ", n)
-  }
-  cli::cli_h3(header)
-  cli::cli_text("{.strong Reasoning}:")
-  cli::cli_verbatim(entry$reasoning)
-  cli::cli_text("{.strong Code}:")
-  cli::cli_code(entry$code)
-  if (!isTRUE(entry$success)) {
-    cli::cli_alert_danger("Failed")
-    if (!is.null(entry$output) && nzchar(entry$output)) {
-      cli::cli_text("{.strong Output}:")
-      cli::cli_verbatim(entry$output)
-    }
-  }
-}
-```
-
-Each iteration records the model's reasoning and the code it wrote. The
-walkthrough below is drawn from the recorded run above. Not every iteration
-succeeds: the model makes wrong turns, hits R string-escaping errors, and
-occasionally wastes a step. That is normal. The REPL loop is designed around
-the assumption that individual steps will fail.
-
-### Early iterations: Broad search
-
-Nearly 4 million characters sit in programmatic space; zero are in token
-space. The model typically starts by mapping the terrain:
-
-```{r iter-early, echo = FALSE}
-show_iteration(latest$history[[2]], 2)
-```
-
-`search()` returns only matching substrings, not entire files. Each result is
-a targeted transfer from programmatic to token space.
-
-### Mid-iterations: Locate definitions, trace variables
-
-As the model accumulates results, it narrows in on specific definitions and
-the surrounding code:
-
-```{r iter-mid, echo = FALSE}
-show_iteration(latest$history[[4]], 4)
-```
-
-The model has access to all of R, not just the provided REPL tools. It
-frequently uses base R functions like `gregexpr()`, `grepl()`, or
-`regmatches()` to refine its searches, and sometimes writes helper functions
-or splits files by header.
-
-### Failures and recovery
-
-Not every iteration succeeds. Let's find one that failed and see how the
-model recovered:
-
-```{r iter-fail, echo = FALSE}
-failed <- which(!vapply(latest$history, function(h) h$success, logical(1)))
-if (length(failed) > 0) {
-  i <- failed[1]
-  show_iteration(latest$history[[i]], i, label = "failed")
-  if (i < length(latest$history)) {
-    show_iteration(latest$history[[i + 1]], i + 1, label = "recovery")
-  }
-} else {
-  cli::cli_alert_success("This run had no failed iterations (unusual but possible).")
-}
-```
-
-Across multiple runs, two failure modes recur:
-
-**String escaping errors.** The model writes `"\("` instead of `"\\("`, or
-`"\$"` instead of `"\\$"`. R rejects the code, the error feeds back, and the
-model self-corrects on the next iteration.
-
-**Lost state.** Each iteration runs in a fresh environment. A helper function
-or parsed data structure defined in iteration 7 does not exist in iteration 8.
-The model encounters this empirically: after a "not found" error, it re-creates
-the object. This costs iterations but is part of the REPL's design. Stateless
-execution prevents accumulated errors from compounding.
-
-A typical run includes 2--4 failed iterations out of 10--15 total.
-
-### Final iteration: SUBMIT
-
-Once the model has gathered enough evidence, it calls `SUBMIT()` with the
-answer:
-
-```{r iter-final, echo = FALSE}
-show_iteration(latest$history[[length(latest$history)]], length(latest$history), label = "final")
-```
-
-`SUBMIT()` returns the final analysis and terminates the REPL loop. If
-`max_iterations` is reached without a `SUBMIT()` call, dsprrr extracts a
-best-effort answer from the full exploration history.
-
-## Step 6: Add Recursive Sub-queries
-
-The analysis above identifies the broken Sass variable chain. To go further
-(proposing a specific code fix, say), the root model may need help
-interpreting complex SCSS mixins or Bootstrap conventions from raw character
-slices. A secondary model handles these focused sub-questions:
-
-```{r rlm-recursive}
-#| cassette: true
-deep_investigator <- rlm_module(
-  signature(
-    "bslib_source, shiny_source, brandyml_source, question -> analysis, fix_proposal",
-    instructions = paste(
-      "You are an expert R/Sass developer. Investigate the bug and propose a",
-      "specific code fix. Use llm_query() to get help interpreting complex",
-      "Sass logic or understanding Bootstrap conventions."
-    )
-  ),
-  runner = runner,
-  max_iterations = 20,
-  sub_lm = chat_openai(model = "gpt-5-mini"), # Secondary model for sub-queries
-  max_llm_calls = 10,
-  verbose = TRUE
-)
-
-result <- run(
-  deep_investigator,
-  bslib_source = bslib_source,
-  shiny_source = shiny_source,
-  brandyml_source = brandyml_source,
-  question = paste(
-    "Investigate bslib issue #1123 and propose a fix.",
-    "The page_sidebar() title bar should respect the primary color the same",
-    "way page_navbar() does. What's the minimal change to fix this?"
-  ),
-  .llm = chat_openai(model = "gpt-5-mini")
-)
-
-cli::cli_h3("Analysis")
-cli::cli_verbatim(result$analysis)
-cli::cli_h3("Proposed Fix")
-cli::cli_verbatim(result$fix_proposal)
-```
-
-With `sub_lm` set, the root model can delegate interpretive tasks to a
-secondary model. For example, when it encounters a complex SCSS mixin:
+The first step should inspect shape and schema, not print the full data:
 
 ```r
-llm_query(
-  "In Bootstrap 5 Sass, what is the difference between $navbar-bg and
-   $navbar-light-bg? When would each be used?",
-  context_slice = scss_snippet
+list(
+  session_dim = dim(.context$sessions),
+  session_fields = names(.context$sessions),
+  releases = table(.context$sessions$release),
+  change_fields = names(.context$changes)
 )
 ```
 
-The root model orchestrates exploration; the sub-model handles focused
-interpretation. A smaller, cheaper model is usually sufficient for these
-queries, since the sub-questions are narrow and well-scoped.
+### 2. Calculate cohort-level changes
 
-`llm_query_batched()` sends multiple sub-questions in parallel.
+R performs the aggregation exactly:
 
-## Step 7: Inspect Costs and Trajectory
+```r
+rates <- aggregate(
+  converted ~ release + platform + plan,
+  data = .context$sessions,
+  FUN = mean
+)
 
-RLMs trade latency for accuracy:
-
-```{r costs}
-history <- deep_investigator$get_repl_history()
-latest <- history[[length(history)]]
-
-cli::cli_ul()
-cli::cli_li("Iterations used: {latest$iterations_used} / {deep_investigator$max_iterations}")
-cli::cli_li("LLM sub-calls: {latest$llm_calls_used} / {deep_investigator$max_llm_calls}")
-cli::cli_end()
+before <- subset(rates, release == "2.3.9")
+after <- subset(rates, release == "2.4.0")
+deltas <- merge(
+  before,
+  after,
+  by = c("platform", "plan"),
+  suffixes = c("_before", "_after")
+)
+deltas$drop_pp <-
+  100 * (deltas$converted_before - deltas$converted_after)
+deltas[order(-deltas$drop_pp), ]
 ```
 
-A typical run uses 10--15 iterations. Each involves one call to generate
-code plus the execution itself; 2--4 of those iterations will fail (string
-escaping errors, lost state, timeouts) and self-correct. Recursive sub-queries
-add additional calls. Total token usage is a fraction of what stuffing all
-three codebases into one prompt would require.
+The small printed table, rather than all 40,000 rows, enters the next model
+turn.
 
-The tradeoff is wall-clock time. Each iteration is a sequential round-trip
-(generate code, execute, observe result): expect 2--5 minutes for a full run,
-depending on model latency and how many iterations the model needs.
+### 3. Inspect candidate changes
 
-## Step 8: From Traces to Agent Designs
+Once the cohort is known, the model can narrow the change log:
 
-There is a secondary use for `get_repl_history()` beyond debugging. As
-[Breunig (2026)](https://www.dbreunig.com/2026/02/09/the-potential-of-rlms.html)
-observes, running an RLM on the same task multiple times reveals repeatable
-exploration patterns.
+```r
+candidate <- subset(
+  .context$changes,
+  release == "2.4.0" &
+    grepl(
+      "token|retry",
+      paste(component, note),
+      ignore.case = TRUE
+    )
+)
+```
 
-We ran the bslib investigation four times with `gpt-5-mini`. The code varied
-across runs, but the exploration structure converged:
+### 4. Submit typed evidence
 
-| Phase | Run 1 | Run 2 | Run 3 | Run 4 |
-|-------|-------|-------|-------|-------|
-| 1. Orient | `search("page_navbar")` | `search("page_navbar")` | `peek(bslib, 1, 5000)` | `search("page_sidebar")` |
-| 2. Locate definitions | `gregexpr("page_navbar")` + `peek` | `search("page_sidebar")` + `peek` | `search("page_navbar\\b")` | `gregexpr("page_navbar")` + `peek` |
-| 3. Find Sass chain | `search("\\$navbar-bg")` | `search("navbar-bg")` | `search("\\$primary")` | `search("\\$navbar-bg")` |
-| 4. Cross-reference | `search(shiny, "navbar")` | `search(shiny, "navbarPage")` | `search(shiny, "navbar")` | `search(brandyml, "primary")` |
-| 5. Identify gap | Compare page_navbar vs page_sidebar SCSS | Compare $navbar-bg vs sidebar vars | Compare preset mappings | Compare $navbar-bg chain |
+The closing step returns the calculated values and the relevant record:
 
-All four runs searched for `page_navbar` and `$navbar-bg` within the first
-four iterations. All four cross-referenced at least one other package. All four
-converged on the same diagnosis. The specific code and ordering differed, but
-the five-phase structure (orient, locate, trace Sass, cross-reference, identify
-gap) was stable.
-
-That stable structure is a specification you can extract and formalize into a
-deterministic pipeline, trading the RLM's flexibility for speed and
-reliability.
-
-This connects to dsprrr's optimization story. A `compile()` call with a
-teleprompter tunes a module's parameters against a dataset. RLM traces offer a
-complementary path: instead of optimizing *within* a module, you observe the
-module's behavior to design a *new* module, or a chain of modules, that
-encodes the discovered strategy directly.
-
-## Summary
-
-The investigation traced how `bs_theme(primary = ...)` flows through bslib's
-Sass pipeline and found the gap: `page_navbar()` picks up `$primary` via the
-flatly preset's mapping to `$navbar-bg`, but `page_sidebar()`'s title bar
-defaults to `$secondary` with no equivalent link. Three packages, nearly
-4 million characters of source, and the model identified the disconnect in
-a handful of iterations.
-
-More importantly, the traces revealed a stable five-phase exploration pattern
-that converged across multiple runs, the kind of structure you can extract
-and formalize into a deterministic pipeline.
-
-For guidance on when RLMs are the right tool (and when simpler approaches
-win), see the decision framework in
-the [How the RLM Works](how-rlm-works.html) article.
-
-## Try It Yourself
-
-The snippet below uses `read_package_source()` from Step 1. You already have
-the bslib, shiny, and brand.yml source loaded; try a second investigation
-with the same data. There are several
-[open theming issues](https://github.com/rstudio/bslib/issues?q=is%3Aopen+label%3A%22theming%22)
-in bslib that require the same kind of cross-package tracing. For example:
-
-```{r try-it, eval = FALSE}
-# Investigate another theming issue with the same data
-run(
-  investigator,
-  bslib_source = bslib_source,
-  shiny_source = shiny_source,
-  brandyml_source = brandyml_source,
-  question = paste(
-    "How does bs_theme()'s `font_scale` argument propagate through bslib's",
-    "Sass pipeline? Which components respect it and which ignore it?"
+```r
+winner <- deltas[which.max(deltas$drop_pp), ]
+SUBMIT(
+  release = after$release[[1L]],
+  cohort = paste0(
+    "platform=", winner$platform,
+    " / plan=", winner$plan
   ),
-  .llm = chat_openai(model = "gpt-5-mini")
+  before_rate = winner$converted_before,
+  after_rate = winner$converted_after,
+  drop_pp = winner$drop_pp,
+  change_id = candidate$change_id[[1L]],
+  evidence = candidate$note[[1L]]
 )
 ```
 
-Or load your own package source:
+If a submitted value is missing or has the wrong type, the RLM receives that
+validation error and can correct the submission on a later iteration.
 
-```{r try-it-own, eval = FALSE}
-my_source <- read_package_source("your-org/your-package")
+## Inspect and validate the result
 
-explorer <- rlm_module(
-  "codebase, question -> answer",
-  runner = r_code_runner(timeout = 30),
-  max_iterations = 10
+The structured result carries the trajectory produced during this invocation:
+
+```{r inspect-trajectory}
+trajectory <- result$metadata$repl_history
+
+vapply(trajectory, function(step) step$code, character(1))
+vapply(trajectory, function(step) step$success, logical(1))
+```
+
+Validate the model output against an independent calculation rather than
+trusting its prose:
+
+```{r oracle}
+rates <- aggregate(
+  converted ~ release + platform + plan,
+  data = sessions,
+  FUN = mean
 )
 
-run(
-  explorer,
-  codebase = my_source,
-  question = "How does the authentication middleware work?",
-  .llm = chat_openai(model = "gpt-5-mini")
+before <- subset(rates, release == "2.3.9")
+after <- subset(rates, release == "2.4.0")
+comparison <- merge(
+  before,
+  after,
+  by = c("platform", "plan"),
+  suffixes = c("_before", "_after")
+)
+comparison$drop_pp <-
+  100 * (comparison$converted_before - comparison$converted_after)
+oracle <- comparison[which.max(comparison$drop_pp), ]
+candidate <- subset(
+  changes,
+  release == "2.4.0" &
+    grepl("token|retry", paste(component, note),
+      ignore.case = TRUE
+    )
+)
+
+stopifnot(
+  nrow(sessions) == 40000L,
+  nrow(candidate) == 1L,
+  identical(candidate$change_id, "CHG-1842"),
+  identical(result$output$release, "2.4.0"),
+  identical(result$output$cohort, "platform=mobile / plan=pro"),
+  isTRUE(all.equal(result$output$before_rate, oracle$converted_before)),
+  isTRUE(all.equal(result$output$after_rate, oracle$converted_after)),
+  isTRUE(all.equal(result$output$drop_pp, oracle$drop_pp)),
+  identical(result$output$change_id, "CHG-1842"),
+  identical(result$output$evidence, candidate$note[[1L]])
 )
 ```
 
-## Further Reading
+## Recursive queries are optional
 
-- [Zhang, Kraska & Khattab (2025). "Recursive Language Models."](https://arxiv.org/abs/2512.24601)
-  The paper introducing the RLM approach.
-- [Breunig (2026). "The Potential of RLMs."](https://www.dbreunig.com/2026/02/09/the-potential-of-rlms.html)
-  Practical experience with RLMs at scale (400MB+ contexts), plus the
-  trace-to-pipeline idea. Breunig draws a useful analogy: RLMs are to
-  long-context problems what chain-of-thought was to reasoning, a test-time
-  strategy that works today and will improve as models are trained to exploit it.
-- `vignette("advanced-modules", package = "dsprrr")`: ChainOfThought,
-  BestOfN, and other reasoning patterns in dsprrr
-- `vignette("reasoning-models", package = "dsprrr")`: Using reasoning
-  models (o1, o3, GPT-5) with dsprrr
-- `vignette("rag-workflows", package = "dsprrr")`: When retrieval-based
-  approaches are a better fit
+`sub_lm = NULL` inherits the outer model supplied to `run()`. If generated code
+calls `llm_query()` or `llm_query_batched()`, dsprrr performs those calls in the
+host process and replays their results into the same code evaluation. A
+separate, cheaper model can handle those focused reads:
+
+```{r separate-sub-lm}
+investigator <- rlm_module(
+  incident_signature,
+  interpreter_factory = function() {
+    r_code_runner(timeout = 30, persistent = TRUE)
+  },
+  sub_lm = chat_openai(),
+  max_llm_calls = 4
+)
+```
+
+This incident does not require a sub-query: R aggregation plus one targeted
+change record is enough. Do not add recursive calls merely because the module
+supports them.
+
+## Choose the runner deliberately
+
+| Configuration | Use it for | Boundary |
+|---|---|---|
+| `rlm()` with no runner arguments | Compact, JSON-compatible context | Fresh managed OS sandbox; network disabled, workspace writes allowed, bounded transport |
+| `interpreter_factory = function() mcp_repl_runner()` | Explicit managed-sandbox configuration | OS sandbox, fresh runner per invocation, bounded transport |
+| `r_code_runner(persistent = TRUE)` | Trusted tasks with rich or large R objects | Persistent callr process with the host user's permissions |
+
+The managed MCP path is the default for the one-call `rlm()` helper. It requires
+the suggested R package `mcptools` and the external `mcp-repl` executable. It
+disables network access but still permits writes inside the allowed workspace.
+The final JSON-RPC request must fit the 7 KB wire bound; dsprrr tries a
+gzip/base64 wrapper when the raw request is too large. Each encoded RLM control
+frame must fit 3,000 bytes. Large data frames and model objects need a runner or
+resource adapter that preserves those values without forcing them through the
+compact MCP request. Declared host tools execute outside the guest sandbox with
+the host process's permissions.
+
+For a compact document, the managed one-call form is enough:
+
+```{r one-call}
+answer <- rlm(
+  "document, question -> answer",
+  document = "Owner: team-a\nCommitment: publish the audit by Friday",
+  question = "Which commitments have no owner?",
+  .llm = chat_openai(),
+  .max_iterations = 4L,
+  .max_llm_calls = 0L
+)
+```
+
+See [How the RLM Works](how-rlm-works.html) for runner lifecycle, recursive
+calls, budgets, and failure behavior.
+
+## Turn discovery into a program
+
+RLM is a poor default for a known report. If several investigations repeatedly
+aggregate the same columns and join the same records, encode that path in R or
+a dsprrr pipeline. If the best implementation is itself the search problem,
+evaluate it over labeled cases and consider Flex.
+
+Use RLM to discover the path. Use deterministic code once you know it.

--- a/vignettes/dspy-comparison.Rmd
+++ b/vignettes/dspy-comparison.Rmd
@@ -50,7 +50,7 @@ provider communication.
 | `dspy.BestOfN` | `best_of_n()` | Reward-function-guided retries |
 | `dspy.Refine` | `refine()` | Retries with LLM-generated feedback |
 | `dspy.MultiChainComparison` | `multi_chain_comparison()` | |
-| `dspy.RLM` | `rlm_module()` | Recursive language models over an R REPL; accepts the 3.3 `max_iters` spelling and either runner lifecycle. Tool names, inputs, sub-LM responses, and authenticated control frames are validated strictly; compacted mcp-repl control responses fail closed |
+| `dspy.RLM` | `rlm_module()` (experimental) | Inference-time adaptive exploration over an R REPL, with optimizable action and extraction predictors, inherited or separate sub-LMs, replayed recursive values, typed submission repair, and trajectory metadata |
 | Experimental `dspy.Flex` | `flex()` | GEPA can optimize a bounded predictor graph or an R `forward()` program. dsprrr requires an explicit fresh interpreter for executable source rather than choosing a default sandbox |
 | `dspy.Parallel` / `Module.batch` | `run_dataset()`, `run(..., .parallel = TRUE)` | Batch over a data frame; heterogeneous (module, example) fan-out is not yet a dedicated module |
 | `dspy.majority` | `ensemble()` with `reduce_majority()` | Plus `reduce_weighted_vote()`, `reduce_best_by_metric()` |
@@ -64,6 +64,53 @@ enforced sandbox by default; JSON Flex needs no interpreter. See [Flex:
 Optimize the Whole Program](flex-optimization.html) for the practical choice
 between those modes.
 
+The one-call `rlm()` helper is the exception to the explicit-binding rule: it
+creates a fresh managed `mcp-repl` sandbox factory by default. That path is
+intended for compact JSON-compatible context. For trusted rich R objects, opt
+into `r_code_runner(persistent = TRUE)` so one callr process stages the context
+once and keeps derived values for the invocation.
+
+### RLM parity and intentional differences
+
+dsprrr now matches the DSPy 3.3 RLM execution contracts that determine how an
+investigation behaves:
+
+- one factory-owned interpreter belongs to each invocation, and persistent
+  backends retain state across its iterations;
+- `generate_action` and `extract` are child predictors visible to graph
+  optimizers;
+- `sub_lm = NULL` inherits the outer LM, while an explicit sub-LM can handle
+  focused queries;
+- `llm_query()` and `llm_query_batched()` return host-produced values to the
+  same generated R evaluation through validated replay;
+- invalid typed `SUBMIT()` calls become repairable observations rather than
+  silently becoming final output;
+- execution observations use a 10,000-character head-and-tail module bound
+  after any stricter runner transport limit;
+  and
+- structured results include the output source, bounded REPL trajectory,
+  recursive-call counts, usage, and runner policy.
+
+The remaining RLM differences are intentional and user-visible:
+
+| Boundary | DSPy | dsprrr |
+|---|---|---|
+| Generated language | Python | R, with signature inputs under `.context` |
+| Returned value | Prediction with trajectory and top-level `final_reasoning` | `run()` output plus structured metadata; per-step reasoning is in the bounded trajectory and output source is explicit |
+| Interpreter binding | Optional interpreter may be supplied to each `forward()` call | Runner or factory is bound when constructing `rlm_module()`; the one-call `rlm()` helper creates that binding for one invocation |
+| Default local execution | DSPy interpreter configuration | `rlm()` creates a fresh managed `mcp-repl` OS sandbox with network disabled and workspace writes allowed |
+| Large or rich input | `SandboxSerializable` can define interpreter-specific one-time staging | Persistent trusted callr stages serializable native R objects once; no general public custom-staging protocol yet. Managed MCP requires the final raw-or-compressed JSON-RPC request to fit 7 KB and each encoded control frame to fit 3,000 bytes |
+| Typed outputs | Signature adapters validate the configured Python/Pydantic type | RLM validates explicit ellmer string, number, integer, boolean, enum, array, and object types; opaque `TypeJsonSchema` nodes are rejected rather than accepted without validation |
+| Stored trajectory | Full interpreter trajectory | Bounded, formatted execution evidence; large raw runner output is not retained |
+| Recursive replay | Interpreter-dependent | One nonce-bound, schema-checked ordered ledger returns query/tool values in code, but cannot roll back direct external side effects before a request |
+| Batch failures | Per-provider failures become ordered error values | Per-request provider failures become ordered `[ERROR] ...` values; unexpected or batch-infrastructure failures terminate |
+| Host tools | Interpreter-defined | Declared RLM tools execute in the host process, outside the guest sandbox; the bridge caps one generated step at 1,000 tool calls |
+
+RLM remains experimental in dsprrr. The execution and result contracts are
+tested; the convenience API may still evolve. See [the deterministic release
+regression](tutorial-rlm-dsprrr.html) and [the RLM execution
+contract](how-rlm-works.html).
+
 One notable difference: DSPy 3.0 *removed* `dspy.Assert`/`dspy.Suggest`
 in favor of `BestOfN`/`Refine`. dsprrr keeps both styles: declarative
 assertions with retry/backtracking (`with_assertions()`,
@@ -76,10 +123,10 @@ feedback injection.
 
 | DSPy | dsprrr | Fidelity notes |
 |------|--------|----------------|
-| `LabeledFewShot` | `LabeledFewShot` | Equivalent |
-| `BootstrapFewShot` | `BootstrapFewShot` | Equivalent; compiles pipelines jointly (demos for every step harvested from end-to-end traces) |
-| `BootstrapFewShotWithRandomSearch` | `BootstrapFewShotWithRandomSearch` | Equivalent |
-| `MIPROv2` | `MIPROv2` | Discrete Bayesian optimization with UCB over instruction + demo candidates |
+| `LabeledFewShot` | `LabeledFewShot` | Equivalent for a root Predict module; nested-predictor graphs, including RLM and Flex wrappers, are rejected rather than receiving mismatched root-task demos |
+| `BootstrapFewShot` | `BootstrapFewShot` | Compiles ordinary pipelines jointly; programs containing Flex or RLM are rejected because their runtime predictors cannot receive root-task demos |
+| `BootstrapFewShotWithRandomSearch` | `BootstrapFewShotWithRandomSearch` | Random search over ordinary labeled/bootstrap candidates; rejects programs containing Flex or RLM rather than returning a baseline-only no-op |
+| `MIPROv2` | `MIPROv2` | Root Predict modules search instruction + demo candidates; nested graphs search child instructions with `max_bootstrapped_demos = 0L` |
 | `SIMBA` | `SIMBA` | Adapted: hard-example mining + LLM-generated rules; simplified vs. the full introspective algorithm |
 | `GEPA` | `GEPA` | Adapted reflective optimization for instructions and complete Flex sources, with separate train/validation roles, multi-objective selection, lineage, and optional retained outputs. Cached subsample merge acceptance, fine-grained resume, and built-in experiment trackers remain different |
 | `COPRO` | `COPRO` | Equivalent (coordinate ascent over instructions) |
@@ -93,6 +140,13 @@ feedback injection.
 | — | `Omni` | dsprrr addition: independent best-of exploration plus a fresh continuation optimizer, with common validation scoring and optional mirai concurrency |
 | — | `AutoResearch` | dsprrr addition: persistent research-agent loop over validated, jointly editable module snapshots with sandboxed R analysis |
 | — | `MetaHarness` | dsprrr addition: fresh batch proposers plus host-owned frontier selection, lineage, budgets, and checkpoint resume |
+
+For an RLM graph, GEPA can tune both child predictors. MIPROv2 currently tunes
+their instructions only and requires `max_bootstrapped_demos = 0L`; nested demo
+bootstrapping fails explicitly until predictor-local child evidence is
+available. `BootstrapFewShot()`, its random-search variant, and
+`LabeledFewShot()` reject programs containing an RLM because task examples do
+not match the children’s `state -> ...` signatures.
 
 ### GEPA feedback metrics
 
@@ -216,25 +270,32 @@ optimizers operate on single modules).
 
 ## Known gaps (roadmap)
 
+The RLM differences above are disclosed boundaries. Some are intentional API
+choices; others, such as a general public custom-staging protocol, remain parity
+work. Remaining package-level gaps are:
+
 In rough priority order, based on the stable DSPy 3.3 runtime:
 
-1. **Remaining Flex gaps**: concurrent executable evaluation, fine-grained
+1. **General custom input staging for interpreter-backed modules**, analogous
+   to DSPy's `SandboxSerializable`, beyond the current persistent-callr and
+   runner-specific paths.
+2. **Remaining Flex gaps**: concurrent executable evaluation, fine-grained
    checkpoint resume, and GEPA's cached subsample merge-acceptance gate remain
    unimplemented. The top-level R `forward()` function, explicit interpreter
    factory, and non-portable R/Python source are intentional API differences,
    not missing parity.
-2. **One package-wide invocation/result contract** carrying native turns,
+3. **One package-wide invocation/result contract** carrying native turns,
    usage, cost, cache state, timing, and normalized errors across every module.
-3. **Package-level OpenTelemetry spans** for module, optimizer, evaluation,
+4. **Package-level OpenTelemetry spans** for module, optimizer, evaluation,
    cache, and tool activity, composed with ellmer's provider telemetry.
-4. **Native reasoning-trace capture** as a typed output (analogous to
+5. **Native reasoning-trace capture** as a typed output (analogous to
    `dspy.Reasoning`).
-5. **Joint multi-step optimization for other instruction optimizers**
-   (including MIPROv2); demo bootstrapping is already joint and GEPA now
-   selects complete-program components explicitly.
-6. **Adapter-style fallbacks** for models with weak structured-output
+6. **Predictor-local RLM demo evidence** so MIPROv2 can bootstrap child demos;
+   its graph mode currently tunes child instructions only, while GEPA selects
+   the RLM child components explicitly.
+7. **Adapter-style fallbacks** for models with weak structured-output
    support (analogous to `TwoStepAdapter`).
-7. **Weight and RL optimization**, after provider-neutral training data,
+8. **Weight and RL optimization**, after provider-neutral training data,
    reproducibility, cost accounting, and artifact contracts are stable.
 
 If one of these blocks your use case, please

--- a/vignettes/orchestration.Rmd
+++ b/vignettes/orchestration.Rmd
@@ -99,15 +99,16 @@ Functions, tools, retrievers, runners, interpreter factories, and other runtime
 objects are not captured implicitly. Supply a named `registry` to persist
 stable IDs and pass the same registry to `restore_module_config()`. Arbitrary
 embedded runtime values require `trusted = TRUE` both when writing and
-restoring. Version 4 records exactly one of `runner` or `interpreter_factory`
-for each code-executing module, without invoking a factory while writing or
-restoring the artifact. It also preserves a Flex module's source language,
-complete source, predictor- and host-tool-call limits, sandbox requirement, and
-registry-backed factory and tools when executable mode is used.
+restoring. Version 5 records exactly one of `runner` or `interpreter_factory`
+for each code-executing module without invoking a factory while writing or
+restoring the artifact. It preserves Flex source/runtime limits and
+registry-backed tools, and stores the graph-visible RLM `generate_action` and
+`extract` children with their tuned state.
 
-Restoration accepts the current closed schema and validated version 3
-runner-only artifacts. A version 3 manifest is checked against its original
-schema and integrity digest before dsprrr upgrades it in memory; other versions
+Restoration accepts the current closed schema plus validated version 3 and 4
+artifacts. Legacy manifests are checked against their original schema and
+integrity digest before migration; a childless legacy RLM receives fresh
+default children and is written as version 5 on its next save. Other versions
 are rejected. The stored signature remains authoritative. To change a
 signature, update the source program and write a new artifact.
 


### PR DESCRIPTION
## Summary

- Rebuild RLM execution around persistent per-invocation interpreters, one-time rich-context staging, ordered recursive/tool replay, strict typed `SUBMIT()` repair, bounded trajectories, and fail-closed control transport.
- Make `generate_action` and `extract` graph-visible predictor children, add instruction-only nested MIPRO support, reject unsupported demo bootstrapping explicitly, and preserve optimized children in artifact format v5.
- Normalize RLM batching, async lifecycle, cache propagation, provider/token/cost accounting, trace retention, and evaluation evidence across sequential and isolated mirai execution.
- Replace the old RLM narrative with a deterministic 40,000-row release-regression investigation and refresh README, reference, comparison, advanced-module, orchestration, and pkgdown documentation.

## DSPy 3.3 alignment

This implements the core DSPy 3.3 RLM behavior contracts while documenting the remaining R-specific boundaries: generated R instead of Python, construction-time runner binding, bounded managed MCP transport, replay that cannot roll back direct external side effects, explicit ellmer output types, and no general `SandboxSerializable`-style custom staging protocol yet.

## Verification

```r
runner <- r_code_runner(persistent = TRUE)
program <- rlm_module(
  "numbers, question -> answer: integer",
  runner = runner,
  max_llm_calls = 0L
)
run(
  program,
  numbers = c(2L, 4L, 8L),
  question = "Return the largest value.",
  .llm = llm
)
runner$close()
```

- `air format --check .`
- `jarl check R/module-rlm.R R/r-code-runner.R R/rlm-tools.R R/teleprompter-mipro.R`
- Full `devtools::test()` suite
- `devtools::check()`: 0 errors, 0 warnings, 0 notes
- `pkgdown::check_pkgdown()` plus isolated home, article, and reference builds

## Validation note

The external `mcp-repl` executable was unavailable locally for a live managed-runner smoke test. Its protocol, captured-response, attestation, failure, and lifecycle paths are covered by deterministic tests; persistent callr execution was validated end to end.
